### PR TITLE
fix: metric name format fix

### DIFF
--- a/src/eval_framework/metrics/completion/drop_completion.py
+++ b/src/eval_framework/metrics/completion/drop_completion.py
@@ -18,7 +18,7 @@ class DropMetricContext(BaseMetricContext):
 class DropF1ExactMatch(BaseMetric[Completion]):
     """DROP F1 and exact match. Requires DropMetricContext with answer_tuples."""
 
-    NAME = "DROP F1 / Exact Match"
+    NAME = "Drop F1"
     KEYS = ["f1", "exact_match"]
 
     def calculate(self, response: Completion) -> list[MetricResult]:
@@ -52,5 +52,5 @@ class DropF1ExactMatch(BaseMetric[Completion]):
                 higher_is_better=True,
                 error=response.error,
             )
-            for name, key in zip([n.strip() for n in self.NAME.split("/")], self.KEYS)
+            for name, key in zip(self.NAMES, self.KEYS)
         ]

--- a/src/eval_framework/metrics/completion/math_minerva_completion.py
+++ b/src/eval_framework/metrics/completion/math_minerva_completion.py
@@ -20,6 +20,7 @@ class MathMinervaCompletion(BaseMetric[Completion]):
     """
 
     NAME = "Math Minerva Completion"
+    KEYS = ["Exact", "Exact Flex"]
     AGGREGATORS = [PassAtK()]
 
     def __init__(
@@ -36,17 +37,12 @@ class MathMinervaCompletion(BaseMetric[Completion]):
         if response.error:
             return [
                 MetricResult(
-                    metric_name="Exact Match",
+                    metric_name=x,
                     value=None,
                     higher_is_better=True,
                     error=response.error,
-                ),
-                MetricResult(
-                    metric_name="Exact Match (Flex)",
-                    value=None,
-                    higher_is_better=True,
-                    error=response.error,
-                ),
+                )
+                for x in self.NAMES
             ]
 
         gold = response.ground_truth
@@ -55,17 +51,12 @@ class MathMinervaCompletion(BaseMetric[Completion]):
         if not gold:
             return [
                 MetricResult(
-                    metric_name="Exact Match",
+                    metric_name=x,
                     value=None,
                     higher_is_better=True,
                     error="No ground truth available",
-                ),
-                MetricResult(
-                    metric_name="Exact Match (Flex)",
-                    value=None,
-                    higher_is_better=True,
-                    error="No ground truth available",
-                ),
+                )
+                for x in self.NAMES
             ]
 
         raw = response.raw_completion or response.completion
@@ -84,12 +75,8 @@ class MathMinervaCompletion(BaseMetric[Completion]):
         )
 
         return [
-            MetricResult(metric_name="Exact Match", value=exact_match, higher_is_better=True),
-            MetricResult(
-                metric_name="Exact Match (Flex)",
-                value=exact_match_flex,
-                higher_is_better=True,
-            ),
+            MetricResult(metric_name=name, value=value, higher_is_better=True)
+            for name, value in zip(self.NAMES, [exact_match, exact_match_flex])
         ]
 
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## PR Checklist

- [ ] Use descriptive commit messages.
- [ ] Provide tests for your changes.
- [ ] Update any related documentation and include any relevant screenshots.
- [ ] Check if changes need to be made to docs (README or any guides in `/docs/`).

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`metric` objects have a `NAME` and `KEYS` attributes. However, the names of the metrics returned by their `calculate` methods aren't matching these attributes causing troubles in downstream automatic parsing. This PR fixes it for two metric classes i noticed. 
