### PR TITLE
Fix models.py default path in entrypoint

### DIFF
--- a/src/eval_framework/run.py
+++ b/src/eval_framework/run.py
@@ -34,7 +34,7 @@ def parse_args() -> argparse.Namespace:
         "--models",
         type=Path,
         required=False,
-        default="src/eval_framework/llm/models.py",
+        default=Path(__file__).parent / "llm" / "models.py",
         help="The path to the Python module file containing model classes.",
     )
     parser.add_argument(


### PR DESCRIPTION
The current entrypoint assumes for the `models.py` file that code is only executed from the repo. This PR fixes this behavior so that the default `models.py` arguments also works after pip installing `eval_framework`.