### PR TITLE
Update deprecated _get_eval_kwargs() to _get_context() in StructEval task and docs

### DIFF
--- a/docs/add_new_benchmark_guide.md
+++ b/docs/add_new_benchmark_guide.md
@@ -72,7 +72,7 @@ def _get_fewshot_target_text(self, item: dict[str, Any]) -> str:
     assert target is not None and isinstance(target, str)
     return target
 
-def _get_eval_kwargs(self, item: dict[str, Any]) -> dict[str, Any] | None:
+def _get_context(self, item: dict[str, Any]) -> BaseMetricContext | list[BaseMetricContext] | None:
     """Additional parameters for evaluation metrics."""
     return None
 

--- a/docs/completion_task_guide.md
+++ b/docs/completion_task_guide.md
@@ -138,6 +138,12 @@ class MathTask(BaseTask[str]):
 #### Pattern 3: Code Generation
 ```python
 from eval_framework.metrics.completion.code_execution_pass_at_one import CodeExecutionPassAtOne
+from eval_framework.shared.types import BaseMetricContext
+
+class CodeTaskMetricContext(BaseMetricContext):
+    """Will be passed to the metric for this task."""
+    test_cases: list
+    entry_point: str
 
 class CodeTask(BaseTask[str]):
     NAME = "Code Generation"
@@ -154,12 +160,12 @@ class CodeTask(BaseTask[str]):
     def _get_ground_truth(self, item: dict[str, Any]) -> str:
         return item['canonical_solution']
 
-    def _get_eval_kwargs(self, item: dict[str, Any]) -> dict[str, Any]:
+    def _get_context(self, item: dict[str, Any]) -> CodeTaskMetricContext:
         """Provide test cases for code execution."""
-        return {
-            'test_cases': item['test_cases'],
-            'entry_point': item['entry_point']
-        }
+        return CodeTaskMetricContext(
+            test_cases=item['text_cases'],
+            entry_point=item['entry_point'],
+        )
 ```
 
 ### 4. Advanced Customization

--- a/src/eval_framework/tasks/benchmarks/struct_eval.py
+++ b/src/eval_framework/tasks/benchmarks/struct_eval.py
@@ -5,7 +5,12 @@ from typing import Any
 
 from datasets import DatasetDict
 
-from eval_framework.metrics.completion.struct_eval_metrics import RenderableStructMetric, StructMetric
+from eval_framework.metrics.completion.struct_eval_metrics import (
+    RenderableStructMetric,
+    RenderableStructMetricContext,
+    StructMetric,
+    StructMetricContext,
+)
 from eval_framework.tasks.base import RANDOM_SEED, BaseTask, Language, ResponseType, Sample
 
 StructEvalSubjects = [
@@ -70,11 +75,11 @@ class StructEval(BaseTask[str]):
             "No other text output (explanation, comments, etc.) are allowed.  Do not use markdown code fences.\n"
         )
 
-    def _get_eval_kwargs(self, item: dict[str, Any]) -> dict[str, Any] | None:
-        return {
-            "output_type": item["output_type"],
-            "paths": item["raw_output_metric"],
-        }
+    def _get_context(self, item: dict[str, Any]) -> StructMetricContext | RenderableStructMetricContext:
+        return StructMetricContext(
+            output_type=item["output_type"],
+            paths=item["raw_output_metric"],
+        )
 
     def _get_cue_text(self, item: dict[str, Any]) -> str:
         return "<|BEGIN_CODE|>"
@@ -103,8 +108,8 @@ class RenderableStructEval(StructEval):
     SUBJECTS = RENDERABLE_STRUCTEVAL_SUBJECTS
     METRICS = [RenderableStructMetric]  # Define appropriate metrics for StructEval
 
-    def _get_eval_kwargs(self, item: dict[str, Any]) -> dict[str, Any] | None:
-        return {
-            "output_type": item["output_type"],
-            "keywords": item["raw_output_metric"],
-        }
+    def _get_context(self, item: dict[str, Any]) -> RenderableStructMetricContext:
+        return RenderableStructMetricContext(
+            output_type=item["output_type"],
+            keywords=item["raw_output_metric"],
+        )

--- a/tests/tasks/test_struct_eval.py
+++ b/tests/tasks/test_struct_eval.py
@@ -1,5 +1,6 @@
 import pytest
 
+from eval_framework.metrics.completion.struct_eval_metrics import StructMetricContext
 from eval_framework.tasks.benchmarks.struct_eval import StructEval
 
 
@@ -22,11 +23,15 @@ class TestStructEval:
         assert len(struct_eval_task.SUBJECTS) > 0 and isinstance(struct_eval_task.SUBJECTS[0], str)
         struct_eval_task._load_dataset(struct_eval_task.SUBJECTS[0])
         assert struct_eval_task.dataset is not None, "Dataset should not be None after loading."
-        eval_kwargs = struct_eval_task._get_eval_kwargs(struct_eval_task.dataset[struct_eval_task.SAMPLE_SPLIT][0])
-        assert eval_kwargs is not None, "Eval kwargs should not be None."
-        assert isinstance(eval_kwargs, dict), "Eval kwargs should be a dictionary."
-        assert "output_type" in eval_kwargs, "Eval kwargs must contain 'output_type'."
-        assert "paths" in eval_kwargs, "Eval kwargs must contain 'paths'."
+        eval_context = struct_eval_task._get_context(struct_eval_task.dataset[struct_eval_task.SAMPLE_SPLIT][0])
+        assert eval_context is not None, "Eval context should not be None."
+        assert isinstance(eval_context, StructMetricContext), "Eval context should be a StructMetricContext."
+        assert isinstance(eval_context.output_type, str) and len(eval_context.output_type) > 0, (
+            "Eval context output_type should be a non-empty string."
+        )
+        assert isinstance(eval_context.paths, list) and len(eval_context.paths) > 0, (
+            "Eval context paths should be a non-empty list."
+        )
 
     @pytest.mark.parametrize(
         "sample_text",


### PR DESCRIPTION
## PR Checklist
- [x] Use descriptive commit messages.
- [x] Provide tests for your changes.
- [x] Update any related documentation and include any relevant screenshots.
- [x] Check if changes need to be made to docs (README or any guides in `/docs/`).
- [ ] Reflect the changes you made in the changelog.

No changelog changes, since the PR is just updating a deprecated API and the corresponding docs, not adding/changing features.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

The [StructEval](https://github.com/Aleph-Alpha-Research/eval-framework/blob/update-get-eval-kwargs/src/eval_framework/tasks/benchmarks/struct_eval.py#L78) benchmark was still using the `_get_eval_kwargs()` method, even though it seems to be superseded by `_get_context()`. Same for the docs on adding new benchmarks and completion tasks.
The PR updates all occurrences of `_get_eval_kwargs()` to `_get_context()`.

## QA Instructions, Screenshots, Recordings

Just re-running tests should be sufficient.

## Added/updated tests?
- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
