### PR TITLE
Enable ruff UP rules

### DIFF
--- a/changelog/changelog.py
+++ b/changelog/changelog.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def read_changelog(changelog_path: str) -> str:
-    with open(changelog_path, "r") as file:
+    with open(changelog_path) as file:
         return file.read()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,12 @@ flash-attn = [{ requirement = "torch", match-runtime = true }]
 line-length = 120
 
 [tool.ruff.lint]
-select = ["I", "E", "F"]
+select = [
+    "E", # Pycodestyle Errors
+    "F", # Pyflakes
+    "UP", # Auto-upgrading of new Python features
+    "I", # Sort imports
+]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]

--- a/src/eval_framework/context/determined.py
+++ b/src/eval_framework/context/determined.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Type
+from typing import Any
 
 from determined import get_cluster_info
 from determined.core import Context, DummyDistributedContext
@@ -126,7 +126,7 @@ class DeterminedContext(EvalContext):
             raise ValueError(f"LLM '{self.hparams.llm_name}' not found.")
         llm_class = models[self.hparams.llm_name]
 
-        llm_judge_class: Type[BaseLLM] | None = None
+        llm_judge_class: type[BaseLLM] | None = None
         judge_model_name = self.hparams.task_args.judge_model_name or self.judge_model_name
         if self.judge_models_path is not None and judge_model_name is not None:
             judge_models = import_models(self.judge_models_path)

--- a/src/eval_framework/context/eval.py
+++ b/src/eval_framework/context/eval.py
@@ -3,14 +3,14 @@ import inspect
 import sys
 from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Any, Type
+from typing import Any
 
 from eval_framework.llm.base import BaseLLM
 from eval_framework.tasks.eval_config import EvalConfig
 from eval_framework.tasks.perturbation import PerturbationConfig
 
 
-def import_models(models_file: Path) -> dict[str, Type[BaseLLM]]:
+def import_models(models_file: Path) -> dict[str, type[BaseLLM]]:
     models_file = models_file.resolve()
 
     module_name = models_file.stem

--- a/src/eval_framework/context/local.py
+++ b/src/eval_framework/context/local.py
@@ -1,4 +1,4 @@
-from typing import Any, Type
+from typing import Any
 
 from eval_framework.context.eval import EvalContext, import_models
 from eval_framework.llm.base import BaseLLM
@@ -12,7 +12,7 @@ class LocalContext(EvalContext):
             raise ValueError(f"LLM '{self.llm_name}' not found.")
         llm_class = models[self.llm_name]
 
-        self.llm_judge_class: Type[BaseLLM] | None = None
+        self.llm_judge_class: type[BaseLLM] | None = None
         if self.judge_models_path is not None and self.judge_model_name is not None:
             judge_models = import_models(self.judge_models_path)
             if self.judge_model_name not in judge_models:

--- a/src/eval_framework/external/ifeval_impl/instructions.py
+++ b/src/eval_framework/external/ifeval_impl/instructions.py
@@ -22,7 +22,7 @@ import logging
 import random
 import re
 import string
-from typing import Dict, Optional, Sequence, Union
+from collections.abc import Sequence
 
 import langdetect
 
@@ -30,7 +30,7 @@ from eval_framework.external.ifeval_impl import instructions_util
 
 logger = logging.getLogger(__name__)
 
-_InstructionArgsDtype = Optional[Dict[str, Union[int, str, Sequence[str]]]]
+_InstructionArgsDtype = dict[str, int | str | Sequence[str]] | None
 
 _LANGUAGES = instructions_util.LANGUAGE_CODES
 

--- a/src/eval_framework/external/ifeval_impl/instructions_util.py
+++ b/src/eval_framework/external/ifeval_impl/instructions_util.py
@@ -1672,7 +1672,7 @@ def count_words(text):
     return num_words
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _get_sentence_tokenizer():
     return nltk.data.load("nltk:tokenizers/punkt/english.pickle")
 

--- a/src/eval_framework/external/ifeval_impl/utils.py
+++ b/src/eval_framework/external/ifeval_impl/utils.py
@@ -1,7 +1,6 @@
 # mypy: ignore-errors
 
 import dataclasses
-from typing import Dict, Optional, Union
 
 from eval_framework.external.ifeval_impl import instructions_registry
 
@@ -11,7 +10,7 @@ class InputExample:
     key: int
     instruction_id_list: list[str]
     prompt: str
-    kwargs: list[Dict[str, Optional[Union[str, int]]]]
+    kwargs: list[dict[str, str | int | None]]
 
 
 @dataclasses.dataclass

--- a/src/eval_framework/llm/aleph_alpha_api_llm.py
+++ b/src/eval_framework/llm/aleph_alpha_api_llm.py
@@ -6,8 +6,8 @@ import random
 import re
 import time
 import traceback
+from collections.abc import Sequence
 from dataclasses import asdict
-from typing import List, Sequence
 
 import aiohttp
 from aleph_alpha_client import (
@@ -217,8 +217,8 @@ class AlephAlphaAPIModel(BaseLLM):
             return (request, response)
 
     async def _process_requests(
-        self, requests: List[CompletionRequest] | List[EvaluationRequest]
-    ) -> List[RawCompletion | tuple[EvaluationRequest, EvaluationResponse | Error]]:
+        self, requests: list[CompletionRequest] | list[EvaluationRequest]
+    ) -> list[RawCompletion | tuple[EvaluationRequest, EvaluationResponse | Error]]:
         semaphore = asyncio.Semaphore(self.max_async_concurrent_requests)
         async with AsyncClient(
             host=os.getenv("AA_INFERENCE_ENDPOINT", "dummy_endpoint"),
@@ -236,11 +236,11 @@ class AlephAlphaAPIModel(BaseLLM):
 
     def generate_from_messages(
         self,
-        messages: List[Sequence[Message]],
+        messages: list[Sequence[Message]],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
         temperature: float | None = None,
-    ) -> List[RawCompletion]:
+    ) -> list[RawCompletion]:
         if temperature is None:
             effective_temperature = 0.0  # Current default, TODO: refactor to use model's default
             logger.info(
@@ -265,10 +265,10 @@ class AlephAlphaAPIModel(BaseLLM):
         responses = asyncio.run(self._process_requests(requests))
         return responses  # type: ignore
 
-    def logprobs(self, samples: List[Sample]) -> List[RawLoglikelihood]:
-        samples_prompt: List[str] = []
-        evaluation_requests: List[EvaluationRequest] = []
-        results: List[RawLoglikelihood] = []
+    def logprobs(self, samples: list[Sample]) -> list[RawLoglikelihood]:
+        samples_prompt: list[str] = []
+        evaluation_requests: list[EvaluationRequest] = []
+        results: list[RawLoglikelihood] = []
         assert self._formatter, "We need a formatter to generate from messages"
 
         # evaluate all choices independently in flattened list

--- a/src/eval_framework/llm/base.py
+++ b/src/eval_framework/llm/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Sequence
+from collections.abc import Sequence
 
 from eval_framework.shared.types import RawCompletion, RawLoglikelihood
 from eval_framework.tasks.base import Sample
@@ -17,11 +17,11 @@ class BaseLLM(ABC):
     @abstractmethod
     def generate_from_messages(
         self,
-        messages: List[Sequence[Message]],
+        messages: list[Sequence[Message]],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
         temperature: float | None = None,
-    ) -> List[RawCompletion]:
+    ) -> list[RawCompletion]:
         """
         stop_sequences and max_tokens are injected by the task if exist. They should be overwritten or
         extended with the properties of the model. This includes but is not limited to the stop tokens
@@ -39,7 +39,7 @@ class BaseLLM(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def logprobs(self, samples: List[Sample]) -> List[RawLoglikelihood]:
+    def logprobs(self, samples: list[Sample]) -> list[RawLoglikelihood]:
         """
         This function is expected to raise errors which are caught and reported when running the eval.
         Please also make sure to raise an error in case of sequence length issues. We expect to always
@@ -49,10 +49,10 @@ class BaseLLM(ABC):
 
     def generate(
         self,
-        samples: List[Sample],
+        samples: list[Sample],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
         temperature: float | None = None,
-    ) -> List[RawCompletion]:
-        messages: List[Sequence[Message]] = [sample.messages for sample in samples]
+    ) -> list[RawCompletion]:
+        messages: list[Sequence[Message]] = [sample.messages for sample in samples]
         return self.generate_from_messages(messages, stop_sequences, max_tokens, temperature)

--- a/src/eval_framework/llm/huggingface_llm.py
+++ b/src/eval_framework/llm/huggingface_llm.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, List, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import torch
 from tokenizers import Tokenizer
@@ -95,11 +96,11 @@ class HFLLM(BaseLLM):
 
     def generate_from_messages(
         self,
-        messages: List[Sequence[Message]],
+        messages: list[Sequence[Message]],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
         temperature: float | None = None,
-    ) -> List[RawCompletion]:
+    ) -> list[RawCompletion]:
         if temperature is None:
             effective_temperature = 0.0  # Current default, TODO: refactor to use model's default
             logger.info(
@@ -193,7 +194,7 @@ class HFLLM(BaseLLM):
                 completion = completion.split(stop_sequence)[0]
         return completion, len(outputs[prompt_token_count:])
 
-    def logprobs(self, samples: List[Sample]) -> List[RawLoglikelihood]:
+    def logprobs(self, samples: list[Sample]) -> list[RawLoglikelihood]:
         results = []
         for sample in samples:
             # format

--- a/src/eval_framework/llm/models.py
+++ b/src/eval_framework/llm/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -230,7 +230,7 @@ class HFLLM_from_name(HFLLM):
     A generic class to create HFLLM instances from a given model name.
     """
 
-    def __init__(self, model_name: Optional[str] = None, formatter: str = "Llama3Formatter", **kwargs: Any) -> None:
+    def __init__(self, model_name: str | None = None, formatter: str = "Llama3Formatter", **kwargs: Any) -> None:
         if model_name is None:
             raise ValueError("model_name is required")
 

--- a/src/eval_framework/llm/openai_llm.py
+++ b/src/eval_framework/llm/openai_llm.py
@@ -1,7 +1,8 @@
 import json
 import logging
 import os
-from typing import Any, List, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import tiktoken  # OpenAI's official tokenizer library
 from openai import OpenAI
@@ -55,11 +56,11 @@ class OpenAIModel(BaseLLM):
 
     def generate_from_messages(
         self,
-        messages: List[Sequence[Message]],
+        messages: list[Sequence[Message]],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
         temperature: float | None = None,
-    ) -> List[RawCompletion]:
+    ) -> list[RawCompletion]:
         if temperature is None:
             effective_temperature = 0.0  # Current default, TODO: refactor to use model's default
             logger.info(
@@ -142,7 +143,7 @@ class OpenAIModel(BaseLLM):
                 )
         return results
 
-    def logprobs(self, samples: List[Sample]) -> List[RawLoglikelihood]:
+    def logprobs(self, samples: list[Sample]) -> list[RawLoglikelihood]:
         """Get log probabilities for possible completions.
         Args:
             samples: list of Sample containing possible completions
@@ -155,7 +156,7 @@ class OpenAIModel(BaseLLM):
 
     def generate_structured_output(
         self,
-        messages: List[Sequence[Message]],
+        messages: list[Sequence[Message]],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
         temperature: float = 0.0,
@@ -170,7 +171,7 @@ class OpenAIModel(BaseLLM):
             Parsed JSON response
         """
         completions = []
-        list_json_messages: List[Sequence[Message]] = []
+        list_json_messages: list[Sequence[Message]] = []
         for single_messages in messages:
             # Add system message to encourage JSON output
             json_messages = list(single_messages)

--- a/src/eval_framework/llm/vllm_models.py
+++ b/src/eval_framework/llm/vllm_models.py
@@ -1,7 +1,8 @@
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Generic, Literal, Protocol, Sequence, TypeVar, cast, override
+from typing import Any, Literal, Protocol, cast, override
 
 import torch
 from vllm import LLM, SamplingParams
@@ -30,10 +31,7 @@ class TokenizedContainer:
     text: str
 
 
-prompt_type = TypeVar("prompt_type", list[Message], str)
-
-
-class VLLMTokenizerAPI(ABC, Generic[prompt_type]):
+class VLLMTokenizerAPI[prompt_type: (list[Message], str)](ABC):
     """
     Protocol for tokenizer interface that defines required methods.
     Needed for type checking because of the vllm tokenizer.

--- a/src/eval_framework/main.py
+++ b/src/eval_framework/main.py
@@ -1,7 +1,8 @@
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Literal
+from typing import Any, Literal
 
 import wandb
 

--- a/src/eval_framework/metrics/base.py
+++ b/src/eval_framework/metrics/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -25,10 +25,7 @@ class classproperty:
         return self.method(cls)
 
 
-Response = TypeVar("Response")
-
-
-class BaseMetric(ABC, Generic[Response]):
+class BaseMetric[Response](ABC):
     NAME: str
     KEYS: list[str] | None = None
 

--- a/src/eval_framework/metrics/completion_metrics/code_execution_pass_at_one.py
+++ b/src/eval_framework/metrics/completion_metrics/code_execution_pass_at_one.py
@@ -1,6 +1,5 @@
 import os
 import traceback
-from typing import List
 
 from eval_framework.logger import logger
 from eval_framework.metrics.base import BaseMetric, MetricResult
@@ -27,7 +26,7 @@ class CodeExecutionPassAtOne(BaseMetric[Completion]):
                 "home directory."
             )
 
-    def calculate(self, response: Completion) -> List[MetricResult]:
+    def calculate(self, response: Completion) -> list[MetricResult]:
         if response.error is not None:
             return [MetricResult(metric_name=self.NAME, value=None, higher_is_better=True, error=response.error)]
 

--- a/src/eval_framework/metrics/completion_metrics/json_format.py
+++ b/src/eval_framework/metrics/completion_metrics/json_format.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 import jsonschema  # type: ignore
 from pydantic import BaseModel, Field

--- a/src/eval_framework/metrics/completion_metrics/math_reasoning_completion.py
+++ b/src/eval_framework/metrics/completion_metrics/math_reasoning_completion.py
@@ -1,6 +1,7 @@
 import re
 import signal
-from typing import Any, Callable, Iterable
+from collections.abc import Callable, Iterable
+from typing import Any
 
 from sympy import Basic, S, SympifyError, factor, simplify
 from sympy.parsing.latex import parse_latex
@@ -105,7 +106,7 @@ class MathReasoningCompletion(BaseMetric[Completion]):
             final_answer = re.sub(before, after, final_answer)
         for expr in self.REMOVED_EXPRESSIONS_UNITS:
             # Safely remove units at the end, allowing optional space before the unit
-            final_answer = re.sub(r"(.*?)\s*(%s)$" % re.escape(expr), r"\1", final_answer)
+            final_answer = re.sub(rf"(.*?)\s*({re.escape(expr)})$", r"\1", final_answer)
         for expr in self.REMOVED_EXPRESSIONS_FORMAT:
             # Safely remove formatting expressions
             final_answer = final_answer.replace(expr, "")

--- a/src/eval_framework/metrics/completion_metrics/repetition.py
+++ b/src/eval_framework/metrics/completion_metrics/repetition.py
@@ -1,6 +1,7 @@
 import re
 from collections import Counter
-from typing import Final, Sequence
+from collections.abc import Sequence
+from typing import Final
 
 from eval_framework.metrics.base import BaseMetric, MetricResult
 from eval_framework.shared.types import Completion

--- a/src/eval_framework/metrics/llm_metrics/graders/chatbot_style_grader.py
+++ b/src/eval_framework/metrics/llm_metrics/graders/chatbot_style_grader.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 
 from eval_framework.llm.base import BaseLLM as StructuredOutputChatModel
 from eval_framework.metrics.llm_metrics.graders.language import Language

--- a/src/eval_framework/metrics/llm_metrics/graders/comparison_grader.py
+++ b/src/eval_framework/metrics/llm_metrics/graders/comparison_grader.py
@@ -1,5 +1,5 @@
+from collections.abc import Mapping
 from enum import Enum
-from typing import Mapping
 
 from eval_framework.llm.base import BaseLLM as StructuredOutputChatModel
 from eval_framework.metrics.llm_metrics.graders.language import Language

--- a/src/eval_framework/metrics/llm_metrics/graders/conciseness_grader.py
+++ b/src/eval_framework/metrics/llm_metrics/graders/conciseness_grader.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 
 from eval_framework.llm.base import BaseLLM as StructuredOutputChatModel
 from eval_framework.metrics.llm_metrics.graders.language import Language

--- a/src/eval_framework/metrics/llm_metrics/graders/contains_names_grader.py
+++ b/src/eval_framework/metrics/llm_metrics/graders/contains_names_grader.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 
 from eval_framework.llm.base import BaseLLM as StructuredOutputChatModel
 from eval_framework.metrics.llm_metrics.graders.language import Language

--- a/src/eval_framework/metrics/llm_metrics/graders/format_correctness_grader.py
+++ b/src/eval_framework/metrics/llm_metrics/graders/format_correctness_grader.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 
 from eval_framework.llm.base import BaseLLM as StructuredOutputChatModel
 from eval_framework.metrics.llm_metrics.graders.language import Language

--- a/src/eval_framework/metrics/llm_metrics/graders/instruction_grader.py
+++ b/src/eval_framework/metrics/llm_metrics/graders/instruction_grader.py
@@ -1,4 +1,5 @@
-from typing import Literal, Mapping
+from collections.abc import Mapping
+from typing import Literal
 
 from eval_framework.llm.base import BaseLLM as StructuredOutputChatModel
 from eval_framework.metrics.llm_metrics.graders.language import Language

--- a/src/eval_framework/metrics/llm_metrics/graders/language.py
+++ b/src/eval_framework/metrics/llm_metrics/graders/language.py
@@ -1,6 +1,7 @@
+from collections.abc import Mapping
 from dataclasses import dataclass
-from functools import lru_cache
-from typing import Mapping, TypeVar
+from functools import cache
+from typing import TypeVar
 
 import lingua
 from pycountry import languages
@@ -26,7 +27,7 @@ _language_detector = lingua.LanguageDetectorBuilder.from_languages(
 AVAILABLE_LANGUAGES = ["en", "de", "es", "it", "fr", "nl", "pt", "fi"]
 
 
-@lru_cache(maxsize=None)
+@cache
 def detect_language_of(string: str) -> lingua.Language | None:
     return _language_detector.detect_language_of(string)
 

--- a/src/eval_framework/metrics/llm_metrics/graders/long_context_grader.py
+++ b/src/eval_framework/metrics/llm_metrics/graders/long_context_grader.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 
 from eval_framework.llm.base import BaseLLM as StructuredOutputChatModel
 from eval_framework.metrics.llm_metrics.graders.language import Language

--- a/src/eval_framework/metrics/llm_metrics/graders/models.py
+++ b/src/eval_framework/metrics/llm_metrics/graders/models.py
@@ -1,7 +1,8 @@
 import json
 import logging
 import re
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from pydantic import BaseModel
 

--- a/src/eval_framework/metrics/llm_metrics/graders/refusal_grader.py
+++ b/src/eval_framework/metrics/llm_metrics/graders/refusal_grader.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 
 from eval_framework.llm.base import BaseLLM as StructuredOutputChatModel
 from eval_framework.metrics.llm_metrics.graders.language import Language

--- a/src/eval_framework/metrics/llm_metrics/graders/sql_quality_grader.py
+++ b/src/eval_framework/metrics/llm_metrics/graders/sql_quality_grader.py
@@ -1,4 +1,5 @@
-from typing import Any, Literal, Mapping, Optional
+from collections.abc import Mapping
+from typing import Any, Literal
 
 from eval_framework.llm.base import BaseLLM as StructuredOutputChatModel
 from eval_framework.metrics.llm_metrics.graders.language import Language
@@ -115,7 +116,7 @@ Provide your evaluation in the following JSON format:
         self,
         prompt: str,
         completion: str,
-        result: Optional[list[Any]],
+        result: list[Any] | None,
         language: Language,
     ) -> SqlQualityGradingOutput:
         prompt_template = language.language_config(self._prompt_templates)

--- a/src/eval_framework/metrics/llm_metrics/graders/summary_world_knowledge_grader.py
+++ b/src/eval_framework/metrics/llm_metrics/graders/summary_world_knowledge_grader.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 
 from eval_framework.llm.base import BaseLLM as StructuredOutputChatModel
 from eval_framework.metrics.llm_metrics.graders.language import Language

--- a/src/eval_framework/response_generator.py
+++ b/src/eval_framework/response_generator.py
@@ -1,8 +1,9 @@
 import time
 import traceback
+from collections.abc import Callable
 from datetime import UTC, datetime
 from functools import partial
-from typing import Any, Callable, List
+from typing import Any
 
 try:
     from determined import get_cluster_info
@@ -130,10 +131,10 @@ class ResponseGenerator:
 
     def _generate_completions(
         self,
-        samples: List[Sample],
+        samples: list[Sample],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
-    ) -> List[Completion]:
+    ) -> list[Completion]:
         """
         Generates completions for the sample.
         :param sample: sample to generate completions for
@@ -144,7 +145,7 @@ class ResponseGenerator:
         if stop_sequences is None:
             stop_sequences = []
 
-        raw_completions: List[RawCompletion]
+        raw_completions: list[RawCompletion]
         try:
             raw_completions = self.llm.generate(samples=samples, stop_sequences=stop_sequences, max_tokens=max_tokens)
         except Exception as e:
@@ -201,13 +202,13 @@ class ResponseGenerator:
 
         return completion_list
 
-    def _generate_loglikelihoods(self, samples: List[Sample]) -> List[Loglikelihood]:
+    def _generate_loglikelihoods(self, samples: list[Sample]) -> list[Loglikelihood]:
         """
         Generate log likelihoods when a sample is run against the model.
         :param sample: sample to run the task against
         :return: loglikelihoods
         """
-        raw_loglikelihoods: List[RawLoglikelihood]
+        raw_loglikelihoods: list[RawLoglikelihood]
         try:
             raw_loglikelihoods = self.llm.logprobs(samples)
         except Exception as e:
@@ -246,7 +247,7 @@ class ResponseGenerator:
             )
         return loglikelihood_list
 
-    def _generative_output_type_selector(self) -> Callable[[List[Sample]], List[Completion] | List[Loglikelihood]]:
+    def _generative_output_type_selector(self) -> Callable[[list[Sample]], list[Completion] | list[Loglikelihood]]:
         """
         Selects the generative output type based on the response type.
         :return: function to generate responses
@@ -262,7 +263,7 @@ class ResponseGenerator:
 
     def _run_task_against_model(
         self, should_preempt_callable: Callable[[], bool]
-    ) -> tuple[List[Completion | Loglikelihood], bool]:
+    ) -> tuple[list[Completion | Loglikelihood], bool]:
         """
         Runs the task against the model and generates responses.
         :param should_preempt_callable: function to check if preempt is called
@@ -317,7 +318,7 @@ class ResponseGenerator:
         :return: None
         """
 
-        def _process_batch(samples_batch: List[Sample]) -> None:
+        def _process_batch(samples_batch: list[Sample]) -> None:
             if not samples_batch:
                 return
             if len(samples_batch) > 1:
@@ -343,7 +344,7 @@ class ResponseGenerator:
             # Count samples by iterating (this might be expensive for large datasets)
             total_num_samples = sum(1 for _ in self.task.iterate_samples(None))
 
-        samples_batch: List[Sample] = []
+        samples_batch: list[Sample] = []
         with tqdm(total=total_num_samples, desc=f"Processing {self.response_type.value}") as pbar:
             for i, sample in enumerate(self.task.iterate_samples(self.num_samples)):
                 subject = f" - Subject: {sample.subject}"

--- a/src/eval_framework/result_processors/result_processor.py
+++ b/src/eval_framework/result_processors/result_processor.py
@@ -30,7 +30,7 @@ class ResultsFileProcessor(ResultProcessor):
     def load_metadata(self) -> dict:
         metadata_file = self.output_dir / "metadata.json"
         if os.path.exists(metadata_file):
-            with open(metadata_file, "r") as f:
+            with open(metadata_file) as f:
                 return json.load(f)
         else:
             logger.info("No metadata found.")

--- a/src/eval_framework/shared/types.py
+++ b/src/eval_framework/shared/types.py
@@ -1,5 +1,5 @@
 import re
-from typing import Type, TypeVar, cast
+from typing import TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -161,7 +161,9 @@ class Loglikelihood(BaseLoglikelihood):
 MetricContext = TypeVar("MetricContext", bound=BaseMetricContext)
 
 
-def extract_context_metric(response: Completion, metric_context_class: Type[MetricContext]) -> MetricContext:
+def extract_context_metric[MetricContext: BaseMetricContext](
+    response: Completion, metric_context_class: type[MetricContext]
+) -> MetricContext:
     assert response.context is not None, "Expected context to be provided in the response"
     if not isinstance(response.context, list):
         assert isinstance(response.context, metric_context_class) or isinstance(response.context, BaseMetricContext), (

--- a/src/eval_framework/task_loader.py
+++ b/src/eval_framework/task_loader.py
@@ -2,8 +2,8 @@ import importlib.util
 import inspect
 import logging
 import os
+from collections.abc import Sequence
 from types import ModuleType
-from typing import Sequence
 
 from aenum import extend_enum
 

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -1,9 +1,10 @@
 import os
 import random
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generic, Iterable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import iso639
 from datasets import DownloadConfig, load_dataset
@@ -72,7 +73,7 @@ class Sample(BaseModel):
 SubjectType = TypeVar("SubjectType")
 
 
-class BaseTask(ABC, Generic[SubjectType]):
+class BaseTask[SubjectType](ABC):
     NAME: str
     DATASET_PATH: str
     SAMPLE_SPLIT: str

--- a/src/eval_framework/tasks/perturbation.py
+++ b/src/eval_framework/tasks/perturbation.py
@@ -33,9 +33,7 @@ _AUGMENTER_PORT = 0
 SomeBaseTask = TypeVar("SomeBaseTask", bound=BaseTask[Any])
 
 
-def create_perturbation_class(
-    base_class: type[SomeBaseTask], perturbation_config: PerturbationConfig
-) -> type[SomeBaseTask]:
+def create_perturbation_class[T: BaseTask](base_class: type[T], perturbation_config: PerturbationConfig) -> type[T]:
     # mypy seems to have trouble inferring the type
     class EditorPerturbation(base_class):  # type: ignore
         def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/src/eval_framework/tasks/utils.py
+++ b/src/eval_framework/tasks/utils.py
@@ -7,8 +7,9 @@ import os
 import random
 import re
 import string
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Literal, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import numpy as np
 from dotenv import load_dotenv

--- a/src/eval_framework/utils/logging_config.py
+++ b/src/eval_framework/utils/logging_config.py
@@ -1,11 +1,10 @@
 import logging
 import sys
 from pathlib import Path
-from typing import Optional
 
 
 def setup_logging(
-    output_dir: Optional[Path] = None, log_level: int = logging.INFO, log_filename: str = "evaluation.log"
+    output_dir: Path | None = None, log_level: int = logging.INFO, log_filename: str = "evaluation.log"
 ) -> logging.Logger:
     """
     Set up centralized logging configuration for the entire framework.

--- a/src/template_formatting/formatter.py
+++ b/src/template_formatting/formatter.py
@@ -3,10 +3,9 @@ import re
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Any, Literal, overload
+from typing import Any, Literal, overload, override
 
 from pydantic import BaseModel, Field, field_serializer, field_validator
-from typing_extensions import override
 
 try:
     from transformers import AutoTokenizer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Sequence
+from collections.abc import Callable, Sequence
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -31,7 +31,7 @@ class MockLLM(BaseLLM):
         self.logprob_counter = 0
         self.logprob_samples: list[Sample] = []
 
-    def logprobs(self, samples: List[Sample]) -> List[RawLoglikelihood]:
+    def logprobs(self, samples: list[Sample]) -> list[RawLoglikelihood]:
         rawloglikelihoods = []
         for sample in samples:
             self.logprob_counter += 1
@@ -53,11 +53,11 @@ class MockLLM(BaseLLM):
 
     def generate_from_messages(
         self,
-        messages: List[Sequence[Message]],
+        messages: list[Sequence[Message]],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
         temperature: float | None = None,
-    ) -> List[RawCompletion]:
+    ) -> list[RawCompletion]:
         self.generate_counter += 1
         return [
             RawCompletion(

--- a/tests/llm/test_aleph_alpha_api_llm.py
+++ b/tests/llm/test_aleph_alpha_api_llm.py
@@ -1,5 +1,4 @@
 import json
-from typing import List
 from unittest import mock
 
 import pytest
@@ -15,7 +14,7 @@ from template_formatting.formatter import Message, Role
 def test_aleph_alpha_api_llm() -> None:
     model = Llama31_8B_Instruct_API(max_retries=0)
 
-    messages: List[Message] = [
+    messages: list[Message] = [
         Message(role=Role.USER, content="Question: What color is the night sky?\n"),
         Message(role=Role.ASSISTANT, content="Answer:"),
     ]
@@ -40,7 +39,7 @@ def test_aleph_alpha_api_llm() -> None:
         ),
     ]
 
-    results: List[RawLoglikelihood] = model.logprobs(list_of_samples)
+    results: list[RawLoglikelihood] = model.logprobs(list_of_samples)
 
     assert len(results) == 2
     assert set(results[0].loglikelihoods.keys()) == {"red", "blue", "black", "white"}
@@ -49,7 +48,7 @@ def test_aleph_alpha_api_llm() -> None:
     assert set(results[1].loglikelihoods_sequence_positions.keys()) == {"foo", "bar"}
 
     # -- TEST COMPLETIONS --
-    generation_results: List[RawCompletion] = model.generate_from_messages(
+    generation_results: list[RawCompletion] = model.generate_from_messages(
         messages=[messages, messages], stop_sequences=["\n"], max_tokens=4, temperature=0
     )
 
@@ -81,7 +80,7 @@ def test_error_on_overly_long_prompt(mock_complete: mock.AsyncMock, mock_evaluat
         context=None,
     )
 
-    lresults: List[RawLoglikelihood] = model.logprobs([sample])
+    lresults: list[RawLoglikelihood] = model.logprobs([sample])
 
     # ... the loglikelihoods should be empty and the error should be stored
     assert len(lresults) == 1
@@ -94,7 +93,7 @@ def test_error_on_overly_long_prompt(mock_complete: mock.AsyncMock, mock_evaluat
 
     # given a too long log-likelihood task ...
     msg = (Message(role=Role.USER, content="text" * 10000),)
-    cresults: List[RawCompletion] = model.generate_from_messages(messages=[msg], max_tokens=4)
+    cresults: list[RawCompletion] = model.generate_from_messages(messages=[msg], max_tokens=4)
 
     # ... the completion should be empty and the error should be stored
     assert len(cresults) == 1

--- a/tests/llm/test_huggingface_llm.py
+++ b/tests/llm/test_huggingface_llm.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 from eval_framework.llm.models import SmolLM135M
@@ -14,7 +12,7 @@ def test_hf_llm() -> None:
 
     model = SmolLM135M()
 
-    messages: List[Message] = [
+    messages: list[Message] = [
         Message(role=Role.USER, content="Question: What color is the night sky?\n"),
         Message(role=Role.ASSISTANT, content="Answer:"),
     ]
@@ -39,7 +37,7 @@ def test_hf_llm() -> None:
         ),
     ]
 
-    results: List[RawLoglikelihood] = model.logprobs(list_of_samples)
+    results: list[RawLoglikelihood] = model.logprobs(list_of_samples)
 
     assert len(results) == 2
     assert set(results[0].loglikelihoods.keys()) == {"red", "blue", "black", "white"}
@@ -48,7 +46,7 @@ def test_hf_llm() -> None:
     assert set(results[1].loglikelihoods_sequence_positions.keys()) == {"foo", "bar"}
 
     # -- TEST COMPLETIONS --
-    generation_results: List[RawCompletion] = model.generate_from_messages(
+    generation_results: list[RawCompletion] = model.generate_from_messages(
         messages=[messages, messages], stop_sequences=["\n"], max_tokens=4, temperature=0
     )
 
@@ -76,7 +74,7 @@ def test_error_on_overly_long_prompt() -> None:
         context=None,
     )
 
-    lresults: List[RawLoglikelihood] = model.logprobs([sample])
+    lresults: list[RawLoglikelihood] = model.logprobs([sample])
 
     # ... the loglikelihoods should be empty and the error should be stored
     assert len(lresults) == 1
@@ -89,7 +87,7 @@ def test_error_on_overly_long_prompt() -> None:
 
     # given a too long log-likelihood task ...
     msg = (Message(role=Role.USER, content="text" * 10000),)
-    cresults: List[RawCompletion] = model.generate_from_messages(messages=[msg], max_tokens=4)
+    cresults: list[RawCompletion] = model.generate_from_messages(messages=[msg], max_tokens=4)
 
     # ... the completion should be empty and the error should be stored
     assert len(cresults) == 1

--- a/tests/llm/test_vllm.py
+++ b/tests/llm/test_vllm.py
@@ -1,7 +1,8 @@
 import gc
 import logging
 import time
-from typing import Any, List, Sequence, Type, TypeVar
+from collections.abc import Sequence
+from typing import Any, TypeVar
 from unittest.mock import Mock, patch
 
 import pytest
@@ -29,7 +30,7 @@ def clean_up() -> None:
     torch.cuda.empty_cache()
 
 
-def safe_vllm_setup(model_fn: Type[T], kwargs: Any) -> T:
+def safe_vllm_setup[T: VLLMModel](model_fn: type[T], kwargs: Any) -> T:
     """Safely initialize VLLM model with enhanced error handling."""
     assert "max_model_len" in kwargs
     kwargs["max_num_seqs"] = 1
@@ -74,10 +75,10 @@ def safe_vllm_setup(model_fn: Type[T], kwargs: Any) -> T:
         ),
     ],
 )
-def test_vllm(model_fn: Type[T], kwargs: Any) -> None:
+def test_vllm[T: VLLMModel](model_fn: type[T], kwargs: Any) -> None:
     model = safe_vllm_setup(model_fn, kwargs)
 
-    messages: List[Message] = [
+    messages: list[Message] = [
         Message(role=Role.USER, content="Question: What color is the night sky?\n"),
         Message(role=Role.ASSISTANT, content="Answer:"),
     ]
@@ -101,7 +102,7 @@ def test_vllm(model_fn: Type[T], kwargs: Any) -> None:
             context=None,
         ),
     ]
-    results: List[RawLoglikelihood] = []
+    results: list[RawLoglikelihood] = []
     for sample in list_of_samples:
         results.extend(model.logprobs([sample]))
 
@@ -145,7 +146,7 @@ def test_vllm(model_fn: Type[T], kwargs: Any) -> None:
         ),
     ],
 )
-def test_vllm_error_on_overly_long_prompt(model_fn: Type[T], kwargs: Any) -> None:
+def test_vllm_error_on_overly_long_prompt[T: VLLMModel](model_fn: type[T], kwargs: Any) -> None:
     model = safe_vllm_setup(model_fn, kwargs)
 
     # given a too long log-likelihood task ...
@@ -161,7 +162,7 @@ def test_vllm_error_on_overly_long_prompt(model_fn: Type[T], kwargs: Any) -> Non
         context=None,
     )
 
-    lresults: List[RawLoglikelihood] = model.logprobs([sample])
+    lresults: list[RawLoglikelihood] = model.logprobs([sample])
     # THEN the loglikelihoods should be empty and the error should be stored
     assert len(lresults) == 1
     assert (
@@ -171,7 +172,7 @@ def test_vllm_error_on_overly_long_prompt(model_fn: Type[T], kwargs: Any) -> Non
 
     # GIVEN a too long completion task
     msg = [Message(role=Role.USER, content="text" * 10000)]
-    cresults: List[RawCompletion] = model.generate_from_messages(messages=[msg], max_tokens=300)
+    cresults: list[RawCompletion] = model.generate_from_messages(messages=[msg], max_tokens=300)
 
     # ... the completion should be empty and the error should be stored
     assert len(cresults) == 1
@@ -412,13 +413,13 @@ def test_invalid_sampling_param_raises() -> None:
     ],
 )
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires >=2 GPUs for tensor_parallel_size=2")
-def test_logprobs_batched_vs_single(model_fn: Type[T], kwargs: Any) -> None:
+def test_logprobs_batched_vs_single[T: VLLMModel](model_fn: type[T], kwargs: Any) -> None:
     """
     Test that batched logprobs inference produces identical results to single-sample inference.
     """
     model = safe_vllm_setup(model_fn, kwargs)
 
-    base_messages_1: List[Message] = [
+    base_messages_1: list[Message] = [
         Message(
             role=Role.USER,
             content="Small streams often flow into bigger streams or rivers. The small "
@@ -428,7 +429,7 @@ def test_logprobs_batched_vs_single(model_fn: Type[T], kwargs: Any) -> None:
         Message(role=Role.ASSISTANT, content="Answer:"),
     ]
 
-    base_messages_2: List[Message] = [
+    base_messages_2: list[Message] = [
         Message(
             role=Role.USER,
             content="Photosynthesis is the process by which plants make their own"
@@ -438,7 +439,7 @@ def test_logprobs_batched_vs_single(model_fn: Type[T], kwargs: Any) -> None:
         Message(role=Role.ASSISTANT, content="Answer:"),
     ]
 
-    base_messages_3: List[Message] = [
+    base_messages_3: list[Message] = [
         Message(
             role=Role.USER,
             content="The Earth's atmosphere is composed of different layers. The"
@@ -472,7 +473,7 @@ def test_logprobs_batched_vs_single(model_fn: Type[T], kwargs: Any) -> None:
         ),
     ]
 
-    single_results: List[RawLoglikelihood] = []
+    single_results: list[RawLoglikelihood] = []
     for sample in test_samples:
         result = model.logprobs([sample])
         single_results.extend(result)
@@ -484,7 +485,7 @@ def test_logprobs_batched_vs_single(model_fn: Type[T], kwargs: Any) -> None:
     kwargs["batch_size"] = 12
     model = safe_vllm_setup(model_fn, kwargs)
 
-    batched_results: List[RawLoglikelihood] = model.logprobs(test_samples)
+    batched_results: list[RawLoglikelihood] = model.logprobs(test_samples)
 
     assert len(single_results) == len(batched_results) == 3
 
@@ -575,7 +576,7 @@ def test_logprobs_batched_vs_single(model_fn: Type[T], kwargs: Any) -> None:
     ],
 )
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires >=2 GPUs for tensor_parallel_size=2")
-def test_completions_batched_vs_single(model_fn: Type[T], kwargs: Any) -> None:
+def test_completions_batched_vs_single[T: VLLMModel](model_fn: type[T], kwargs: Any) -> None:
     """
     Test that batched completion inference produces identical results to single-message inference.
     """
@@ -608,7 +609,7 @@ def test_completions_batched_vs_single(model_fn: Type[T], kwargs: Any) -> None:
     temperature = 0.0
     stop_sequences = ["\n"]
 
-    single_results: List[RawCompletion] = []
+    single_results: list[RawCompletion] = []
     for messages in test_message_sequences:
         result = model.generate_from_messages(
             messages=[messages], max_tokens=max_tokens, temperature=temperature, stop_sequences=stop_sequences
@@ -621,7 +622,7 @@ def test_completions_batched_vs_single(model_fn: Type[T], kwargs: Any) -> None:
     kwargs["batch_size"] = 10
     model = safe_vllm_setup(model_fn, kwargs)
 
-    batched_results: List[RawCompletion] = model.generate_from_messages(
+    batched_results: list[RawCompletion] = model.generate_from_messages(
         messages=test_message_sequences,
         max_tokens=max_tokens,
         temperature=temperature,

--- a/tests/metrics/test_csv_format.py
+++ b/tests/metrics/test_csv_format.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from collections.abc import Sequence
 
 import pytest
 
@@ -36,7 +36,7 @@ NO_CSV_TEXT = """Sure here's your CSV:
 This is not a csv."""
 
 
-def assert_consistent_column_count(csv_lines: Optional[Sequence[str]], delimiter: Optional[str], count: int) -> None:
+def assert_consistent_column_count(csv_lines: Sequence[str] | None, delimiter: str | None, count: int) -> None:
     assert csv_lines
     counts = [len(csv_line.split(delimiter)) for csv_line in csv_lines]
     assert set(counts) == set([count])

--- a/tests/metrics/test_json_format.py
+++ b/tests/metrics/test_json_format.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 import pytest
 

--- a/tests/mock_wandb.py
+++ b/tests/mock_wandb.py
@@ -1,6 +1,7 @@
 import traceback
+from collections.abc import Sequence
 from types import TracebackType
-from typing import Any, Dict, Literal, Optional, Sequence, TypedDict, Unpack
+from typing import Any, Literal, TypedDict, Unpack
 
 from wandb import Settings
 from wandb.apis.public import RetryingClient
@@ -39,8 +40,8 @@ class RunInitKwargs(TypedDict, total=False):
     client: RetryingClient | None
     entity: str | None
     project: str | None
-    filters: Optional[Dict[str, Any]]
-    order: Optional[str]
+    filters: dict[str, Any] | None
+    order: str | None
     per_page: int
     include_sweeps: bool
 

--- a/tests/tasks/test_all_formatters.py
+++ b/tests/tasks/test_all_formatters.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import pytest
 
 from eval_framework.task_names import TaskName
@@ -98,7 +96,7 @@ SPECIAL_ARGS = {
 
 @pytest.mark.parametrize("formatter_cls", [Llama3Formatter, ConcatFormatter])
 @pytest.mark.parametrize("task_name", list(TaskName))
-def test_all_tasks_formatter(task_name: TaskName, formatter_cls: Type["BaseFormatter"]) -> None:
+def test_all_tasks_formatter(task_name: TaskName, formatter_cls: type["BaseFormatter"]) -> None:
     """
     Test that the formatted sample for each (Task, Formatter) pair is consistent by hashing the output.
 

--- a/tests/tasks/test_cwe_accuracy.py
+++ b/tests/tasks/test_cwe_accuracy.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 from eval_framework.metrics.base import MetricResult
@@ -14,13 +12,13 @@ class TestCWEAccuracy:
         return CWEAccuracy()
 
     @pytest.fixture
-    def default_messages(self) -> List[Message]:
+    def default_messages(self) -> list[Message]:
         return [
             Message(role=Role.SYSTEM, content="You are a helpful assistant."),
             Message(role=Role.USER, content="Please analyze this text and find the most common words."),
         ]
 
-    def test_cwe_all_words_present(self, metric: CWEAccuracy, default_messages: List[Message]) -> None:
+    def test_cwe_all_words_present(self, metric: CWEAccuracy, default_messages: list[Message]) -> None:
         # Test when all words are present in the answer
         completion = Completion(
             id=1,
@@ -36,7 +34,7 @@ class TestCWEAccuracy:
         result: MetricResult = metric.calculate(completion)[0]
         assert result.value == 1.0
 
-    def test_cwe_all_words_different_order(self, metric: CWEAccuracy, default_messages: List[Message]) -> None:
+    def test_cwe_all_words_different_order(self, metric: CWEAccuracy, default_messages: list[Message]) -> None:
         # Test when all words are present but in different order
         completion = Completion(
             id=2,
@@ -52,7 +50,7 @@ class TestCWEAccuracy:
         result: MetricResult = metric.calculate(completion)[0]
         assert result.value == 1.0
 
-    def test_cwe_missing_word(self, metric: CWEAccuracy, default_messages: List[Message]) -> None:
+    def test_cwe_missing_word(self, metric: CWEAccuracy, default_messages: list[Message]) -> None:
         # Test when one word is missing
         completion = Completion(
             id=3,
@@ -68,7 +66,7 @@ class TestCWEAccuracy:
         result: MetricResult = metric.calculate(completion)[0]
         assert result.value == 0.0
 
-    def test_cwe_extra_words(self, metric: CWEAccuracy, default_messages: List[Message]) -> None:
+    def test_cwe_extra_words(self, metric: CWEAccuracy, default_messages: list[Message]) -> None:
         # Test when there are extra words (should still pass if all required words are present)
         completion = Completion(
             id=4,
@@ -85,7 +83,7 @@ class TestCWEAccuracy:
         result: MetricResult = metric.calculate(completion)[0]
         assert result.value == 1.0
 
-    def test_cwe_case_insensitive(self, metric: CWEAccuracy, default_messages: List[Message]) -> None:
+    def test_cwe_case_insensitive(self, metric: CWEAccuracy, default_messages: list[Message]) -> None:
         # Test case insensitivity
         completion = Completion(
             id=5,
@@ -101,7 +99,7 @@ class TestCWEAccuracy:
         result: MetricResult = metric.calculate(completion)[0]
         assert result.value == 1.0
 
-    def test_cwe_with_explanation(self, metric: CWEAccuracy, default_messages: List[Message]) -> None:
+    def test_cwe_with_explanation(self, metric: CWEAccuracy, default_messages: list[Message]) -> None:
         # Test with additional explanation text
         completion = Completion(
             id=6,
@@ -119,7 +117,7 @@ class TestCWEAccuracy:
         result: MetricResult = metric.calculate(completion)[0]
         assert result.value == 1.0
 
-    def test_cwe_with_error(self, metric: CWEAccuracy, default_messages: List[Message]) -> None:
+    def test_cwe_with_error(self, metric: CWEAccuracy, default_messages: list[Message]) -> None:
         # Test with an error in the completion
         completion = Completion(
             id=7,

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -3,7 +3,6 @@ import tempfile
 import time
 import uuid
 from collections.abc import Sequence
-from typing import List
 
 import pytest
 
@@ -646,11 +645,11 @@ def test_redis_cache() -> None:
 
         def generate_from_messages(
             self,
-            messages: List[Sequence[Message]],
+            messages: list[Sequence[Message]],
             stop_sequences: list[str] | None = None,
             max_tokens: int | None = None,
             temperature: float | None = None,
-        ) -> List[RawCompletion]:
+        ) -> list[RawCompletion]:
             return [self.do_one(single_messages) for single_messages in messages]
 
         @redis_cache(
@@ -669,7 +668,7 @@ def test_redis_cache() -> None:
                 raw_completion_error=error,
             )
 
-        def logprobs(self, sample: List[Sample]) -> List[RawLoglikelihood]:
+        def logprobs(self, sample: list[Sample]) -> list[RawLoglikelihood]:
             raise NotImplementedError
 
     class BarLLM(FooLLM):
@@ -727,11 +726,11 @@ def test_redis_cache() -> None:
 
         def generate_from_messages(
             self,
-            messages: List[Sequence[Message]],
+            messages: list[Sequence[Message]],
             stop_sequences: list[str] | None = None,
             max_tokens: int | None = None,
             temperature: float | None = None,
-        ) -> List[RawCompletion]:
+        ) -> list[RawCompletion]:
             return [self.do_one(single_messages) for single_messages in messages]
 
         @redis_cache(
@@ -749,7 +748,7 @@ def test_redis_cache() -> None:
                 completion_sequence_positions=None,
             )
 
-        def logprobs(self, sample: List[Sample]) -> List[RawLoglikelihood]:
+        def logprobs(self, sample: list[Sample]) -> list[RawLoglikelihood]:
             raise NotImplementedError
 
     dummy_completion_1 = [

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,5 +1,5 @@
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 from unittest import mock
 
 import pytest

--- a/tests/test_evaluation_generator.py
+++ b/tests/test_evaluation_generator.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,9 +3,10 @@ import json
 import logging
 import os
 import shutil
+from collections.abc import Callable
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Callable, Generic, TypeVar
+from typing import Any
 from unittest.mock import patch
 
 from datasets import Dataset, DatasetDict
@@ -13,9 +14,6 @@ from datasets import Dataset, DatasetDict
 from eval_framework.constants import RED, RESET
 from eval_framework.result_processors.base import Result
 from eval_framework.tasks.base import BaseTask, SubjectType
-
-T = TypeVar("T", bound=BaseTask)
-
 
 HASHES_FILE = Path(__file__).parent / "tasks" / "task-prompts-hashes.json"
 
@@ -75,7 +73,7 @@ def create_mock_load_hf_dataset(
             if kwargs == captured_kwargs:
                 # return load_dataset('json', data_files=f'{subject}_data.json')
 
-                with open(f"{subject}_data.json", "r") as f:
+                with open(f"{subject}_data.json") as f:
                     data = json.load(f)
 
                 # Convert the JSON data back to the expected dataset format
@@ -89,7 +87,7 @@ def create_mock_load_hf_dataset(
     return mock_load_hf_dataset
 
 
-class DatasetPatcher(Generic[T]):
+class DatasetPatcher[T: BaseTask]:
     def __init__(self, task_class: type[T], num_samples: int = 2, num_fewshot: int = 0):
         self.task_class = task_class
         self.num_fewshot = num_fewshot

--- a/utils/inspect-jsonl.py
+++ b/utils/inspect-jsonl.py
@@ -47,7 +47,7 @@ def jsonl_to_colored_json(filepath: str, highlights: list, strip_keys: list) -> 
     Converts JSONL file to pretty printed and colorized JSON.
     """
     try:
-        with open(filepath, "r") as file:
+        with open(filepath) as file:
             for line in file:
                 data = json.loads(line)
                 colored_output = colorize_json(data, 4, highlights, strip_keys)


### PR DESCRIPTION
This automatically replaces legacy Python features with more modern solutions supported by the minimum Python version specified (3.12 in our case).
