### PR TITLE
test: Prompt format tests for mmlu de

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ known-third-party = ["wandb"]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]
+"tests/tests_eval_framework/tasks/benchmarks/test_mmlu_de.py" = ["E501"]
 
 [tool.mypy]
 plugins = "pydantic.mypy"

--- a/tests/tests_eval_framework/conftest.py
+++ b/tests/tests_eval_framework/conftest.py
@@ -7,8 +7,6 @@ import wandb
 from _pytest.fixtures import FixtureRequest
 
 from eval_framework.llm.base import BaseLLM, Sample
-from eval_framework.llm.huggingface import Pythia410m, SmolLM135M, Smollm135MInstruct
-from eval_framework.llm.vllm import Qwen3_0_6B_VLLM
 from eval_framework.shared.types import RawCompletion, RawLoglikelihood
 from template_formatting.formatter import Message
 from tests.tests_eval_framework.mock_wandb import MockArtifact, MockWandb, MockWandbApi, MockWandbRun
@@ -60,20 +58,29 @@ class MockLLM(BaseLLM):
         ]
 
 
-model_dict = {
-    "Pythia410m": Pythia410m,
-    "SmolLM135M": SmolLM135M,
-    "Smollm135MInstruct": Smollm135MInstruct,
-    "Qwen3_0_6B_VLLM": Qwen3_0_6B_VLLM,
-    "MockLLM": MockLLM,
-}
+# Stand-ins for ``import_models`` / dotted ``llm_name`` in ``test_run`` (no torch).
+# ``test_llms`` lazy-imports real HF classes when a parametrized test runs.
+SmolLM135M = type("SmolLM135M", (MockLLM,), {})
+Smollm135MInstruct = type("Smollm135MInstruct", (MockLLM,), {})
+
+# Supported ``test_llms`` parametrization values (HF/vLLM imported lazily in the fixture).
+model_list: list[str] = ["Pythia410m", "SmolLM135M", "Smollm135MInstruct", "Qwen3_0_6B_VLLM", "MockLLM"]
 
 
 @pytest.fixture()
 def test_llms(request: FixtureRequest) -> BaseLLM:
-    if request.param not in model_dict:
-        raise ValueError(f"Unknown LLM name: {request.param}")
-    return model_dict[request.param]()
+    name = request.param
+    if name == "MockLLM":
+        return MockLLM()
+    elif name == "Qwen3_0_6B_VLLM":
+        from eval_framework.llm.vllm import Qwen3_0_6B_VLLM
+
+        return Qwen3_0_6B_VLLM()
+    elif name in model_list:
+        import eval_framework.llm.huggingface as hf_module
+
+        return getattr(hf_module, name)
+    raise ValueError(f"Unknown LLM name: {name}")
 
 
 @pytest.fixture

--- a/tests/tests_eval_framework/tasks/benchmarks/test_mmlu_de.py
+++ b/tests/tests_eval_framework/tasks/benchmarks/test_mmlu_de.py
@@ -1,11 +1,144 @@
-import pytest
+"""Tests for MMLU_DE formatter hashes and offline prompt construction."""
 
-from template_formatting.formatter import BaseFormatter, ConcatFormatter, Llama3Formatter
-from tests.tests_eval_framework.tasks.benchmarks.utils import get_task_names_for_module, run_formatter_hash_test
+from unittest.mock import patch
+
+import pytest
+from datasets import Dataset, DatasetDict
+
+from eval_framework.tasks.base import Sample
+from eval_framework.tasks.benchmarks.mmlu_de import MMLU_DE
+from template_formatting.formatter import BaseFormatter, ConcatFormatter, Llama3Formatter, Message, Role
+from tests.tests_eval_framework.tasks.benchmarks.utils import run_formatter_hash_test
+
+# ---------------------------------------------------------------------------
+# Formatter hash tests (Hugging Face)
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.formatter_hash
 @pytest.mark.parametrize("formatter_cls", [Llama3Formatter, ConcatFormatter])
-@pytest.mark.parametrize("task_name", get_task_names_for_module("mmlu_de"))
-def test_formatter_hash(task_name: str, formatter_cls: type[BaseFormatter]) -> None:
-    run_formatter_hash_test(task_name, formatter_cls)
+def test_formatter_hash(formatter_cls: type[BaseFormatter]) -> None:
+    run_formatter_hash_test("MMLU_DE", formatter_cls)
+
+
+# ---------------------------------------------------------------------------
+# Offline prompt tests (patched HF load; production task API otherwise)
+# ---------------------------------------------------------------------------
+
+_SUBJECT = "abstract_algebra"
+
+# Dummy offline rows (obvious test content, fictional data).
+_EVAL_ROW = {
+    "answer": 1,
+    "question_de": (
+        "Aussage 1 | Papageien können keine Farben sehen und leben nur in Schwarz-Weiß. "
+        "Aussage 2 | Graupapageien sind berühmt dafür, dass sie niemals Menschenstimmen nachahmen."
+    ),
+    "choices_de": ["Wahr, Wahr", "Falsch, Falsch", "Wahr, Falsch", "Falsch, Wahr"],
+}
+
+_FEWSHOT_ROW = {
+    "answer": 2,
+    "question_de": (
+        "Aussage 1 | Tiger sind die größte lebende Katzenart und haben ein Streifenmuster wie ein Fingerabdruck. "
+        "Aussage 2 | Ein Test-Tiger in diesem Offline-Benchmark springt zuverlässig 50 Meter weit, wenn niemand hinschaut."
+    ),
+    "choices_de": ["Wahr, Wahr", "Falsch, Falsch", "Wahr, Falsch", "Falsch, Wahr"],
+}
+
+
+def _fictional_dataset(task: MMLU_DE) -> DatasetDict:
+    return DatasetDict(
+        {
+            task.SAMPLE_SPLIT: Dataset.from_list([_EVAL_ROW]),
+            task.FEWSHOT_SPLIT: Dataset.from_list([_FEWSHOT_ROW]),
+        }
+    )
+
+
+def _first_sample(*, num_fewshot: int) -> Sample:
+    """Same entry points as production: ``with_overwrite`` + ``iterate_samples``."""
+    task = MMLU_DE.with_overwrite(
+        num_fewshot=num_fewshot,
+        custom_subjects=[_SUBJECT],
+        custom_hf_revision=None,
+    )
+    with patch.object(task, "_load_hf_dataset", return_value=_fictional_dataset(task)):
+        return next(iter(task.iterate_samples(1)))
+
+
+class TestMMLU_DEWithHardcodedData:
+    """Offline prompt, ground-truth, and completion formatting for MMLU_DE."""
+
+    def test_0shot_prompt(self) -> None:
+        sample = _first_sample(num_fewshot=0)
+
+        assert sample.messages == _EXPECTED_0SHOT_EVAL_MESSAGES
+        assert sample.ground_truth == " B"
+        assert sample.possible_completions == [" A", " B", " C", " D"]
+
+    def test_1shot_prompt(self) -> None:
+        sample = _first_sample(num_fewshot=1)
+
+        assert sample.messages == _EXPECTED_1SHOT_MESSAGES
+        assert sample.ground_truth == " B"
+        assert sample.possible_completions == [" A", " B", " C", " D"]
+
+
+INTRO_PROMPT = """Die folgenden sind Multiple Choice Fragen (mit Antworten) über Abstrakte Algebra.
+
+"""
+
+EVAL_QUESTION_PROMPT = (
+    "Frage: Aussage 1 | Papageien können keine Farben sehen und leben nur in Schwarz-Weiß. "
+    "Aussage 2 | Graupapageien sind berühmt dafür, dass sie niemals Menschenstimmen nachahmen.\n"
+    "A. Wahr, Wahr\n"
+    "B. Falsch, Falsch\n"
+    "C. Wahr, Falsch\n"
+    "D. Falsch, Wahr\n"
+)
+
+FEWSHOT_QUESTION_PROMPT = (
+    "Frage: Aussage 1 | Tiger sind die größte lebende Katzenart und haben ein Streifenmuster wie ein Fingerabdruck. "
+    "Aussage 2 | Ein Test-Tiger in diesem Offline-Benchmark springt zuverlässig 50 Meter weit, wenn niemand hinschaut.\n"
+    "A. Wahr, Wahr\n"
+    "B. Falsch, Falsch\n"
+    "C. Wahr, Falsch\n"
+    "D. Falsch, Wahr\n"
+)
+
+ANSWER_CUE = "Antwort:"
+FEWSHOT_ANSWER = "Antwort: C"
+
+_EXPECTED_0SHOT_EVAL_MESSAGES = [
+    Message(role=Role.USER, content=INTRO_PROMPT + EVAL_QUESTION_PROMPT),
+    Message(role=Role.ASSISTANT, content=ANSWER_CUE),
+]
+
+_EXPECTED_1SHOT_MESSAGES = [
+    Message(role=Role.USER, content=INTRO_PROMPT + FEWSHOT_QUESTION_PROMPT),
+    Message(role=Role.ASSISTANT, content=FEWSHOT_ANSWER),
+    Message(role=Role.USER, content=EVAL_QUESTION_PROMPT),
+    Message(role=Role.ASSISTANT, content=ANSWER_CUE),
+]
+
+EXPECTED_FULL_CONCAT_OUTPUT = """Die folgenden sind Multiple Choice Fragen (mit Antworten) über Abstrakte Algebra.
+
+Frage: Aussage 1 | Tiger sind die größte lebende Katzenart und haben ein Streifenmuster wie ein Fingerabdruck. Aussage 2 | Ein Test-Tiger in diesem Offline-Benchmark springt zuverlässig 50 Meter weit, wenn niemand hinschaut.
+A. Wahr, Wahr
+B. Falsch, Falsch
+C. Wahr, Falsch
+D. Falsch, Wahr
+Antwort: C
+
+Frage: Aussage 1 | Papageien können keine Farben sehen und leben nur in Schwarz-Weiß. Aussage 2 | Graupapageien sind berühmt dafür, dass sie niemals Menschenstimmen nachahmen.
+A. Wahr, Wahr
+B. Falsch, Falsch
+C. Wahr, Falsch
+D. Falsch, Wahr
+Antwort:"""
+
+
+concat_formater = ConcatFormatter()
+concat_formatted = concat_formater.format(_EXPECTED_1SHOT_MESSAGES, output_mode="string")
+assert concat_formatted == EXPECTED_FULL_CONCAT_OUTPUT

--- a/tests/tests_eval_framework/test_run.py
+++ b/tests/tests_eval_framework/test_run.py
@@ -7,17 +7,17 @@ from unittest.mock import Mock, patch
 
 from eval_framework.context.local import _load_model as _load_model_orig
 from eval_framework.run import run
-from tests.tests_eval_framework.conftest import MockLLM
+from tests.tests_eval_framework import conftest as test_conftest
+
+_CLI_MOCK_LLM_NAMES = frozenset({"SmolLM135M", "Smollm135MInstruct"})
 
 
 def _load_model_mock(llm_name: str, models_path, *, info: str = ""):
-    """Return MockLLM for SmolLM135M/Smollm135MInstruct to avoid downloading real models.
-    Use a subclass with the same __name__ as the requested class so output paths match
-    the test assertions (which use llm_name, i.e. the class name)."""
-    clazz = _load_model_orig(llm_name, models_path, info=info)
-    if clazz.__name__ in ("SmolLM135M", "Smollm135MInstruct"):
-        return type(clazz.__name__, (MockLLM,), {})
-    return clazz
+    """Use conftest stand-ins for Smol names so ``test_run`` never imports torch/HF."""
+    class_name = llm_name.rsplit(".", 1)[-1]
+    if class_name in _CLI_MOCK_LLM_NAMES:
+        return getattr(test_conftest, class_name)
+    return _load_model_orig(llm_name, models_path, info=info)
 
 
 @patch("argparse.ArgumentParser.parse_args")


### PR DESCRIPTION
In order to have explicit prompt tests that do not require downloading data points from huggingface, we add fictional data points to the benchmark task tests for MMLU_DE. These are fictional data points, but strictly adhere to the desired format.
It is checked that these fictional data points are being correctly transformed into the desired prompts. 


## PR Checklist

- [x] Use descriptive commit messages.
- [x] Provide tests for your changes.
- [ ] Update any related documentation and include any relevant screenshots.
- [ ] Check if changes need to be made to docs (README or any guides in `/docs/`).

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the hardware and config this has been tested on, as well as any relevant
additional information._

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
