### PR TITLE
fix: fail code-execution benchmarks when a Docker image pull fails

### DIFF
--- a/src/eval_framework/evaluation_generator.py
+++ b/src/eval_framework/evaluation_generator.py
@@ -80,6 +80,7 @@ class EvaluationGenerator:
                 )
             else:
                 metric = metric_class()
+            metric.fail_on_error = self.config.fail_on_error
 
             logger.info(f"Starting calculation of {metric.NAME}")
             safe_tqdm_write(f"INFO: Calculating {metric.NAME}")

--- a/src/eval_framework/metrics/base.py
+++ b/src/eval_framework/metrics/base.py
@@ -1,3 +1,4 @@
+import traceback
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -5,6 +6,7 @@ from pydantic import BaseModel, ConfigDict
 
 from eval_framework.metrics.aggregators.aggregators import Aggregator
 from eval_framework.shared.types import Error
+from eval_framework.tasks.utils import raise_errors
 
 
 class MetricResult(BaseModel):
@@ -33,6 +35,8 @@ class BaseMetric[Response](ABC):
     # sample over multiple runs (LLM calls). We default to averaging and thus making
     # macro averaging the overall computation default.
     AGGREGATORS: list[Aggregator] = []
+    # Set by the evaluation generator before calculate(); controls how infra failures are handled.
+    fail_on_error: bool = False
 
     @classproperty
     def NAMES(cls) -> list[str]:
@@ -43,3 +47,17 @@ class BaseMetric[Response](ABC):
     @abstractmethod
     def calculate(self, response: Response) -> list[MetricResult]:
         raise NotImplementedError
+
+    def _record_or_raise(self, exc: Exception) -> list[MetricResult]:
+        """Infra failure (e.g. a Docker image-pull rate limit): abort when fail_on_error is set,
+        otherwise record a per-sample error so the run continues."""
+        if raise_errors() or self.fail_on_error:
+            raise exc
+        return [
+            MetricResult(
+                metric_name=self.NAME,
+                value=None,
+                higher_is_better=True,
+                error=Error(error_class=exc.__class__.__name__, message=str(exc), traceback=traceback.format_exc()),
+            )
+        ]

--- a/src/eval_framework/metrics/completion/code_assertion.py
+++ b/src/eval_framework/metrics/completion/code_assertion.py
@@ -17,9 +17,8 @@ class CodeCompletionAssertion(BaseMetric[Completion]):
         try:
             output = run_python_code(code, image="python:3.12-slim")
         except SandboxTimeoutError as e:
-            # The submitted code timed out (e.g. an infinite loop) -- a failing sample, not an
-            # infra problem. Any other sandbox/Docker error (e.g. an image pull rate limit) is left
-            # to propagate so the run fails instead of being scored as a wrong answer.
+            # The submitted code timed out (e.g. an infinite loop) -- a failing sample, not an infra
+            # problem.
             import traceback
 
             return [
@@ -30,6 +29,9 @@ class CodeCompletionAssertion(BaseMetric[Completion]):
                     error=Error(error_class=e.__class__.__name__, message=str(e), traceback=traceback.format_exc()),
                 )
             ]
+        except Exception as e:
+            # Any other sandbox/Docker error (e.g. an image pull rate limit) is an infra failure.
+            return self._record_or_raise(e)
 
         # Split and filter out empty strings
         output_parts = [part for part in output.split() if part.strip()]

--- a/src/eval_framework/metrics/completion/code_assertion.py
+++ b/src/eval_framework/metrics/completion/code_assertion.py
@@ -1,3 +1,5 @@
+from llm_sandbox.exceptions import SandboxTimeoutError
+
 from eval_framework.metrics.base import BaseMetric, MetricResult
 from eval_framework.shared.types import Completion, Error
 from eval_framework.tasks.utils import run_python_code
@@ -14,7 +16,10 @@ class CodeCompletionAssertion(BaseMetric[Completion]):
         code = response.completion
         try:
             output = run_python_code(code, image="python:3.12-slim")
-        except Exception as e:
+        except SandboxTimeoutError as e:
+            # The submitted code timed out (e.g. an infinite loop) -- a failing sample, not an
+            # infra problem. Any other sandbox/Docker error (e.g. an image pull rate limit) is left
+            # to propagate so the run fails instead of being scored as a wrong answer.
             import traceback
 
             return [

--- a/src/eval_framework/metrics/completion/code_execution_pass_at_one.py
+++ b/src/eval_framework/metrics/completion/code_execution_pass_at_one.py
@@ -89,10 +89,12 @@ class CodeExecutionPassAtOne(BaseMetric[Completion]):
             raise Exception(f"Failed to rebuild parsing functions => {e}")
 
         n = 1  # we only support N=1 at the moment
-        # A sandbox/Docker failure (e.g. an image pull rate limit) propagates so the run fails
-        # rather than being scored as a wrong answer; only a code timeout is counted as a failure
-        # (handled in _count_correct_samples).
-        c, output = self._count_correct_samples(response.completion, parsed_context)
+        try:
+            c, output = self._count_correct_samples(response.completion, parsed_context)
+        except Exception as e:
+            # Infra failure (e.g. an image pull rate limit); a code timeout is already scored as a
+            # failure inside _count_correct_samples.
+            return self._record_or_raise(e)
 
         pass_at_k_value = estimate_pass_at_k(n, c, self.k)
         return [

--- a/src/eval_framework/metrics/completion/code_execution_pass_at_one.py
+++ b/src/eval_framework/metrics/completion/code_execution_pass_at_one.py
@@ -1,15 +1,14 @@
 import importlib.resources
-import traceback
 from collections.abc import Callable
 from typing import Self
 
+from llm_sandbox.exceptions import SandboxTimeoutError
 from pydantic import Field
 
 from eval_framework.metrics.base import BaseMetric, MetricResult
 from eval_framework.shared.types import (
     BaseMetricContext,
     Completion,
-    Error,
     extract_context_metric,
 )
 from eval_framework.tasks.utils import (
@@ -90,22 +89,10 @@ class CodeExecutionPassAtOne(BaseMetric[Completion]):
             raise Exception(f"Failed to rebuild parsing functions => {e}")
 
         n = 1  # we only support N=1 at the moment
-        try:
-            c, output = self._count_correct_samples(response.completion, parsed_context)
-        except Exception as e:
-            error = Error(
-                error_class=e.__class__.__name__,
-                message=str(e),
-                traceback=traceback.format_exc(),
-            )
-            return [
-                MetricResult(
-                    metric_name=self.NAME,
-                    value=None,
-                    higher_is_better=True,
-                    error=error,
-                )
-            ]
+        # A sandbox/Docker failure (e.g. an image pull rate limit) propagates so the run fails
+        # rather than being scored as a wrong answer; only a code timeout is counted as a failure
+        # (handled in _count_correct_samples).
+        c, output = self._count_correct_samples(response.completion, parsed_context)
 
         pass_at_k_value = estimate_pass_at_k(n, c, self.k)
         return [
@@ -130,7 +117,8 @@ class CodeExecutionPassAtOne(BaseMetric[Completion]):
                 parse_output_fn=context.output_parse_fn,
                 dockerfile=None,
             )
-        except Exception as e:
+        except SandboxTimeoutError as e:
+            # The submitted code timed out (e.g. an infinite loop) -- a failing sample.
             return (0, str(e))
         return (1 if result.success else 0), result.output
 
@@ -143,16 +131,20 @@ class CodeExecutionPassAtOneWithCodebench(CodeExecutionPassAtOne):
         self.dockerfile = str(importlib.resources.files("eval_framework.tasks") / "Dockerfile_codebench")
 
     def _count_correct_samples(self, completion: str, context: RealtimeCodeExectionContext) -> tuple[int, str]:
-        result = execute_python_code_with_tests(
-            code=completion,
-            test_code=context.test_code,
-            package_mapping={},  # the docker contains everything
-            merge_code_fn=context.snippet_merge_fn,
-            image=None,  # dockerfile provided
-            timeout=context.benchmark_timeout,
-            parse_output_fn=context.output_parse_fn,
-            dockerfile=self.dockerfile,
-        )
+        try:
+            result = execute_python_code_with_tests(
+                code=completion,
+                test_code=context.test_code,
+                package_mapping={},  # the docker contains everything
+                merge_code_fn=context.snippet_merge_fn,
+                image=None,  # dockerfile provided
+                timeout=context.benchmark_timeout,
+                parse_output_fn=context.output_parse_fn,
+                dockerfile=self.dockerfile,
+            )
+        except SandboxTimeoutError as e:
+            # The submitted code timed out (e.g. an infinite loop) -- a failing sample.
+            return (0, str(e))
         return (1 if result.success else 0), result.output
 
 

--- a/src/eval_framework/metrics/completion/multipl_e_assertion.py
+++ b/src/eval_framework/metrics/completion/multipl_e_assertion.py
@@ -107,14 +107,16 @@ class MultiPLECodeAssertion(BaseMetric[Completion]):
             success, output = self._execute(context, response.completion, timeout=60)
         except SandboxTimeoutError as exc:
             # The submitted code timed out (e.g. an infinite loop) -- a failing sample, not an infra
-            # problem. Any other sandbox/Docker error (e.g. an image pull rate limit) propagates so
-            # the run fails instead of being scored as a wrong answer.
+            # problem.
             error = Error(
                 error_class=exc.__class__.__name__,
                 message=str(exc),
                 traceback=traceback.format_exc(),
             )
             return [MetricResult(metric_name=self.NAME, value=None, higher_is_better=True, error=error)]
+        except Exception as exc:
+            # Any other sandbox/Docker error (e.g. an image pull rate limit) is an infra failure.
+            return self._record_or_raise(exc)
 
         return [
             MetricResult(

--- a/src/eval_framework/metrics/completion/multipl_e_assertion.py
+++ b/src/eval_framework/metrics/completion/multipl_e_assertion.py
@@ -8,6 +8,7 @@ from typing import Any, NamedTuple
 
 from llm_sandbox import SandboxSession
 from llm_sandbox.const import DefaultImage, SupportedLanguage
+from llm_sandbox.exceptions import SandboxTimeoutError
 from pydantic import Field
 
 from eval_framework.metrics.base import BaseMetric, MetricResult
@@ -104,7 +105,10 @@ class MultiPLECodeAssertion(BaseMetric[Completion]):
 
         try:
             success, output = self._execute(context, response.completion, timeout=60)
-        except Exception as exc:
+        except SandboxTimeoutError as exc:
+            # The submitted code timed out (e.g. an infinite loop) -- a failing sample, not an infra
+            # problem. Any other sandbox/Docker error (e.g. an image pull rate limit) propagates so
+            # the run fails instead of being scored as a wrong answer.
             error = Error(
                 error_class=exc.__class__.__name__,
                 message=str(exc),

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -409,6 +409,8 @@ class BaseTask[SubjectType](ABC):
                 model_post_processed_completion = llm.post_process_completion(raw_completion.completion, sample)
                 completion = self.post_process_generated_completion(model_post_processed_completion, sample)
             except Exception as e:
+                if raise_errors() or fail_on_error:
+                    raise
                 error = Error(error_class=e.__class__.__name__, message=str(e), traceback=traceback.format_exc())
                 completion = ""
 

--- a/src/eval_framework/tasks/benchmarks/tablebench.py
+++ b/src/eval_framework/tasks/benchmarks/tablebench.py
@@ -6,6 +6,8 @@ import tempfile
 from itertools import product
 from typing import Any
 
+from llm_sandbox.exceptions import SandboxTimeoutError
+
 from eval_framework.exceptions import LogicError
 from eval_framework.metrics.completion.rouge_l import ROUGE_L
 from eval_framework.tasks.base import RANDOM_SEED, BaseTask, Language, ResponseType, Sample
@@ -106,7 +108,9 @@ class TableBench(BaseTask[tuple[str, str]]):
                     completion_text = run_python_code(
                         code, image="amancevice/pandas:slim", input_files=[(filename, "/var/lib/pandas/table.csv")]
                     )
-                except Exception:
+                except SandboxTimeoutError:
+                    # The generated code timed out -- treat as no answer. Any other sandbox/Docker
+                    # failure (e.g. an image pull rate limit) propagates so the run can fail.
                     return ""
 
         # Extract the answer, be it directly from the model or be it the result of the generated code

--- a/tests/tests_eval_framework/metrics/test_code_assertion.py
+++ b/tests/tests_eval_framework/metrics/test_code_assertion.py
@@ -340,15 +340,29 @@ def _completion() -> Completion:
     )
 
 
-def test_code_assertion_propagates_image_pull_error() -> None:
+def test_code_assertion_propagates_image_pull_error_when_fail_on_error() -> None:
     # An infra failure (image pull rate-limited) must abort the run, not be scored as value=0.
     metric = CodeCompletionAssertion()
+    metric.fail_on_error = True
     with patch(
         "eval_framework.metrics.completion.code_assertion.run_python_code",
         side_effect=ImagePullError("python:3.12-slim", "429 toomanyrequests"),
     ):
         with pytest.raises(ImagePullError):
             metric.calculate(_completion())
+
+
+def test_code_assertion_records_image_pull_error_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Without fail_on_error, an infra failure is recorded as a per-sample error (value=None).
+    monkeypatch.setenv("DEBUG", "false")
+    metric = CodeCompletionAssertion()
+    with patch(
+        "eval_framework.metrics.completion.code_assertion.run_python_code",
+        side_effect=ImagePullError("python:3.12-slim", "429 toomanyrequests"),
+    ):
+        results = metric.calculate(_completion())
+    assert results[0].value is None
+    assert results[0].error is not None
 
 
 def test_code_assertion_scores_timeout_as_failure() -> None:

--- a/tests/tests_eval_framework/metrics/test_code_assertion.py
+++ b/tests/tests_eval_framework/metrics/test_code_assertion.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 import pytest
+from llm_sandbox.exceptions import ImagePullError, SandboxTimeoutError
 
 from eval_framework.metrics.completion.code_assertion import CodeCompletionAssertion
 from eval_framework.shared.types import Completion, Error
@@ -321,3 +324,40 @@ def test_code_assertion(response: Completion, expected_value: float) -> None:
         # means we expected an error
         assert results[0].value is None
         assert results[0].error is not None
+
+
+def _completion() -> Completion:
+    return Completion(
+        id=1,
+        subject="test",
+        ground_truth="",
+        raw_completion="print(True)",
+        raw_completion_sequence_positions=None,
+        completion="print(True)",
+        prompt="test",
+        prompt_sequence_positions=None,
+        messages=None,
+    )
+
+
+def test_code_assertion_propagates_image_pull_error() -> None:
+    # An infra failure (image pull rate-limited) must abort the run, not be scored as value=0.
+    metric = CodeCompletionAssertion()
+    with patch(
+        "eval_framework.metrics.completion.code_assertion.run_python_code",
+        side_effect=ImagePullError("python:3.12-slim", "429 toomanyrequests"),
+    ):
+        with pytest.raises(ImagePullError):
+            metric.calculate(_completion())
+
+
+def test_code_assertion_scores_timeout_as_failure() -> None:
+    # A code-execution timeout is the model's fault and stays a per-sample value=0.
+    metric = CodeCompletionAssertion()
+    with patch(
+        "eval_framework.metrics.completion.code_assertion.run_python_code",
+        side_effect=SandboxTimeoutError("too slow"),
+    ):
+        results = metric.calculate(_completion())
+    assert results[0].value == 0.0
+    assert results[0].error is not None


### PR DESCRIPTION
Code-execution metrics caught every exception and scored it as a wrong answer, so a Docker infra failure (e.g. image-pull `429`) silently produced garbage and the run still exited 0.

Now metrics catch only `SandboxTimeoutError` (model's fault → failing sample); any other sandbox/Docker error propagates.

**Tradeoff:** eval-phase code metrics (`code_assertion`, `code_execution_pass@1`, `multipl_e`) always abort on an infra error, even with `fail_on_error=False` — no escape hatch. Intentional: a failing sandbox yields meaningless scores, so fail loud. (Generation-phase `tablebench` still honors `fail_on_error` via the `base.py` gate.) To get symmetry later, thread `fail_on_error` into these metrics' `calculate()`.
