### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
           version: "~=0.8.10"
 
       - name: Check tag
+        # For test releases, we allow any version
+        if: github.event_name == 'release'
         shell: bash
         run: |
             PACKAGE_VERSION=$(uv version --short)
@@ -88,5 +90,5 @@ jobs:
           packages-dir: dist/
           # Test release platform for now
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
+          skip-existing: false
           print-hash: true


### PR DESCRIPTION
This couldn't be tested before it was on `main`, and the version check does not make sense for a non-release. Manually triggering the [release workflow](https://github.com/Aleph-Alpha-Research/eval-framework/actions/workflows/release.yml) works now as expected: [workflow](https://github.com/Aleph-Alpha-Research/eval-framework/actions/runs/17428745825) and corresponding [test release on pypi](https://test.pypi.org/project/eval-framework/)