### PR TITLE
keep sample definition flexible for extending classes to define

### DIFF
--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -180,7 +180,7 @@ class BaseTask[SubjectType](ABC):
                 cache_dir=f"{Path.home()}/.cache/eval-framework",
             )
 
-    def _shuffle_splits(self, hf_dataset: DatasetDict) -> dict[str, list[dict[str, Any]]]:
+    def _shuffle_splits(self, hf_dataset: DatasetDict) -> dict[str, Any]:
         dataset = {}
         self.rnd = random.Random(RANDOM_SEED)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR keeps sample typing more flexible for classes extending BaseTask to define the sample types 

## Added/updated tests?
- [ ] Yes
- [ x] No, and this is why: this fix does not introduce any logic; just relaxes the constraint on the type making mypy checking more flexible for extending classes
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
No