### PR TITLE
hyphen and space-insensitive task lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - 2025-09-03: Packages are now released to PyPI
+- 2025-09-03: Task look-ups are now insensitive to case, hyphens, underscores and whitespace
 - 2025-09-03: Import paths in `llm` and `metrics` no longer have a `_llm` and `_metrics` suffix. E.g., `llm/huggingface.py` instead of `llm/huggingface_llm.py`
 - 2025-08-29: commented out the flacky SPHYR test
 - 2025-09-03: Our benchmarks tasks are now registered lazily, which reduces the amount of code that is imported

--- a/tests/tasks/test_registry.py
+++ b/tests/tasks/test_registry.py
@@ -1,6 +1,8 @@
 import functools
 from collections.abc import Callable
 
+import pytest
+
 from eval_framework.tasks.benchmarks.math_reasoning import MATH, MATHLvl5
 from eval_framework.tasks.registry import (
     Registry,
@@ -35,11 +37,20 @@ def test_case_insensitive_lookup() -> None:
     assert get_task("Math") is MATH
     assert get_task("math") is MATH
 
+    # Special punctuation not allowed
+    with pytest.raises(ValueError):
+        register_task("MATH.Lvl.5", MATHLvl5)
+
     register_task("MATH Lvl 5", MATHLvl5)
     assert set(registered_task_names()) == {"MATH", "MATH Lvl 5"}
     assert get_task("math lvl 5") is MATHLvl5
     assert get_task("MATH LVL 5") is MATHLvl5
     assert get_task("Math Lvl 5") is MATHLvl5
+    assert get_task("Math Lvl     5") is MATHLvl5
+    assert get_task("Math-Lvl_5") is MATHLvl5
+
+    with pytest.raises(ValueError):
+        get_task("Math.Lvl.5")
 
 
 @temporary_registry


### PR DESCRIPTION
As discussed, having this task lookup be insensitive to whitespace and hypthens will alleviate and practical pain-points when running evals.
