### PR TITLE
Handle empty stop sequences in HFLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The `--llm-name` (and `--judge-model-name`) argument can now also be a module path like `eval_framework.llm.huggingface.HFLLM`.
   Combining this with `--llm-args` (`-judge-model-args`) should cover many use-cases without having to provide a `models.py` file.
+- Minor fix allowing for empty `stop_sequences` in `eval_framework.llm.huggingface.StopSequenceCriteria`.
 
 ### Tasks
 

--- a/src/eval_framework/llm/huggingface.py
+++ b/src/eval_framework/llm/huggingface.py
@@ -31,9 +31,12 @@ class StopSequenceCriteria(StoppingCriteria):
         self.prompt_token_count = prompt_token_count
         # (relatively weak) upper bound for the number of tokens that
         # need to be decoded to check for stop sequences
-        self.token_history_length = max(map(len, stop_sequences))
+        self.token_history_length = max(map(len, stop_sequences), default=0)
 
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs: Any) -> bool:
+        if not self.stop_sequences:
+            return False
+
         sequence = input_ids[0].tolist()
         sequence = sequence[self.prompt_token_count :]
         if len(sequence) > self.token_history_length:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
     - 📗 Reflect the changes you made in the changelog.

-->


## PR Checklist
- [x] Use descriptive commit messages.
- [x] Provide tests for your changes.
- [ ] Update any related documentation and include any relevant screenshots.
- [x] Check if changes need to be made to docs (README or any guides in `/docs/`).
- [x] Reflect the changes you made in the changelog.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

[StopSequenceCriteria](https://github.com/Aleph-Alpha-Research/eval-framework/blob/main/src/eval_framework/llm/huggingface.py#L27) for the HFLLM currently thows an error when initialized with empty `stop_sequences`.
This leads to issues since the [response_generator](https://github.com/Aleph-Alpha-Research/eval-framework/blob/main/src/eval_framework/response_generator.py#L113) passes an empty list of `stop_sequences` by default.

This PR handles empty `stop_sequences` in `StopSequenceCriteria` gracefully.

## QA Instructions, Screenshots, Recordings

Running tests should be sufficient.

## Added/updated tests?
- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
