### PR TITLE
Refactor code exec

### DIFF
--- a/src/eval_framework/metrics/completion/code_execution_pass_at_one.py
+++ b/src/eval_framework/metrics/completion/code_execution_pass_at_one.py
@@ -59,7 +59,7 @@ class CodeExecutionPassAtOne(BaseMetric[Completion]):
 
     def __init__(self) -> None:
         self.k = 1
-        # NOTE : this class should be symmetric to the class initialized in the metric class
+        # NOTE : this serializer should be the same class as initialized in the benchmark
         self.serializer = CallableSerializer()
 
     def calculate(self, response: Completion) -> list[MetricResult]:

--- a/src/eval_framework/metrics/completion/code_execution_pass_at_one.py
+++ b/src/eval_framework/metrics/completion/code_execution_pass_at_one.py
@@ -1,5 +1,6 @@
 import traceback
-from typing import Callable, Self
+from collections.abc import Callable
+from typing import Self
 
 from pydantic import Field
 

--- a/src/eval_framework/metrics/completion/code_execution_pass_at_one.py
+++ b/src/eval_framework/metrics/completion/code_execution_pass_at_one.py
@@ -1,15 +1,35 @@
-import os
 import traceback
+from typing import Callable, Self
 
-from eval_framework.logger import logger
 from eval_framework.metrics.base import BaseMetric, MetricResult
 from eval_framework.shared.types import BaseMetricContext, Completion, Error, extract_context_metric
-from eval_framework.tasks.utils import BIG_CODE_BENCH_PACKAGE_MAPPING, execute_python_code_with_tests
+from eval_framework.tasks.utils import CallableSerializer, ExecutionResult, get_external_dependencies, run_python_code
 
 
 class CodeExecutionPassAtOneContext(BaseMetricContext):
+    run_env: str
     code_prompt: str
     test_code: str
+    benchmark_timeout: int = 60
+    snippet_merge_fn: str
+    output_parse_fn: str
+    package_downloads: dict[str, str | None]
+
+
+class RealtimeCodeExectionContext(CodeExecutionPassAtOneContext):
+    snippet_merge_fn: Callable[[str, str], str]
+    output_parse_fn: Callable[[str], ExecutionResult]
+
+    @classmethod
+    def from_context(cls, context: CodeExecutionPassAtOneContext) -> Self:
+        return cls(
+            code_prompt=context.code_prompt,
+            test_code=context.test_code,
+            benchmark_timeout=context.benchmark_timeout,
+            snippet_merge_fn=CallableSerializer.decode(context.snippet_merge_fn),
+            output_parse_fn=CallableSerializer.decode(context.output_parse_fn),
+            package_downloads=context.package_downloads,
+        )
 
 
 class CodeExecutionPassAtOne(BaseMetric[Completion]):
@@ -17,24 +37,20 @@ class CodeExecutionPassAtOne(BaseMetric[Completion]):
 
     def __init__(self) -> None:
         self.k = 1
-        # Get Docker image from environment variable
-        self.python_image = os.environ.get("DOCKER_CODE_EXECUTION")
-        if not self.python_image:
-            raise ValueError(
-                "Environment variable 'DOCKER_CODE_EXECUTION' must be set with a pre-built Docker image name. "
-                "You can build the Docker image from the Dockerfile_codebench available in the repository's "
-                "home directory."
-            )
+        self.serializer = CallableSerializer()
 
     def calculate(self, response: Completion) -> list[MetricResult]:
         if response.error is not None:
             return [MetricResult(metric_name=self.NAME, value=None, higher_is_better=True, error=response.error)]
-
-        context = extract_context_metric(response, CodeExecutionPassAtOneContext)
+        try:
+            context = extract_context_metric(response, CodeExecutionPassAtOneContext)
+            parsed_context = RealtimeCodeExectionContext.from_context(context)
+        except Exception as e:
+            raise Exception(f"Failed to rebuild parsing functions => {e}")
 
         n = 1  # we only support N=1 at the moment
         try:
-            c, output = self._count_correct_samples(response.completion, context.test_code)
+            c, output = self._count_correct_samples(response.completion, parsed_context)
         except Exception as e:
             error = Error(error_class=e.__class__.__name__, message=str(e), traceback=traceback.format_exc())
             return [MetricResult(metric_name=self.NAME, value=None, higher_is_better=True, error=error)]
@@ -50,11 +66,14 @@ class CodeExecutionPassAtOne(BaseMetric[Completion]):
             )
         ]
 
-    def _count_correct_samples(self, completion: str, test_code: str) -> tuple[int, str]:
-        result = execute_python_code_with_tests(
-            completion, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING, image=self.python_image
+    def _count_correct_samples(self, completion: str, context: RealtimeCodeExectionContext) -> tuple[int, str]:
+        combined_code = context.snippet_merge_fn(completion, context.test_code)
+        packages = get_external_dependencies(combined_code, context.package_downloads)
+        # Run the combined code in the sandbox
+        output = run_python_code(
+            combined_code, image=context.run_env, timeout=context.benchmark_timeout, packages=packages
         )
-        logger.info(f"Output of code execution: {result.output}")
+        result = context.output_parse_fn(output)
         return (1 if result.success else 0), result.output
 
 

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 import iso639
-from datasets import DownloadConfig, load_dataset
+from datasets import DatasetDict, DownloadConfig, load_dataset
 from huggingface_hub import HfApi
 from huggingface_hub.errors import RevisionNotFoundError
 from pydantic import BaseModel, ConfigDict
@@ -180,7 +180,7 @@ class BaseTask[SubjectType](ABC):
                 cache_dir=f"{Path.home()}/.cache/eval-framework",
             )
 
-    def _shuffle_splits(self, hf_dataset) -> dict[str, list[dict[str, Any]]]:
+    def _shuffle_splits(self, hf_dataset: DatasetDict) -> dict[str, list[dict[str, Any]]]:
         dataset = {}
         self.rnd = random.Random(RANDOM_SEED)
 

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -180,9 +180,9 @@ class BaseTask[SubjectType](ABC):
                 cache_dir=f"{Path.home()}/.cache/eval-framework",
             )
 
-    def _shuffle_splits(self, hf_dataset):
+    def _shuffle_splits(self, hf_dataset) -> dict[str, list[dict[str, Any]]]:
         dataset = {}
-        rnd = random.Random(RANDOM_SEED)
+        self.rnd = random.Random(RANDOM_SEED)
 
         for split, data in hf_dataset.items():
             if split not in [self.SAMPLE_SPLIT, self.FEWSHOT_SPLIT]:
@@ -191,16 +191,16 @@ class BaseTask[SubjectType](ABC):
             data_list = list(data)
 
             if split == self.SAMPLE_SPLIT:
-                rnd.shuffle(data_list)
+                self.rnd.shuffle(data_list)
 
             dataset[split] = data_list
 
-        return dataset, rnd
+        return dataset
 
     def _load_dataset(self, subject: SubjectType) -> None:
         name = subject if subject != NO_SUBJECT else None
         hf_dataset = self._load_hf_dataset(path=self.DATASET_PATH, name=name)
-        self.dataset, self.rnd = self._shuffle_splits(hf_dataset=hf_dataset)
+        self.dataset = self._shuffle_splits(hf_dataset=hf_dataset)
 
     def post_process_generated_completion(self, completion_text: str, sample: Sample | None = None) -> str:
         return completion_text

--- a/src/eval_framework/tasks/benchmarks/bigcodebench.py
+++ b/src/eval_framework/tasks/benchmarks/bigcodebench.py
@@ -1,3 +1,4 @@
+import os
 import random
 import re
 from typing import Any
@@ -14,6 +15,7 @@ from eval_framework.tasks.base import (
     Sample,
     SubjectType,
 )
+from eval_framework.tasks.utils import BIG_CODE_BENCH_PACKAGE_MAPPING, CallableSerializer, _parse_unittest_output
 
 PROMPT_INSTRUCTION = (
     "Please provide a self-contained Python script, without tests or example usage, that solves the following "
@@ -41,6 +43,7 @@ class BigCodeBench(BaseTask[str]):
 
     def __init__(self, num_fewshot: int = 0) -> None:
         assert num_fewshot == 0, "Fewshot is not supported for BigCodeBench"
+        self.serializer = CallableSerializer()
         super().__init__(num_fewshot)
 
     def _load_dataset(self, subject: SubjectType) -> None:
@@ -71,7 +74,22 @@ class BigCodeBench(BaseTask[str]):
         return None
 
     def _get_context(self, item: dict[str, Any]) -> CodeExecutionPassAtOneContext:
-        return CodeExecutionPassAtOneContext(code_prompt=item["code_prompt"], test_code=item["test"])
+        def merge_snippets(code: str, test_code: str) -> str:
+            if "unittest.main(" not in test_code:
+                test_code += "\n\nif __name__ == '__main__':\n  unittest.main()"
+
+            # Combine the implementation code and test code
+            combined_code = code + "\n\n" + test_code
+            return combined_code
+
+        return CodeExecutionPassAtOneContext(
+            run_env=os.environ.get("DOCKER_CODE_EXECUTION"),
+            code_prompt=item["code_prompt"],
+            test_code=item["test"],
+            snippet_merge_fn=self.serializer.encode(merge_snippets),
+            output_parse_fn=self.serializer.encode(_parse_unittest_output),
+            package_downloads=BIG_CODE_BENCH_PACKAGE_MAPPING,
+        )
 
     def post_process_generated_completion(self, completion_text: str, sample: Sample | None = None) -> str:
         if sample is not None and sample.context is not None and sample.subject == "calibrated":

--- a/src/eval_framework/tasks/benchmarks/bigcodebench.py
+++ b/src/eval_framework/tasks/benchmarks/bigcodebench.py
@@ -47,6 +47,7 @@ class BigCodeBench(BaseTask[str]):
 
     def __init__(self, num_fewshot: int = 0) -> None:
         assert num_fewshot == 0, "Fewshot is not supported for BigCodeBench"
+        # NOTE : this serializer should be the same class as initialized in the metric
         self.serializer = CallableSerializer()
         super().__init__(num_fewshot)
 

--- a/src/eval_framework/tasks/benchmarks/bigcodebench.py
+++ b/src/eval_framework/tasks/benchmarks/bigcodebench.py
@@ -75,6 +75,8 @@ class BigCodeBench(BaseTask[str]):
 
     def _get_context(self, item: dict[str, Any]) -> CodeExecutionPassAtOneContext:
         def merge_snippets(code: str, test_code: str) -> str:
+            # Add unittest.main() if not present (note that without "if" sometimes it just reports
+            # "Ran 0 tests" errorneously).
             if "unittest.main(" not in test_code:
                 test_code += "\n\nif __name__ == '__main__':\n  unittest.main()"
 

--- a/src/eval_framework/tasks/utils.py
+++ b/src/eval_framework/tasks/utils.py
@@ -4,8 +4,9 @@ import os
 import random
 import re
 import string
+from collections.abc import Callable
 from pathlib import Path
-from typing import Literal, NamedTuple, Callable, Any
+from typing import Any, Literal, NamedTuple
 
 import dill
 import numpy as np

--- a/tests/tasks/test_bigcodebench.py
+++ b/tests/tasks/test_bigcodebench.py
@@ -1,7 +1,7 @@
 import pytest
 from datasets import DownloadConfig, load_dataset
 
-from eval_framework.tasks.benchmarks.bigcodebench import BigCodeBench, extract_executable_code
+from eval_framework.tasks.benchmarks.bigcodebench import extract_executable_code
 from eval_framework.tasks.utils import BIG_CODE_BENCH_PACKAGE_MAPPING, extract_imports
 
 
@@ -319,35 +319,3 @@ def test_all_imports_in_mapping() -> None:
 
     except Exception as e:
         pytest.skip(f"Skipping dataset test due to error: {str(e)}")
-
-
-class TestCodeComposition:
-    def test_merge(self):
-        code = "import random\nimport statistics\ndef task_func(LETTERS):\n\treturn LETTERS"
-        test_code = """
-        import unittest
-        class TestCases(unittest.TestCase):
-        \tdef setup(self):
-        \t\tself.letters = ['a','b','c']
-        \tdef testcase1(self):
-        \t\tself.assertTrue(self.letters == task_func(self.letters))
-        """
-        merged_code = BigCodeBench.merge_snippets(code, test_code)
-        gt = code + "\n\n" + test_code
-        assert merged_code.startswith(gt)
-
-    def test_with_main(self):
-        code = "import random\nimport statistics\ndef task_func(LETTERS):\n\treturn LETTERS"
-        test_code = """
-        import unittest
-        class TestCases(unittest.TestCase):
-        \tdef setup(self):
-        \t\tself.letters = ['a','b','c']
-        \tdef testcase1(self):
-        \t\tself.assertTrue(self.letters == task_func(self.letters))
-        if __name__ == '__main__':
-        \tunittest.main()
-        """
-        merged_code = BigCodeBench.merge_snippets(code, test_code)
-        gt = code + "\n\n" + test_code
-        assert merged_code.startswith(gt)

--- a/tests/tasks/test_bigcodebench.py
+++ b/tests/tasks/test_bigcodebench.py
@@ -1,9 +1,7 @@
 import pytest
 from datasets import DownloadConfig, load_dataset
 
-from eval_framework.tasks.benchmarks.bigcodebench import (
-    extract_executable_code,
-)
+from eval_framework.tasks.benchmarks.bigcodebench import BigCodeBench, extract_executable_code
 from eval_framework.tasks.utils import BIG_CODE_BENCH_PACKAGE_MAPPING, extract_imports
 
 
@@ -321,3 +319,35 @@ def test_all_imports_in_mapping() -> None:
 
     except Exception as e:
         pytest.skip(f"Skipping dataset test due to error: {str(e)}")
+
+
+class TestCodeComposition:
+    def test_merge(self):
+        code = "import random\nimport statistics\ndef task_func(LETTERS):\n\treturn LETTERS"
+        test_code = """
+        import unittest
+        class TestCases(unittest.TestCase):
+        \tdef setup(self):
+        \t\tself.letters = ['a','b','c']
+        \tdef testcase1(self):
+        \t\tself.assertTrue(self.letters == task_func(self.letters))
+        """
+        merged_code = BigCodeBench.merge_snippets(code, test_code)
+        gt = code + "\n\n" + test_code
+        assert merged_code.startswith(gt)
+
+    def test_with_main(self):
+        code = "import random\nimport statistics\ndef task_func(LETTERS):\n\treturn LETTERS"
+        test_code = """
+        import unittest
+        class TestCases(unittest.TestCase):
+        \tdef setup(self):
+        \t\tself.letters = ['a','b','c']
+        \tdef testcase1(self):
+        \t\tself.assertTrue(self.letters == task_func(self.letters))
+        if __name__ == '__main__':
+        \tunittest.main()
+        """
+        merged_code = BigCodeBench.merge_snippets(code, test_code)
+        gt = code + "\n\n" + test_code
+        assert merged_code.startswith(gt)

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -780,6 +780,7 @@ class TestBigCodeBenchDataset:
         for pkg in common_packages:
             assert pkg in BIG_CODE_BENCH_PACKAGE_MAPPING, f"Package {pkg} not in mapping"
 
+
 def test_fn_recover() -> None:
     def fn(x: int) -> int:
         return x * 2

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -10,6 +10,7 @@ from eval_framework.tasks.utils import (
     extract_imports,
     get_external_dependencies,
     run_python_code,
+    unittest_merge_snippets,
 )
 
 
@@ -148,6 +149,38 @@ class TestParseUnittestOutput:
         assert result.output == "All tests completed successfully."
 
 
+class TestCodeComposition:
+    def test_merge(self) -> None:
+        code = "import random\nimport statistics\ndef task_func(LETTERS):\n\treturn LETTERS"
+        test_code = """
+        import unittest
+        class TestCases(unittest.TestCase):
+        \tdef setup(self):
+        \t\tself.letters = ['a','b','c']
+        \tdef testcase1(self):
+        \t\tself.assertTrue(self.letters == task_func(self.letters))
+        """
+        merged_code = unittest_merge_snippets(code, test_code)
+        gt = code + "\n\n" + test_code
+        assert merged_code.startswith(gt)
+
+    def test_with_main(self) -> None:
+        code = "import random\nimport statistics\ndef task_func(LETTERS):\n\treturn LETTERS"
+        test_code = """
+        import unittest
+        class TestCases(unittest.TestCase):
+        \tdef setup(self):
+        \t\tself.letters = ['a','b','c']
+        \tdef testcase1(self):
+        \t\tself.assertTrue(self.letters == task_func(self.letters))
+        if __name__ == '__main__':
+        \tunittest.main()
+        """
+        merged_code = unittest_merge_snippets(code, test_code)
+        gt = code + "\n\n" + test_code
+        assert merged_code.startswith(gt)
+
+
 class TestExecutePythonCodeWithTests:
     """Integration tests for execute_python_code_with_tests."""
 
@@ -162,7 +195,15 @@ class TestAdd(unittest.TestCase):
         self.assertEqual(add(1, 2), 3)
     """
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is True
         assert "tests completed successfully" in result.output
@@ -172,7 +213,15 @@ class TestAdd(unittest.TestCase):
         code = "def add(a, b): return a - b"  # Incorrect implementation
         test_code = "assert add(1, 2) == 3"
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is False
         assert "AssertionError" in result.output
@@ -182,7 +231,15 @@ class TestAdd(unittest.TestCase):
         code = "def add(a, b) return a + b"  # Missing colon
         test_code = "assert add(1, 2) == 3"
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is False
         assert "SyntaxError" in result.output
@@ -192,7 +249,15 @@ class TestAdd(unittest.TestCase):
         code = "def divide(a, b): return a / b"
         test_code = "assert divide(1, 0) == float('inf')"
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is False
         assert any(err in result.output for err in ["ZeroDivisionError", "division by zero"])
@@ -208,7 +273,15 @@ class TestHang(unittest.TestCase):
 unittest.main()
     """
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING, timeout=1)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=1,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is False
         assert "timeout" in result.output.lower()
@@ -224,7 +297,15 @@ class TestCircleArea(unittest.TestCase):
 unittest.main()
     """
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is True
         assert "tests completed successfully" in result.output
@@ -246,7 +327,15 @@ class TestIsEven(unittest.TestCase):
 unittest.main()
     """
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is True
         assert "tests completed successfully" in result.output
@@ -263,7 +352,15 @@ assert is_positive(-5) == False
 assert is_positive(0) == True  # This will fail
         """
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is False
         assert "AssertionError" in result.output
@@ -305,7 +402,15 @@ class TestStack(unittest.TestCase):
 unittest.main()
         """
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is True
         assert "tests completed successfully" in result.output
@@ -315,7 +420,15 @@ unittest.main()
         code = "def get_pi(): return math.pi"  # Missing import
         test_code = "assert get_pi() > 3.1"
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is False
         assert any(err in result.output for err in ["NameError", "math is not defined"])
@@ -329,7 +442,15 @@ def function():
         """
         test_code = "assert True"
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is False
         assert "IndentationError" in result.output
@@ -345,7 +466,15 @@ class TestEmptyCode(unittest.TestCase):
 unittest.main()
     """
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is True
         assert "tests completed successfully" in result.output
@@ -355,7 +484,15 @@ unittest.main()
         code = "def function(): return True"
         test_code = ""
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
 
         assert result.success is False
         assert "'unittest' is not defined" in result.output
@@ -406,7 +543,15 @@ class TestCases(unittest.TestCase):
 unittest.main()
     """
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
         assert result.success is True
         assert result.output == "All 2 tests completed successfully."
 
@@ -452,7 +597,15 @@ class TestCases(unittest.TestCase):
 unittest.main()
     """
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
         assert result.success is False
         assert "FAILED" in result.output
 
@@ -479,7 +632,15 @@ class TestCases(unittest.TestCase):
 unittest.main()
     """
 
-        result = execute_python_code_with_tests(code, test_code, BIG_CODE_BENCH_PACKAGE_MAPPING)
+        result = execute_python_code_with_tests(
+            code=code,
+            test_code=test_code,
+            package_mapping=BIG_CODE_BENCH_PACKAGE_MAPPING,
+            merge_code_fn=unittest_merge_snippets,
+            image="python:3.12",
+            timeout=10,
+            parse_output_fn=_parse_unittest_output,
+        )
         assert result.success is False
         assert "NameError" in result.output
         assert "task_func" in result.output

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -4,6 +4,7 @@ import time
 
 from eval_framework.tasks.utils import (
     BIG_CODE_BENCH_PACKAGE_MAPPING,
+    CallableSerializer,
     _parse_unittest_output,
     execute_python_code_with_tests,
     extract_imports,
@@ -617,3 +618,12 @@ class TestBigCodeBenchDataset:
 
         for pkg in common_packages:
             assert pkg in BIG_CODE_BENCH_PACKAGE_MAPPING, f"Package {pkg} not in mapping"
+
+def test_fn_recover() -> None:
+    def fn(x: int) -> int:
+        return x * 2
+
+    serializer = CallableSerializer()
+    encoded_fn = serializer.encode(fn)
+    decoded_fn = serializer.decode(encoded_fn)
+    assert decoded_fn(2) == fn(2)


### PR DESCRIPTION
## What type of PR is this?

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Current state of Pass@1 metric is really entangled to the need of having python's unittest library for test execution. The current refactor abstracts away this logic and enables each benchmark to define the code it uses to run the tests and the methodology to parse the outputs. 



## Added/updated tests?
- [x] Yes; particularly to test the serializer class which wraps callable and sends the functions across classes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Are there any post deployment tasks we need to perform?
No