### PR TITLE
Feature/configurable sampling params

### DIFF
--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -96,3 +96,31 @@ poetry run eval_framework \
 ```
 
 This approach allows you to evaluate any model available on Hugging Face by specifying the `model_name` and appropriate `formatter` in the `--llm-args` parameter.
+
+## Configuring Sampling Parameters for vLLM Models
+
+vLLM models now support configurable sampling parameters through the `--llm-args` parameter. You can specify individual sampling parameters using dot notation:
+
+```bash
+poetry run eval_framework \
+    --models src/eval_framework/llm/models.py \
+    --llm-name Qwen3_0_6B_VLLM \
+    --llm-args sampling_params.temperature=0.7 sampling_params.top_p=0.95 sampling_params.max_tokens=150 \
+    --task-name "GSM8K" \
+    --output-dir ./eval \
+    --num-fewshot 5 \
+    --num-samples 10
+```
+
+You can also combine sampling parameters with other model arguments:
+
+```bash
+poetry run eval_framework \
+    --models src/eval_framework/llm/models.py \
+    --llm-name Qwen3_0_6B_VLLM \
+    --llm-args max_model_len=2048 sampling_params.temperature=0.8 sampling_params.top_p=0.9 \
+    --task-name "GSM8K" \
+    --output-dir ./eval \
+    --num-fewshot 5 \
+    --num-samples 10
+```

--- a/src/eval_framework/llm/aleph_alpha_api_llm.py
+++ b/src/eval_framework/llm/aleph_alpha_api_llm.py
@@ -239,8 +239,16 @@ class AlephAlphaAPIModel(BaseLLM):
         messages: List[Sequence[Message]],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
-        temperature: float = 0.0,
+        temperature: float | None = None,
     ) -> List[RawCompletion]:
+        if temperature is None:
+            effective_temperature = 0.0  # Current default, TODO: refactor to use model's default
+            logger.info(
+                f"Using default temperature value: {effective_temperature} as no custom temperature value was provided"
+            )
+        else:
+            effective_temperature = temperature
+
         requests = []
         assert self._formatter, "We need a formatter to generate from messages"
 
@@ -250,7 +258,7 @@ class AlephAlphaAPIModel(BaseLLM):
                     prompt=Prompt.from_text(self._formatter.format(single_messages, output_mode="string")),
                     maximum_tokens=max_tokens,
                     stop_sequences=stop_sequences,
-                    temperature=temperature,
+                    temperature=effective_temperature,
                 )
             )
 

--- a/src/eval_framework/llm/base.py
+++ b/src/eval_framework/llm/base.py
@@ -20,7 +20,7 @@ class BaseLLM(ABC):
         messages: List[Sequence[Message]],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
-        temperature: float = 0.0,
+        temperature: float | None = None,
     ) -> List[RawCompletion]:
         """
         stop_sequences and max_tokens are injected by the task if exist. They should be overwritten or
@@ -52,7 +52,7 @@ class BaseLLM(ABC):
         samples: List[Sample],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
-        temperature: float = 0.0,
+        temperature: float | None = None,
     ) -> List[RawCompletion]:
         messages: List[Sequence[Message]] = [sample.messages for sample in samples]
         return self.generate_from_messages(messages, stop_sequences, max_tokens, temperature)

--- a/src/eval_framework/llm/openai_llm.py
+++ b/src/eval_framework/llm/openai_llm.py
@@ -21,7 +21,7 @@ class OpenAIModel(BaseLLM):
         self,
         model_name: str = "gpt-4o",
         formatter: BaseFormatter | None = None,
-        temperature: float = 0.0,
+        temperature: float | None = None,
         api_key: str | None = None,
         organization: str | None = None,
         base_url: str | None = None,
@@ -58,8 +58,15 @@ class OpenAIModel(BaseLLM):
         messages: List[Sequence[Message]],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
-        temperature: float = 0.0,
+        temperature: float | None = None,
     ) -> List[RawCompletion]:
+        if temperature is None:
+            effective_temperature = 0.0  # Current default, TODO: refactor to use model's default
+            logger.info(
+                f"Using default temperature value: {effective_temperature} as no custom temperature value was provided"
+            )
+        else:
+            effective_temperature = temperature
         """Generate completion from messages.
         Args:
             messages: Sequence of messages
@@ -76,7 +83,7 @@ class OpenAIModel(BaseLLM):
                 response = self._client.completions.create(
                     model=self._model_name,
                     prompt=prompt,
-                    temperature=self._temperature,
+                    temperature=effective_temperature,
                     max_tokens=max_tokens,
                     stop=stop_sequences,
                 )
@@ -109,7 +116,7 @@ class OpenAIModel(BaseLLM):
                 chat_response = self._client.chat.completions.create(
                     model=self._model_name,
                     messages=chat_messages,
-                    temperature=self._temperature,
+                    temperature=effective_temperature,
                     max_tokens=max_tokens,
                     stop=stop_sequences,
                 )

--- a/src/eval_framework/llm/vllm_models.py
+++ b/src/eval_framework/llm/vllm_models.py
@@ -1,11 +1,9 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Generic, List, Optional, Protocol, Sequence, TypeVar, cast, override
+from typing import Any, Generic, Protocol, Sequence, TypeVar, cast, override
 
 import torch
-from template_formatting.formatter import BaseFormatter, HFFormatter, Message
-from template_formatting.mistral_formatter import MistralSerializer
 from vllm import LLM, SamplingParams
 from vllm.inputs.data import TokensPrompt
 from vllm.outputs import RequestOutput
@@ -16,6 +14,8 @@ from eval_framework.llm.base import BaseLLM
 from eval_framework.shared.types import Error, PromptTooLongException, RawCompletion, RawLoglikelihood
 from eval_framework.tasks.base import Sample
 from eval_framework.tasks.utils import raise_errors, redis_cache
+from template_formatting.formatter import BaseFormatter, HFFormatter, Message
+from template_formatting.mistral_formatter import MistralSerializer
 
 logger = logging.getLogger(__name__)
 

--- a/src/eval_framework/main.py
+++ b/src/eval_framework/main.py
@@ -24,12 +24,12 @@ def main(
     """Runs the entire evaluation process: responses generation and evaluation."""
 
     # Set up centralized logging early
-    output_dir = generate_output_dir(llm.__class__.__name__, config)
+    output_dir = generate_output_dir(llm.name, config)
     print(f"Output directory for evaluation: {output_dir}")
     setup_logging(output_dir=output_dir, log_level=logging.INFO, log_filename="evaluation.log")
 
     logger.info(f"{RED}[ Running full evaluation process ------- ]{RESET}")
-    logger.info(f"Evaluating {llm.__class__.__name__} on {config.task_name.name}")
+    logger.info(f"Evaluating {llm.name} on {config.task_name.name}")
     logger.info(f"Configuration: num_fewshot={config.num_fewshot}, num_samples={config.num_samples}")
     logger.info(f"Output directory: {output_dir}")
 

--- a/src/eval_framework/run.py
+++ b/src/eval_framework/run.py
@@ -1,6 +1,7 @@
 import argparse
 import datetime
 from pathlib import Path
+from typing import Any
 
 try:
     from eval_framework.context.determined import DeterminedContext
@@ -188,13 +189,21 @@ def parse_args() -> argparse.Namespace:
         help=("The args of the judge model used within OpenAIModel wrapper."),
     )
 
-    llm_args = {}
+    llm_args: dict[str, Any] = {}
     args = parser.parse_args()
 
     for arg in args.llm_args or []:
         if "=" in arg:
             key, value = arg.split("=", 1)
-            llm_args[key] = value
+
+            # Handle nested keys like "sampling_params.temperature=0.7"
+            if "." in key:
+                nested_key, sub_key = key.split(".", 1)
+                if nested_key not in llm_args:
+                    llm_args[nested_key] = {}
+                llm_args[nested_key][sub_key] = value
+            else:
+                llm_args[key] = value
 
     args.llm_args = llm_args
 

--- a/src/eval_framework/tasks/eval_config.py
+++ b/src/eval_framework/tasks/eval_config.py
@@ -1,3 +1,4 @@
+import ast
 import json
 from pathlib import Path
 from typing import Any
@@ -58,17 +59,20 @@ class EvalConfig(BaseConfig):
     @field_validator("llm_args", mode="before")
     @classmethod
     def validate_llm_args(cls, value: dict[str, Any]) -> dict[str, Any]:
-        typed_value = {}
-        for k, v in value.items():
-            try:  # maybe this llm argument is actually a number?
-                if "." in str(v):
-                    v = float(v)
-                else:
-                    v = int(v)
-            except ValueError:
-                pass
-            typed_value[k] = v
-        return typed_value
+        def convert_value(v: Any) -> Any:
+            if isinstance(v, dict):
+                # Recursively process nested dictionaries (like sampling_params)
+                return {k: convert_value(nested_v) for k, nested_v in v.items()}
+            elif isinstance(v, str):
+                try:
+                    # Try to evaluate as a Python literal (int, float, bool, None, list, dict, etc.)
+                    return ast.literal_eval(v)
+                except (ValueError, SyntaxError):
+                    return v  # keep as string if not a valid literal
+            else:
+                return v  # already proper type
+
+        return convert_value(value)
 
     @field_validator("judge_model_args", mode="before")
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ class MockLLM(BaseLLM):
         messages: List[Sequence[Message]],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
-        temperature: float = 0.0,
+        temperature: float | None = None,
     ) -> List[RawCompletion]:
         self.generate_counter += 1
         return [

--- a/tests/llm/test_vllm.py
+++ b/tests/llm/test_vllm.py
@@ -400,7 +400,7 @@ def test_dict_overrides_model_defaults() -> None:
 def test_invalid_sampling_param_raises() -> None:
     with pytest.raises(TypeError):
         # Call the method on the class directly to avoid gpu context
-        VLLMModel._process_sampling_params(None, {"invalid_param": "value"})
+        VLLMModel._process_sampling_params(None, {"invalid_param": "value"})  # type: ignore[arg-type]
 
 
 @pytest.mark.vllm

--- a/tests/llm/test_vllm.py
+++ b/tests/llm/test_vllm.py
@@ -397,11 +397,10 @@ def test_dict_overrides_model_defaults() -> None:
 
 
 @pytest.mark.vllm
-@pytest.mark.gpu
 def test_invalid_sampling_param_raises() -> None:
     with pytest.raises(TypeError):
-        # Don't use safe_vllm_setup here since we want the actual TypeError to be raised
-        Qwen3_0_6B_VLLM(max_model_len=30, sampling_params={"invalid_param": "value"})
+        # Call the method on the class directly to avoid gpu context
+        VLLMModel._process_sampling_params(None, {"invalid_param": "value"})
 
 
 @pytest.mark.vllm

--- a/tests/llm/test_vllm.py
+++ b/tests/llm/test_vllm.py
@@ -400,18 +400,8 @@ def test_dict_overrides_model_defaults() -> None:
 @pytest.mark.gpu
 def test_invalid_sampling_param_raises() -> None:
     with pytest.raises(TypeError):
-        safe_vllm_setup(Qwen3_0_6B_VLLM, {"max_model_len": 30, "sampling_params": {"invalid_param": "value"}})
-
-
-@pytest.mark.vllm
-@pytest.mark.gpu
-def test_mistral_inherits_dict_conversion() -> None:
-    class TestMistralVLLM(MistralVLLM):
-        LLM_NAME = "Qwen/Qwen3-0.6B"
-
-    model = safe_vllm_setup(TestMistralVLLM, {"max_model_len": 30, "sampling_params": {"temperature": 0.9}})
-
-    assert model.sampling_params.temperature == 0.9
+        # Don't use safe_vllm_setup here since we want the actual TypeError to be raised
+        Qwen3_0_6B_VLLM(max_model_len=30, sampling_params={"invalid_param": "value"})
 
 
 @pytest.mark.vllm
@@ -422,6 +412,7 @@ def test_mistral_inherits_dict_conversion() -> None:
         (Qwen3_0_6B_VLLM, {"max_model_len": 32, "dtype": "bfloat16", "tensor_parallel_size": 2}),
     ],
 )
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires >=2 GPUs for tensor_parallel_size=2")
 def test_logprobs_batched_vs_single(model_fn: Type[T], kwargs: Any) -> None:
     """
     Test that batched logprobs inference produces identical results to single-sample inference.
@@ -584,6 +575,7 @@ def test_logprobs_batched_vs_single(model_fn: Type[T], kwargs: Any) -> None:
         ),
     ],
 )
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires >=2 GPUs for tensor_parallel_size=2")
 def test_completions_batched_vs_single(model_fn: Type[T], kwargs: Any) -> None:
     """
     Test that batched completion inference produces identical results to single-message inference.

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -649,7 +649,7 @@ def test_redis_cache() -> None:
             messages: List[Sequence[Message]],
             stop_sequences: list[str] | None = None,
             max_tokens: int | None = None,
-            temperature: float = 0.0,
+            temperature: float | None = None,
         ) -> List[RawCompletion]:
             return [self.do_one(single_messages) for single_messages in messages]
 
@@ -730,7 +730,7 @@ def test_redis_cache() -> None:
             messages: List[Sequence[Message]],
             stop_sequences: list[str] | None = None,
             max_tokens: int | None = None,
-            temperature: float = 0.0,
+            temperature: float | None = None,
         ) -> List[RawCompletion]:
             return [self.do_one(single_messages) for single_messages in messages]
 

--- a/tests/test_eval_config_validation.py
+++ b/tests/test_eval_config_validation.py
@@ -1,0 +1,307 @@
+"""
+Tests for EvalConfig validation logic, specifically the ast.literal_eval() functionality.
+"""
+
+from eval_framework.llm.models import Qwen3_0_6B_VLLM
+from eval_framework.tasks.eval_config import EvalConfig
+
+
+class TestEvalConfigLLMArgsValidation:
+    """Test the llm_args validation with ast.literal_eval() functionality."""
+
+    def test_int_conversion(self) -> None:
+        """Test string to int conversion."""
+        config_data = {
+            "llm_class": Qwen3_0_6B_VLLM,
+            "llm_args": {"max_tokens": "42", "batch_size": "10"},
+            "task_name": "MMLU",
+        }
+
+        config = EvalConfig(**config_data)
+
+        assert config.llm_args["max_tokens"] == 42
+        assert isinstance(config.llm_args["max_tokens"], int)
+        assert config.llm_args["batch_size"] == 10
+        assert isinstance(config.llm_args["batch_size"], int)
+
+    def test_float_conversion(self) -> None:
+        """Test string to float conversion."""
+        config_data = {
+            "llm_class": Qwen3_0_6B_VLLM,
+            "llm_args": {"temperature": "0.7", "top_p": "0.95", "learning_rate": "1e-4"},
+            "task_name": "MMLU",
+        }
+
+        config = EvalConfig(**config_data)
+
+        assert config.llm_args["temperature"] == 0.7
+        assert isinstance(config.llm_args["temperature"], float)
+        assert config.llm_args["top_p"] == 0.95
+        assert isinstance(config.llm_args["top_p"], float)
+        assert config.llm_args["learning_rate"] == 1e-4
+        assert isinstance(config.llm_args["learning_rate"], float)
+
+    def test_boolean_conversion(self) -> None:
+        """Test string to boolean conversion."""
+        config_data = {
+            "llm_class": Qwen3_0_6B_VLLM,
+            "llm_args": {"use_cache": "True", "verbose": "False"},
+            "task_name": "MMLU",
+        }
+
+        config = EvalConfig(**config_data)
+
+        assert config.llm_args["use_cache"] is True
+        assert isinstance(config.llm_args["use_cache"], bool)
+        assert config.llm_args["verbose"] is False
+        assert isinstance(config.llm_args["verbose"], bool)
+
+    def test_none_conversion(self) -> None:
+        """Test string to None conversion."""
+        config_data = {
+            "llm_class": Qwen3_0_6B_VLLM,
+            "llm_args": {"seed": "None", "checkpoint": "None"},
+            "task_name": "MMLU",
+        }
+
+        config = EvalConfig(**config_data)
+
+        assert config.llm_args["seed"] is None
+        assert config.llm_args["checkpoint"] is None
+
+    def test_list_conversion(self) -> None:
+        """Test string to list conversion."""
+        config_data = {
+            "llm_class": Qwen3_0_6B_VLLM,
+            "llm_args": {
+                "stop_tokens": '["<|end|>", "\\n", "END"]',
+                "numbers": "[1, 2, 3, 4]",
+                "mixed_list": '["text", 42, 3.14, True, None]',
+            },
+            "task_name": "MMLU",
+        }
+
+        config = EvalConfig(**config_data)
+
+        assert config.llm_args["stop_tokens"] == ["<|end|>", "\n", "END"]
+        assert isinstance(config.llm_args["stop_tokens"], list)
+        assert config.llm_args["numbers"] == [1, 2, 3, 4]
+        assert isinstance(config.llm_args["numbers"], list)
+        assert config.llm_args["mixed_list"] == ["text", 42, 3.14, True, None]
+        assert isinstance(config.llm_args["mixed_list"], list)
+
+    def test_dict_conversion(self) -> None:
+        """Test string to dict conversion."""
+        config_data = {
+            "llm_class": Qwen3_0_6B_VLLM,
+            "llm_args": {
+                "config": '{"temperature": 0.8, "max_tokens": 100}',
+                "nested": '{"outer": {"inner": 42, "flag": True}}',
+            },
+            "task_name": "MMLU",
+        }
+
+        config = EvalConfig(**config_data)
+
+        assert config.llm_args["config"] == {"temperature": 0.8, "max_tokens": 100}
+        assert isinstance(config.llm_args["config"], dict)
+        assert config.llm_args["nested"] == {"outer": {"inner": 42, "flag": True}}
+        assert isinstance(config.llm_args["nested"], dict)
+
+    def test_string_preservation(self) -> None:
+        """Test that regular strings are preserved as strings."""
+        config_data = {
+            "llm_class": Qwen3_0_6B_VLLM,
+            "llm_args": {
+                "model_name": "gpt-4",
+                "api_key": "sk-1234567890",
+                "endpoint": "https://api.openai.com",
+                "malformed_list": "[1, 2, 3",  # Invalid syntax
+                "malformed_dict": '{"key": }',  # Invalid syntax
+            },
+            "task_name": "MMLU",
+        }
+
+        config = EvalConfig(**config_data)
+
+        assert config.llm_args["model_name"] == "gpt-4"
+        assert isinstance(config.llm_args["model_name"], str)
+        assert config.llm_args["api_key"] == "sk-1234567890"
+        assert isinstance(config.llm_args["api_key"], str)
+        assert config.llm_args["endpoint"] == "https://api.openai.com"
+        assert isinstance(config.llm_args["endpoint"], str)
+        # Malformed literals should remain as strings
+        assert config.llm_args["malformed_list"] == "[1, 2, 3"
+        assert isinstance(config.llm_args["malformed_list"], str)
+        assert config.llm_args["malformed_dict"] == '{"key": }'
+        assert isinstance(config.llm_args["malformed_dict"], str)
+
+    def test_nested_dict_recursive_conversion(self) -> None:
+        """Test that nested dictionaries are converted recursively."""
+        config_data = {
+            "llm_class": Qwen3_0_6B_VLLM,
+            "llm_args": {
+                "sampling_params": {
+                    "temperature": "0.7",
+                    "top_p": "0.9",
+                    "max_tokens": "100",
+                    "stop": '["<|end|>", "\\n"]',
+                    "use_beam_search": "False",
+                    "seed": "None",
+                },
+                "model_config": {
+                    "trust_remote_code": "True",
+                    "gpu_memory_utilization": "0.8",
+                    "max_model_len": "2048",
+                    "nested_config": {
+                        "deep_value": "42",
+                        "deep_flag": "True",
+                    },
+                },
+            },
+            "task_name": "MMLU",
+        }
+
+        config = EvalConfig(**config_data)
+
+        # Test sampling_params conversion
+        sp = config.llm_args["sampling_params"]
+        assert sp["temperature"] == 0.7
+        assert isinstance(sp["temperature"], float)
+        assert sp["top_p"] == 0.9
+        assert isinstance(sp["top_p"], float)
+        assert sp["max_tokens"] == 100
+        assert isinstance(sp["max_tokens"], int)
+        assert sp["stop"] == ["<|end|>", "\n"]
+        assert isinstance(sp["stop"], list)
+        assert sp["use_beam_search"] is False
+        assert isinstance(sp["use_beam_search"], bool)
+        assert sp["seed"] is None
+
+        # Test model_config conversion
+        mc = config.llm_args["model_config"]
+        assert mc["trust_remote_code"] is True
+        assert isinstance(mc["trust_remote_code"], bool)
+        assert mc["gpu_memory_utilization"] == 0.8
+        assert isinstance(mc["gpu_memory_utilization"], float)
+        assert mc["max_model_len"] == 2048
+        assert isinstance(mc["max_model_len"], int)
+
+        # Test deeply nested conversion
+        nc = mc["nested_config"]
+        assert nc["deep_value"] == 42
+        assert isinstance(nc["deep_value"], int)
+        assert nc["deep_flag"] is True
+        assert isinstance(nc["deep_flag"], bool)
+
+    def test_already_correct_types_preserved(self) -> None:
+        """Test that values with correct types are not modified."""
+        config_data = {
+            "llm_class": Qwen3_0_6B_VLLM,
+            "llm_args": {
+                "already_int": 42,
+                "already_float": 3.14,
+                "already_bool": True,
+                "already_none": None,
+                "already_list": [1, 2, 3],
+                "already_dict": {"key": "value"},
+                "mixed": {
+                    "string_to_convert": "123",
+                    "already_converted": 456,
+                },
+            },
+            "task_name": "MMLU",
+        }
+
+        config = EvalConfig(**config_data)
+
+        assert config.llm_args["already_int"] == 42
+        assert isinstance(config.llm_args["already_int"], int)
+        assert config.llm_args["already_float"] == 3.14
+        assert isinstance(config.llm_args["already_float"], float)
+        assert config.llm_args["already_bool"] is True
+        assert isinstance(config.llm_args["already_bool"], bool)
+        assert config.llm_args["already_none"] is None
+        assert config.llm_args["already_list"] == [1, 2, 3]
+        assert isinstance(config.llm_args["already_list"], list)
+        assert config.llm_args["already_dict"] == {"key": "value"}
+        assert isinstance(config.llm_args["already_dict"], dict)
+
+        # Test mixed scenario
+        mixed = config.llm_args["mixed"]
+        assert mixed["string_to_convert"] == 123
+        assert isinstance(mixed["string_to_convert"], int)
+        assert mixed["already_converted"] == 456
+        assert isinstance(mixed["already_converted"], int)
+
+    def test_edge_cases(self) -> None:
+        """Test edge cases and potential problematic inputs."""
+        config_data = {
+            "llm_class": Qwen3_0_6B_VLLM,
+            "llm_args": {
+                "empty_string": "",
+                "whitespace": "   ",
+                "zero": "0",
+                "negative": "-42",
+                "scientific_notation": "1e-5",
+                "large_number": "999999999999999",
+                "empty_list": "[]",
+                "empty_dict": "{}",
+                "single_quote_string": "'hello'",
+                "double_quote_string": '"world"',
+            },
+            "task_name": "MMLU",
+        }
+
+        config = EvalConfig(**config_data)
+
+        assert config.llm_args["empty_string"] == ""
+        assert isinstance(config.llm_args["empty_string"], str)
+        assert config.llm_args["whitespace"] == "   "
+        assert isinstance(config.llm_args["whitespace"], str)
+        assert config.llm_args["zero"] == 0
+        assert isinstance(config.llm_args["zero"], int)
+        assert config.llm_args["negative"] == -42
+        assert isinstance(config.llm_args["negative"], int)
+        assert config.llm_args["scientific_notation"] == 1e-5
+        assert isinstance(config.llm_args["scientific_notation"], float)
+        assert config.llm_args["large_number"] == 999999999999999
+        assert isinstance(config.llm_args["large_number"], int)
+        assert config.llm_args["empty_list"] == []
+        assert isinstance(config.llm_args["empty_list"], list)
+        assert config.llm_args["empty_dict"] == {}
+        assert isinstance(config.llm_args["empty_dict"], dict)
+        assert config.llm_args["single_quote_string"] == "hello"
+        assert isinstance(config.llm_args["single_quote_string"], str)
+        assert config.llm_args["double_quote_string"] == "world"
+        assert isinstance(config.llm_args["double_quote_string"], str)
+
+
+class TestEvalConfigJudgeModelArgsValidation:
+    """Test the judge_model_args validation (which still uses the old approach)."""
+
+    def test_judge_model_args_conversion(self) -> None:
+        """Test that judge_model_args still uses the old conversion approach."""
+        config_data = {
+            "llm_class": Qwen3_0_6B_VLLM,
+            "llm_judge_class": Qwen3_0_6B_VLLM,
+            "judge_model_args": {
+                "temperature": "0.7",
+                "max_tokens": "100",
+                "model_name": "gpt-4",  # String should remain string
+                "use_cache": "True",  # String should remain string (not converted to bool)
+            },
+            "task_name": "MMLU",
+        }
+
+        config = EvalConfig(**config_data)
+
+        assert config.judge_model_args["temperature"] == 0.7
+        assert isinstance(config.judge_model_args["temperature"], float)
+        assert config.judge_model_args["max_tokens"] == 100
+        assert isinstance(config.judge_model_args["max_tokens"], int)
+        assert config.judge_model_args["model_name"] == "gpt-4"
+        assert isinstance(config.judge_model_args["model_name"], str)
+        # Note: The old approach doesn't convert booleans
+        assert config.judge_model_args["use_cache"] == "True"
+        assert isinstance(config.judge_model_args["use_cache"], str)

--- a/tests/test_sampling_params_integration.py
+++ b/tests/test_sampling_params_integration.py
@@ -1,0 +1,101 @@
+"""
+Tests for sampling parameters integration across CLI, configs, and model initialization.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from eval_framework.llm.models import Qwen3_0_6B_VLLM
+from eval_framework.run import parse_args
+from eval_framework.tasks.eval_config import EvalConfig
+
+
+def test_cli_nested_sampling_params_parsing() -> None:
+    """Test CLI args with nested sampling_params get parsed correctly."""
+    test_args = [
+        "run.py",
+        "--llm-name",
+        "Qwen3_0_6B_VLLM",
+        "--task-name",
+        "MMLU",
+        "--llm-args",
+        "max_model_len=128",
+        "sampling_params.temperature=0.8",
+        "sampling_params.top_p=0.95",
+    ]
+
+    with patch("sys.argv", test_args):
+        args = parse_args()
+
+    expected_llm_args = {"max_model_len": "128", "sampling_params": {"temperature": "0.8", "top_p": "0.95"}}
+
+    assert args.llm_args == expected_llm_args
+
+
+def test_eval_config_validates_nested_sampling_params() -> None:
+    """Test EvalConfig correctly validates and converts nested sampling_params."""
+    config_data = {
+        "llm_class": Qwen3_0_6B_VLLM,
+        "llm_args": {
+            "max_model_len": "128",
+            "sampling_params": {"temperature": "0.7", "top_p": "0.9", "max_tokens": "100"},
+        },
+        "task_name": "MMLU",
+        "num_fewshot": 5,
+        "num_samples": 10,
+    }
+
+    config = EvalConfig(**config_data)
+
+    # Verify recursive type conversion works
+    assert config.llm_args["max_model_len"] == 128  # int conversion
+    assert config.llm_args["sampling_params"]["temperature"] == 0.7  # float conversion
+    assert config.llm_args["sampling_params"]["top_p"] == 0.9  # float conversion
+    assert config.llm_args["sampling_params"]["max_tokens"] == 100  # int conversion
+
+
+@pytest.mark.vllm
+def test_sampling_params_dict_conversion() -> None:
+    """Test dict to SamplingParams object conversion."""
+    from typing import Any
+
+    from vllm import SamplingParams
+
+    sampling_params_dict: dict[str, Any] = {
+        "temperature": 0.8,
+        "top_p": 0.95,
+        "max_tokens": 100,
+        "stop": ["<|end|>", "\n"],
+    }
+
+    sampling_params_obj = SamplingParams(**sampling_params_dict)
+
+    assert isinstance(sampling_params_obj, SamplingParams)
+    assert sampling_params_obj.temperature == 0.8
+    assert sampling_params_obj.top_p == 0.95
+    assert sampling_params_obj.max_tokens == 100
+    assert sampling_params_obj.stop == ["<|end|>", "\n"]
+
+
+def test_multiple_nested_keys() -> None:
+    """Test parsing multiple levels of nesting in CLI args."""
+    test_args = [
+        "run.py",
+        "--llm-name",
+        "test",
+        "--llm-args",
+        "sampling_params.temperature=0.5",
+        "sampling_params.stop=END",
+        "other_config.nested_value=42",
+    ]
+
+    with patch("sys.argv", test_args):
+        args = parse_args()
+
+    expected_llm_args = {
+        "sampling_params": {"temperature": "0.5", "stop": "END"},
+        "other_config": {"nested_value": "42"},
+    }
+
+    assert args.llm_args == expected_llm_args


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
     - 📗 Reflect the changes you made in the changelog.

-->

This pull request refactors how temperature and sampling parameters are handled across multiple LLM backends and improves type consistency and configuration parsing. The main goal is to allow temperature and other sampling parameters to be set more flexibly, including via nested configuration arguments, and to ensure that default values are used when parameters are not provided. The changes also standardize type hints and improve code maintainability.

**Temperature and Sampling Parameter Handling:**

* All LLM backends (`aleph_alpha_api_llm.py`, `huggingface_llm.py`, `openai_llm.py`, `vllm_models.py`) now accept `temperature: float | None` instead of a default value, and use a default of `0.0` if not provided, with logging to indicate which value is used. [[1]](diffhunk://#diff-d86a8e867ea5ec69e56851f823c28b390720f8462554281579765367f1f1a55aL242-R251) [[2]](diffhunk://#diff-97526e12ea8e894fc1a20dde80b280032b1c1923c53d18f63f6dec9245f74b54L23-R23) [[3]](diffhunk://#diff-03452c429d36e463033a235fe78c0cfa6081dac6794ccec34968abc880225eacL101-R110) [[4]](diffhunk://#diff-537d3ecbf46e59f178ebdcde258c52f9b8767d49b0457507329250c2ae2425ebL24-R24) [[5]](diffhunk://#diff-4fbe939a8ac5fe371cb0eb4d3597854feb8636e29f0ac4962059f1c95a25691cL199-R214)
* The logic for passing temperature to model generation functions is updated to use an `effective_temperature` variable, ensuring the correct value is used and logged. [[1]](diffhunk://#diff-d86a8e867ea5ec69e56851f823c28b390720f8462554281579765367f1f1a55aL253-R261) [[2]](diffhunk://#diff-03452c429d36e463033a235fe78c0cfa6081dac6794ccec34968abc880225eacL151-R159) [[3]](diffhunk://#diff-03452c429d36e463033a235fe78c0cfa6081dac6794ccec34968abc880225eacL160-R169) [[4]](diffhunk://#diff-537d3ecbf46e59f178ebdcde258c52f9b8767d49b0457507329250c2ae2425ebL79-R86) [[5]](diffhunk://#diff-537d3ecbf46e59f178ebdcde258c52f9b8767d49b0457507329250c2ae2425ebL112-R119)

**Flexible Sampling Parameter Configuration:**

* `vllm_models.py` now accepts `sampling_params` as either a `SamplingParams` object or a dictionary, converting as needed. The `_process_sampling_params` method standardizes this and ensures default parameters are used if none are provided. [[1]](diffhunk://#diff-4fbe939a8ac5fe371cb0eb4d3597854feb8636e29f0ac4962059f1c95a25691cL124-R124) [[2]](diffhunk://#diff-4fbe939a8ac5fe371cb0eb4d3597854feb8636e29f0ac4962059f1c95a25691cL141-R164) [[3]](diffhunk://#diff-4fbe939a8ac5fe371cb0eb4d3597854feb8636e29f0ac4962059f1c95a25691cL445-R443)
* The `_resolve_sampling_params` method in `vllm_models.py` is refactored to allow dynamic override of temperature and other sampling parameters, with logging for overrides and defaults.

**Configuration Parsing Improvements:**

* In `run.py`, command-line parsing for `llm_args` is enhanced to support nested keys (e.g., `sampling_params.temperature=0.7`), allowing more granular configuration via the CLI.

**Type Hint Standardization:**

* Type hints throughout the LLM modules are updated for consistency, using `list` instead of `List` and other minor corrections for clarity and maintainability. [[1]](diffhunk://#diff-4fbe939a8ac5fe371cb0eb4d3597854feb8636e29f0ac4962059f1c95a25691cL57-R57) [[2]](diffhunk://#diff-4fbe939a8ac5fe371cb0eb4d3597854feb8636e29f0ac4962059f1c95a25691cL189-R192) [[3]](diffhunk://#diff-4fbe939a8ac5fe371cb0eb4d3597854feb8636e29f0ac4962059f1c95a25691cL364-R365)

**Minor Logging and Import Updates:**

* Logging statements are added or improved to clarify which temperature and sampling parameters are used.
* Minor import and formatting cleanups are made for clarity. [[1]](diffhunk://#diff-4fbe939a8ac5fe371cb0eb4d3597854feb8636e29f0ac4962059f1c95a25691cR7-R8) [[2]](diffhunk://#diff-4fbe939a8ac5fe371cb0eb4d3597854feb8636e29f0ac4962059f1c95a25691cL17-L18) [[3]](diffhunk://#diff-1ff71a2853c085a8c28d7acdfa22bea5e98175e4f8bdb8a7d9756f923390d2c1R1)

These changes collectively make model configuration more robust and user-friendly, especially for advanced evaluation and experimentation workflows.

## PR Checklist
- [x] Use descriptive commit messages.
- [x] Provide tests for your changes.
- [x] Update any related documentation and include any relevant screenshots.
- [x] Check if changes need to be made to docs (README or any guides in `/docs/`).
- [ ] Reflect the changes you made in the changelog.

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the hardware and config this has been tested on, as well as any relevant
additional information._


## Added/updated tests?
- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
