### PR TITLE
llm_name can be module path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Models
 
+- The `--llm-name` (and `--judge-model-name`) argument can now also be a module path like `eval_framework.llm.huggingface.HFLLM`.
+  Combining this with `--llm-args` (`-judge-model-args`) should cover many use-cases without having to provide a `models.py` file.
+
 ### Tasks
 
 ### Metrics

--- a/README.md
+++ b/README.md
@@ -186,8 +186,7 @@ To evaluate a single benchmark locally, you can use the following command:
 
 ```bash
 eval_framework \
-    --models src/eval_framework/llm/models.py \
-    --llm-name Smollm135MInstruct \
+    --models 'eval_framework.llm.models.Smollm135MInstruct' \
     --task-name "GSM8K" \
     --output-dir ./eval \
     --num-fewshot 5 \

--- a/docs/cli_usage.md
+++ b/docs/cli_usage.md
@@ -14,8 +14,7 @@ And execute a single evaluation locally:
 
 ```bash
 uv run eval_framework \
-    --models src/eval_framework/llm/models.py \
-    --llm-name Smollm135MInstruct \
+    --llm-name 'eval_framework.llm.models.Smollm135MInstruct' \
     --task-name "GSM8K" \
     --output-dir ./eval \
     --num-fewshot 5 \
@@ -30,13 +29,13 @@ uv run eval_framework [OPTIONS]
 
 ### Required Arguments
 
-**`--models MODELS`**
-Path to the Python module file containing model classes.
+**`--llm-name LLM_NAME`**
+Either a module path to a model, or the name of a model found in the file provided via the `--models` flag.
 
 ### Execution Configuration
 
-**`--llm-name LLM_NAME`**
-The class derived from `eval_framework.llm.base.BaseLLM` found in the `models.py` module to instantiate for evaluation.
+**`--models MODELS`**
+Path to the Python module file containing model classes.
 
 **`--llm-args [LLM_ARGS ...]`**
 Arguments to pass to the LLM as key=value pairs.
@@ -118,8 +117,7 @@ You can run models directly from Hugging Face Hub using the `HFLLM_from_name` cl
 
 ```bash
 uv run eval_framework \
-    --models src/eval_framework/llm/models.py \
-    --llm-name HFLLM_from_name \
+    --llm-name 'eval_framework.llm.huggingface.HFLLM_from_name' \
     --llm-args model_name="microsoft/DialoGPT-medium" formatter="Llama3Formatter" \
     --task-name "GSM8K" \
     --output-dir ./eval \
@@ -135,8 +133,7 @@ vLLM models support configurable sampling parameters through the `--llm-args` pa
 
 ```bash
 uv run eval_framework \
-    --models src/eval_framework/llm/models.py \
-    --llm-name Qwen3_0_6B_VLLM \
+    --llm-name 'eval_framework.llm.models.Qwen3_0_6B_VLLM' \
     --llm-args sampling_params.temperature=0.7 sampling_params.top_p=0.95 sampling_params.max_tokens=150 \
     --task-name "GSM8K" \
     --output-dir ./eval \
@@ -148,8 +145,7 @@ You can also combine sampling parameters with other model arguments:
 
 ```bash
 uv run eval_framework \
-    --models src/eval_framework/llm/models.py \
-    --llm-name Qwen3_0_6B_VLLM \
+    --llm-name 'eval_framework.llm.models.Qwen3_0_6B_VLLM' \
     --llm-args max_model_len=2048 sampling_params.temperature=0.8 sampling_params.top_p=0.9 \
     --task-name "GSM8K" \
     --output-dir ./eval \

--- a/src/eval_framework/context/determined.py
+++ b/src/eval_framework/context/determined.py
@@ -112,10 +112,13 @@ class DeterminedContext(EvalContext):
             if val_cli and val_hparams and val_cli != val_hparams:
                 logger.info(f"CLI argument {name} ({val_cli}) is being overridden by hyperparameters: ({val_hparams}).")
 
-        llm_class = _load_model(self.llm_name, models_path=self.models_path)
+        llm_name = getattr(self.hparams, "llm_name", self.llm_name)
+        judge_model_name = getattr(self.hparams.task_args, "judge_model_name", self.judge_model_name)
+
+        llm_class = _load_model(llm_name, models_path=self.models_path)
         llm_judge_class: type[BaseLLM] | None = None
-        if self.judge_model_name is not None:
-            llm_judge_class = _load_model(self.judge_model_name, models_path=self.judge_models_path, info="judge")
+        if judge_model_name is not None:
+            llm_judge_class = _load_model(judge_model_name, models_path=self.judge_models_path, info="judge")
 
         # for all optional hyperparameters, resort to the respective CLI argument if the hyperparameter is not set
         self.config = EvalConfig(

--- a/src/eval_framework/context/eval.py
+++ b/src/eval_framework/context/eval.py
@@ -2,6 +2,7 @@ import importlib.util
 import inspect
 import sys
 from contextlib import AbstractContextManager
+from os import PathLike
 from pathlib import Path
 from typing import Any
 
@@ -11,7 +12,7 @@ from eval_framework.tasks.eval_config import EvalConfig
 from eval_framework.tasks.perturbation import PerturbationConfig
 
 
-def import_models(models_file: Path | str) -> dict[str, type[BaseLLM]]:
+def import_models(models_file: PathLike | str) -> dict[str, type[BaseLLM]]:
     models_file = Path(models_file).resolve()
     library_path = Path(eval_framework.__path__[0]).resolve()
 
@@ -86,10 +87,10 @@ class EvalContext(AbstractContextManager):
         self.wandb_run_id = wandb_run_id
         self.hf_upload_dir = hf_upload_dir
         self.hf_upload_repo = hf_upload_repo
-        self.llm_args = llm_args
+        self.llm_args = llm_args if llm_args is not None else {}
         self.judge_models_path = judge_models_path
         self.judge_model_name = judge_model_name
-        self.judge_model_args = judge_model_args
+        self.judge_model_args = judge_model_args if judge_model_args is not None else {}
         self.batch_size = batch_size
         self.description = description
 

--- a/src/eval_framework/run.py
+++ b/src/eval_framework/run.py
@@ -50,16 +50,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--llm-name",
         type=str,
-        required=False,
+        required=True,
         help=(
-            "The class derived from `eval_framework.llm.base.BaseLLM` found in the "
-            "models module to instantiate for evaluation."
+            "Either a full import path for a model (e.g., `eval_framework.huggingface.HFLLM`) or the "
+            "name of a class derived from `eval_framework.llm.base.BaseLLM` that can be found in the "
+            "models file. The resulting model is instantiated with the arguments provided via `--llm-args`."
         ),
     )
     parser.add_argument(
         "--llm-args",
         type=str,
-        nargs="*",
+        nargs="+",
+        default=(),
         required=False,
         help="The arguments to pass to the LLM as key=value pairs.",
     )
@@ -113,9 +115,11 @@ def parse_args() -> argparse.Namespace:
         type=str,
         nargs="+",
         required=False,
-        help="The subjects of the task to evaluate. If empty, all subjects are evaluated. Subjects in the form of "
-        "tuples can be specified in a comma-delimited way, possibly using wildcard * in some dimensions of a tuple, "
-        'e.g. "DE_DE, *" or "FR_FR, astronomy".',
+        help=(
+            "The subjects of the task to evaluate. If empty, all subjects are evaluated. Subjects in the form of "
+            "tuples can be specified in a comma-delimited way, possibly using wildcard * in some dimensions of a "
+            "tuple, e.g., 'DE_DE, *' or 'FR_FR, astronomy'."
+        ),
     )
     parser.add_argument(
         "--hf-revision",
@@ -156,8 +160,10 @@ def parse_args() -> argparse.Namespace:
         type=str,
         default=None,
         required=False,
-        help="The name of the Weights & Biases project to log runs to. "
-        "The environment variable WANDB_API_KEY must be set.",
+        help=(
+            "The name of the Weights & Biases project to log runs to. "
+            "The environment variable WANDB_API_KEY must be set."
+        ),
     )
     parser.add_argument(
         "--wandb-entity",
@@ -171,9 +177,11 @@ def parse_args() -> argparse.Namespace:
         type=str,
         default=None,
         required=False,
-        help="The ID of an existing Weights & Biases run to resume. "
-        "If not given, creates a new fun. If given and exists, "
-        "will continue the run but will overwrite the pthon command logged in wandb.",
+        help=(
+            "The ID of an existing Weights & Biases run to resume. "
+            "If not given, creates a new run. If given and exists, "
+            "will continue the run but will overwrite the Python command logged in wandb."
+        ),
     )
     parser.add_argument(
         "--description",
@@ -198,27 +206,31 @@ def parse_args() -> argparse.Namespace:
         required=False,
         help="Whether to save logs to a file in the output directory (default: True).",
     )
+
     parser.add_argument(
         "--judge-model-name",
         type=str,
         required=False,
         help=(
-            "The class derived from `eval_framework.llm.base.BaseLLM` found in the "
-            "judge-models module to instantiate for LLM judge evaluation metrics."
+            "Either a full import path for a judge (e.g., `eval_framework.huggingface.HFLLM`) or the "
+            "name of a class derived from `eval_framework.llm.base.BaseLLM` that can be found in the "
+            "models file. The resulting judge model is instantiated with the arguments provided via "
+            "`--judge-model-args`."
         ),
     )
     parser.add_argument(
         "--judge-model-args",
         type=str,
         required=False,
-        nargs="*",
-        help=("The args of the judge model used."),
+        nargs="+",
+        default=(),
+        help="The args of the judge model used.",
     )
 
     llm_args: dict[str, Any] = {}
     args = parser.parse_args()
 
-    for arg in args.llm_args or []:
+    for arg in args.llm_args:
         if "=" in arg:
             key, value = arg.split("=", 1)
 
@@ -234,7 +246,7 @@ def parse_args() -> argparse.Namespace:
     args.llm_args = llm_args
 
     judge_model_args = {}
-    for arg in args.judge_model_args or []:
+    for arg in args.judge_model_args:
         if "=" in arg:
             key, value = arg.split("=", 1)
             judge_model_args[key] = value

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -53,6 +53,51 @@ def test_run(mock_create_perturbation_class: Mock, mock_parse_args: Mock, tmp_pa
 
 
 @patch("argparse.ArgumentParser.parse_args")
+@patch("eval_framework.response_generator.create_perturbation_class")
+def test_run_path(mock_create_perturbation_class: Mock, mock_parse_args: Mock, tmp_path: Path) -> None:
+    version_str = f"v{importlib.metadata.version('eval_framework')}"
+    task_name = "ARC"
+    module = "tests.conftest"
+    llm_name = "SmolLM135M"
+    mock_parse_args.return_value = Namespace(
+        context="local",
+        models=None,
+        llm_name=f"{module}.{llm_name}",
+        num_samples=4,
+        max_tokens=None,
+        num_fewshot=0,
+        task_name=task_name,
+        hf_revision=None,
+        wandb_project="test-project",
+        wandb_entity="test-entity",
+        wandb_run_id="test-run",
+        output_dir=tmp_path,
+        hf_upload_dir="",
+        hf_upload_repo="",
+        llm_args=[],
+        judge_models=Path(__file__).parent / "conftest.py",
+        judge_model_name="tests.conftest.Smollm135MInstruct",
+        judge_model_args={},
+        batch_size=2,
+        task_subjects=None,
+        description="",
+        perturbation_type="editor",
+        perturbation_probability=0.5,
+        perturbation_seed=123,
+        extra_task_modules=None,
+        save_logs=True,
+    )
+
+    mock_create_perturbation_class.side_effect = lambda x, _: x  # don't spin up docker here just for the test
+
+    run()
+
+    results_path = str(tmp_path / llm_name / f"{version_str}_{task_name}" / "*" / "results.jsonl")
+    results_files = glob.glob(results_path)
+    assert len(results_files) == 1
+
+
+@patch("argparse.ArgumentParser.parse_args")
 def test_run_no_judge_model(mock_parse_args: Mock, tmp_path: Path) -> None:
     version_str = f"v{importlib.metadata.version('eval_framework')}"
     task_name = "ARC"
@@ -61,6 +106,48 @@ def test_run_no_judge_model(mock_parse_args: Mock, tmp_path: Path) -> None:
         context="local",
         models=Path(__file__).parent / "conftest.py",
         llm_name=llm_name,
+        num_samples=4,
+        max_tokens=None,
+        num_fewshot=0,
+        task_name=task_name,
+        hf_revision=None,
+        output_dir=tmp_path,
+        wandb_project="test-project",
+        wandb_entity="test-entity",
+        wandb_run_id="test-run",
+        hf_upload_dir="",
+        hf_upload_repo="",
+        llm_args=[],
+        judge_models=None,
+        judge_model_name=None,
+        judge_model_args={},
+        batch_size=2,
+        task_subjects=None,
+        description="",
+        perturbation_type="",
+        perturbation_probability=None,
+        perturbation_seed=None,
+        extra_task_modules=None,
+        save_logs=True,
+    )
+
+    run()
+
+    results_path = str(tmp_path / llm_name / f"{version_str}_{task_name}" / "*" / "results.jsonl")
+    results_files = glob.glob(results_path)
+    assert len(results_files) == 1
+
+
+@patch("argparse.ArgumentParser.parse_args")
+def test_run_path_no_judge_model(mock_parse_args: Mock, tmp_path: Path) -> None:
+    version_str = f"v{importlib.metadata.version('eval_framework')}"
+    task_name = "ARC"
+    module = "tests.conftest"
+    llm_name = "SmolLM135M"
+    mock_parse_args.return_value = Namespace(
+        context="local",
+        models=None,
+        llm_name=f"{module}.{llm_name}",
         num_samples=4,
         max_tokens=None,
         num_fewshot=0,


### PR DESCRIPTION
Currently, the only accepted workflow is to manually write a models files, which creates some overhead and makes it more difficult to post-hoc figure out which model was used.

This PR proposes to accept a fully qualified module path when no models.py file is provided. That is, `llm_name="eval_framework.huggingface.HFLLM"` should be equivalent to passing `llm_name="HFLLM"` together with `--models="src/eval_framework/llm/huggingface.py"`.