### PR TITLE
fix: preserve system role when sending messages to OpenAI chat API

### DIFF
--- a/src/eval_framework/llm/openai.py
+++ b/src/eval_framework/llm/openai.py
@@ -8,16 +8,36 @@ from functools import partial
 
 import tiktoken
 from openai import OpenAI
-from openai.types.chat import ChatCompletionAssistantMessageParam, ChatCompletionUserMessageParam
+from openai.types.chat import (
+    ChatCompletionAssistantMessageParam,
+    ChatCompletionMessageParam,
+    ChatCompletionSystemMessageParam,
+    ChatCompletionUserMessageParam,
+)
 from tokenizers import Tokenizer
 from transformers import AutoTokenizer
 
 from eval_framework.llm.base import BaseLLM
 from eval_framework.shared.types import ConcatCompression, Error, RawCompletion, RawLoglikelihood
 from eval_framework.tasks.base import Sample
-from template_formatting.formatter import BaseFormatter, ConcatFormatter, HFFormatter, Message
+from template_formatting.formatter import BaseFormatter, ConcatFormatter, HFFormatter, Message, Role
 
 logger = logging.getLogger(__name__)
+
+
+def _to_chat_completion_message(message: Message) -> ChatCompletionMessageParam:
+    match message.role:
+        case Role.SYSTEM:
+            return ChatCompletionSystemMessageParam(role="system", content=message.content)
+        case Role.USER:
+            return ChatCompletionUserMessageParam(role="user", content=message.content)
+        case Role.ASSISTANT:
+            return ChatCompletionAssistantMessageParam(role="assistant", content=message.content)
+        case None:
+            raise ValueError(
+                "Cannot send a Message without a role through the chat completion API; "
+                "the legacy roleless format is only supported for fine-tuning."
+            )
 
 
 class OpenAIModel(BaseLLM):
@@ -158,14 +178,7 @@ class OpenAIModel(BaseLLM):
 
             else:
                 # Use chat completion API
-                chat_messages = [
-                    (
-                        ChatCompletionUserMessageParam(role="user", content=m.content)
-                        if m.role is not None and m.role.value.lower() == "user"
-                        else ChatCompletionAssistantMessageParam(role="assistant", content=m.content)
-                    )
-                    for m in single_messages
-                ]
+                chat_messages = [_to_chat_completion_message(m) for m in single_messages]
                 assert self._model_name is not None
                 chat_response = self._client.chat.completions.create(
                     model=self._model_name,

--- a/tests/tests_eval_framework/llm/test_openai.py
+++ b/tests/tests_eval_framework/llm/test_openai.py
@@ -153,3 +153,24 @@ def test_generate_from_messages_validates_temperature_and_top_p(mocker: MockerFi
         model.generate_from_messages([], top_p=1.5)
     with pytest.raises(AssertionError, match="top_p"):
         model.generate_from_messages([], top_p=-1.0)
+
+
+def test_generate_from_messages_preserves_message_roles(mocker: MockerFixture) -> None:
+    mock_client = mocker.MagicMock()
+    mocker.patch("eval_framework.llm.openai.OpenAI", return_value=mock_client)
+    mock_client.chat.completions.create.return_value = _make_chat_response(mocker)
+
+    model = OpenAIModel(model_name="gpt-4o-mini-2024-07-18")
+    messages = [
+        [
+            Message(role=Role.SYSTEM, content="system prompt"),
+            Message(role=Role.USER, content="user prompt"),
+            Message(role=Role.ASSISTANT, content="assistant prompt"),
+        ]
+    ]
+
+    model.generate_from_messages(messages)
+
+    sent_messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    assert [m["role"] for m in sent_messages] == ["system", "user", "assistant"]
+    assert [m["content"] for m in sent_messages] == ["system prompt", "user prompt", "assistant prompt"]


### PR DESCRIPTION
The previous mapping turned every non-user role (including SYSTEM) into
an assistant message, so any task that prepended a system prompt would
have it silently rewritten as role=assistant in the chat completion
request. Adds a behavior test that mocks the client and asserts roles
are preserved end-to-end.

Alternative to #197: same intent, but extracts the conversion as a
module-level helper (independent of model_name init), uses an
exhaustive match over Role, and raises on the legacy roleless format
instead of silently mapping it to assistant.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
