### PR TITLE
feat: add EvalConfig.fail_on_error to surface request failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### General
 
+* Add `EvalConfig.fail_on_error` (default `False`). When set, request/sample errors (e.g. unreachable inference endpoint, exhausted retries) propagate instead of being captured into a blank `Error` result. Useful when a non-zero exit code is wanted on failure, e.g. in CI.
+
 ### Bug Fixes
 
 ## [0.3.4](https://github.com/Aleph-Alpha-Research/eval-framework/compare/v0.3.3...v0.3.4) (2026-04-13)

--- a/src/eval_framework/response_generator.py
+++ b/src/eval_framework/response_generator.py
@@ -114,8 +114,8 @@ class ResponseGenerator:
         try:
             raw_loglikelihoods = self.llm.logprobs(samples)
         except Exception as e:
-            if raise_errors():
-                raise e
+            if raise_errors() or self.config.fail_on_error:
+                raise
             logger.info(f"Error: {e.__class__.__name__} {e}")
             raw_loglikelihoods = [
                 RawLoglikelihood(
@@ -166,7 +166,8 @@ class ResponseGenerator:
                     self.llm,
                     stop_sequences=stop_sequences,
                     max_tokens=max_tokens,
-                )  # type: ignore[call-arg]
+                    fail_on_error=self.config.fail_on_error,
+                )
             case ResponseType.LOGLIKELIHOODS:
                 return self._generate_loglikelihoods
             case _:

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -352,12 +352,15 @@ class BaseTask[SubjectType](ABC):
         samples: list[Sample],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
+        fail_on_error: bool = False,
     ) -> list[Completion]:
         """
         Generates completions for the sample.
         :param sample: sample to generate completions for
         :param stop_sequences: stop sequences to use in completion generation
         :param max_tokens: maximum tokens to use in completion generation
+        :param fail_on_error: if True, re-raise the original exception instead of capturing it
+                              into a per-sample Error completion
         :return: completion
         """
         if stop_sequences is None:
@@ -367,8 +370,8 @@ class BaseTask[SubjectType](ABC):
         try:
             raw_completions = llm.generate(samples=samples, stop_sequences=stop_sequences, max_tokens=max_tokens)
         except Exception as e:
-            if raise_errors():
-                raise e
+            if raise_errors() or fail_on_error:
+                raise
             logger.info(f"Error: {e.__class__.__name__} {e}")
             raw_completions = [
                 RawCompletion(

--- a/src/eval_framework/tasks/benchmarks/aidanbench.py
+++ b/src/eval_framework/tasks/benchmarks/aidanbench.py
@@ -104,7 +104,12 @@ class AidanBenchOriginal(BaseTask[str]):
         return [Message(role=Role.USER, content=instruction_message)]
 
     def _generation_loop(
-        self, llm: "BaseLLM", stop_sequences: list[str] | None, max_tokens: int | None, initial_samples: list[Sample]
+        self,
+        llm: "BaseLLM",
+        stop_sequences: list[str] | None,
+        max_tokens: int | None,
+        initial_samples: list[Sample],
+        fail_on_error: bool = False,
     ) -> tuple[list[list[Message]], list[Union["Error", None]]]:
         initial_messages = [s.messages for s in initial_samples]
         samples = [(s, False) for s in initial_samples]  # (sample, is_done)
@@ -118,6 +123,7 @@ class AidanBenchOriginal(BaseTask[str]):
                 [samples[i][0] for i in not_done_idx],
                 stop_sequences=stop_sequences,
                 max_tokens=max_tokens,
+                fail_on_error=fail_on_error,
             )
             new_completion_messages: list[list[Message] | None] = [c.messages for c in new_completions]
             new_errors = [c.error for c in new_completions]
@@ -164,11 +170,14 @@ class AidanBenchOriginal(BaseTask[str]):
         samples: list[Sample],
         stop_sequences: list[str] | None = None,
         max_tokens: int | None = None,
+        fail_on_error: bool = False,
     ) -> list[Completion]:
         assert all(len(s.messages) == 1 and s.messages[0].role == Role.USER for s in samples), (
             "Each sample must have exactly one USER message."
         )
-        all_message_histories, errors = self._generation_loop(llm, stop_sequences, max_tokens, samples)
+        all_message_histories, errors = self._generation_loop(
+            llm, stop_sequences, max_tokens, samples, fail_on_error=fail_on_error
+        )
 
         completion_list = []
         for idx, sample in enumerate(samples):

--- a/src/eval_framework/tasks/eval_config.py
+++ b/src/eval_framework/tasks/eval_config.py
@@ -27,6 +27,7 @@ KEYS_UNRELATED_TO_RESULTS = {
     "save_intermediate_results",
     "save_logs",
     "delete_output_dir_after_upload",
+    "fail_on_error",
 }
 
 
@@ -59,6 +60,9 @@ class EvalConfig(BaseConfig):
     # how many times to repeat a single sample
     # can be used to reduce variance of tasks with low number of samples, e.g. AIME24
     repeats: Annotated[int, BeforeValidator(lambda v: 1 if v is None else v), Field(ge=1)] = 1
+    # When True, request/sample errors (e.g. unreachable inference endpoint, exhausted retries)
+    # propagate instead of being captured into a blank Error result.
+    fail_on_error: Annotated[bool, BeforeValidator(lambda v: False if v is None else v)] = False
     # Adding a new member? Remember to update KEYS_UNRELATED_TO_RESULTS if it doesn't impact eval results.
 
     @property

--- a/tests/tests_eval_framework/tasks/test_aidanbench.py
+++ b/tests/tests_eval_framework/tasks/test_aidanbench.py
@@ -116,7 +116,7 @@ def test_generate_completions_returns_proper_format():
     task = AidanBench(num_fewshot=0)
 
     # Mock the generation loop to return simple message history
-    def mock_generation_loop(llm, stop_sequences, max_tokens, initial_samples):
+    def mock_generation_loop(llm, stop_sequences, max_tokens, initial_samples, fail_on_error=False):
         message_histories = []
         errors = []
 

--- a/tests/tests_eval_framework/test_response_generator.py
+++ b/tests/tests_eval_framework/test_response_generator.py
@@ -1,4 +1,6 @@
+from collections.abc import Iterable, Sequence
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -7,15 +9,17 @@ from huggingface_hub.errors import RevisionNotFoundError
 
 from eval_framework.llm.base import BaseLLM
 from eval_framework.response_generator import ResponseGenerator, repeat_samples
+from eval_framework.result_processors.base import ResultProcessor
 from eval_framework.result_processors.result_processor import ResultsFileProcessor
-from eval_framework.shared.types import Completion, RawCompletion
-from eval_framework.tasks.base import Sample
+from eval_framework.shared.types import Completion, RawCompletion, RawLoglikelihood
+from eval_framework.tasks.base import BaseTask, Language, ResponseType, Sample
 from eval_framework.tasks.benchmarks.arc import ARC
 from eval_framework.tasks.eval_config import EvalConfig
 from eval_framework.tasks.perturbation import PerturbationConfig, PerturbationType
-from eval_framework.tasks.registry import get_task
+from eval_framework.tasks.registry import get_task, register_task
 from template_formatting.formatter import Message, Role
 from tests.tests_eval_framework.conftest import MockLLM
+from tests.tests_eval_framework.tasks.test_registry import temporary_registry
 
 
 def test_generate_completions_message_handling() -> None:
@@ -269,7 +273,9 @@ def test_response_generator_llm_token_overloading(
     )
     generated = generator.generate(lambda: False)
     # make sure that run complete is called with the precedence values
-    called_stop_sequences, called_max_tokens = generator.task.generate_completions.call_args[1].values()
+    call_kwargs = generator.task.generate_completions.call_args[1]
+    called_stop_sequences = call_kwargs["stop_sequences"]
+    called_max_tokens = call_kwargs["max_tokens"]
 
     assert generated
     assert expected_max_tokens == called_max_tokens
@@ -561,3 +567,106 @@ def test_response_generator_applies_model_then_task_post_processing(tmp_path: Pa
 
     assert completions[0].raw_completion == "raw_answer"
     assert completions[0].completion == "TASK[MODEL[raw_answer]]"
+
+
+class SaboteurLLM(BaseLLM):
+    """LLM that always raises — drives the fail_on_error code path without mocks."""
+
+    def generate_from_messages(
+        self,
+        messages: list[Sequence[Message]],
+        stop_sequences: list[str] | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+    ) -> list[RawCompletion]:
+        raise RuntimeError("inference connection failed")
+
+    def logprobs(self, samples: list[Sample]) -> list[RawLoglikelihood]:
+        raise RuntimeError("inference connection failed")
+
+
+class NoopResultProcessor(ResultProcessor):
+    """No-op result processor sufficient for ResponseGenerator's metadata + IO calls."""
+
+    output_dir = Path("/tmp")
+
+    def save_metadata(self, metadata: dict) -> None: ...
+    def load_metadata(self) -> dict:
+        return {}
+
+    def save_responses(self, responses: list) -> None: ...
+    def save_response(self, response: Any) -> None: ...
+    def load_responses(self) -> list:
+        return []
+
+    def save_metrics_results(self, results: list) -> None: ...
+    def save_metrics_result(self, result: Any) -> None: ...
+    def save_aggregated_results(self, result: dict) -> None: ...
+    def load_metrics_results(self) -> list:
+        return []
+
+
+class StubTask(BaseTask[str]):
+    """Minimal task that yields a single sample, no HF dataset loader."""
+
+    NAME = "StubTask"
+    DATASET_PATH = "stub"
+    SAMPLE_SPLIT = "test"
+    FEWSHOT_SPLIT = "test"
+    SUBJECTS = ["stub"]
+    LANGUAGE = Language.ENG
+    RESPONSE_TYPE = ResponseType.COMPLETION
+    METRICS: list = []
+    PERTURBATION_UNMODIFIABLE_WORDS: list = []
+
+    def iterate_samples(self, num_samples: int | None = None) -> Iterable[Sample]:
+        yield Sample(
+            id=0,
+            messages=[Message(role=Role.USER, content="Hello")],
+            ground_truth="A",
+            subject="stub",
+            possible_completions=None,
+        )
+
+
+@temporary_registry
+def test_fail_on_error_propagates_llm_failure() -> None:
+    # Given a generator configured with fail_on_error=True against an LLM that always raises
+    register_task(StubTask)
+    config = EvalConfig(
+        task_name="StubTask",
+        num_fewshot=0,
+        num_samples=1,
+        llm_class=SaboteurLLM,
+        save_intermediate_results=False,
+        fail_on_error=True,
+    )
+    generator = ResponseGenerator(SaboteurLLM(), config, NoopResultProcessor())  # type: ignore[arg-type]
+
+    # Then the original exception propagates
+    with pytest.raises(RuntimeError, match="inference connection failed"):
+        # When running the generator
+        generator.generate(should_preempt_callable=lambda: False)
+
+
+@temporary_registry
+def test_fail_on_error_disabled_swallows_llm_failure() -> None:
+    # Given a generator with the default fail_on_error=False against an LLM that always raises
+    register_task(StubTask)
+    config = EvalConfig(
+        task_name="StubTask",
+        num_fewshot=0,
+        num_samples=1,
+        llm_class=SaboteurLLM,
+        save_intermediate_results=False,
+    )
+    generator = ResponseGenerator(SaboteurLLM(), config, NoopResultProcessor())  # type: ignore[arg-type]
+
+    # When running the generator
+    responses, _ = generator.generate(should_preempt_callable=lambda: False)
+
+    # Then the failure is captured per-sample as an Error, not raised
+    assert len(responses) == 1
+    assert responses[0].error is not None
+    assert responses[0].error.error_class == "RuntimeError"


### PR DESCRIPTION
By default, request/sample errors (e.g. unreachable inference endpoint,
exhausted retries) are captured into a blank Error result and the run
exits 0, so failures don't surface in CI. Setting fail_on_error=True
re-raises the original exception at the catch sites in
BaseTask.generate_completions and ResponseGenerator._generate_loglikelihoods.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
