### PR TITLE
refactor: extract shared prompt test utilities

### DIFF
--- a/tests/tests_eval_framework/tasks/benchmarks/test_mmlu_de.py
+++ b/tests/tests_eval_framework/tasks/benchmarks/test_mmlu_de.py
@@ -1,14 +1,15 @@
 """Tests for MMLU_DE formatter hashes and offline prompt construction."""
 
-from unittest.mock import patch
-
 import pytest
-from datasets import Dataset, DatasetDict
 
-from eval_framework.tasks.base import Sample
 from eval_framework.tasks.benchmarks.mmlu_de import MMLU_DE
 from template_formatting.formatter import BaseFormatter, ConcatFormatter, Llama3Formatter, Message, Role
-from tests.tests_eval_framework.tasks.benchmarks.utils import get_task_names_for_module, run_formatter_hash_test
+from tests.tests_eval_framework.tasks.benchmarks.utils import (
+    ExpectedPrompt,
+    assert_offline_prompt_formatting,
+    get_task_names_for_module,
+    run_formatter_hash_test,
+)
 
 # ---------------------------------------------------------------------------
 # Formatter hash tests (Hugging Face)
@@ -26,11 +27,11 @@ def test_formatter_hash(task_name: str, formatter_cls: type[BaseFormatter]) -> N
 # Offline prompt tests (patched HF load; production task API otherwise)
 # ---------------------------------------------------------------------------
 
-_SUBJECT = "abstract_algebra"
+_SUBJECT = "abstract_algebra"  # rendered as "Abstrakte Algebra" in the intro line
 
 # Dummy offline rows (obvious test content, fictional data).
-_EVAL_ROW = {
-    "answer": 1,
+_EVAL_ROW: dict[str] = {
+    "answer": 1,  # -> ground truth " B"
     "question_de": (
         "Aussage 1 | Papageien können keine Farben sehen und leben nur in Schwarz-Weiß. "
         "Aussage 2 | Graupapageien sind berühmt dafür, dass sie niemals Menschenstimmen nachahmen."
@@ -38,8 +39,8 @@ _EVAL_ROW = {
     "choices_de": ["Wahr, Wahr", "Falsch, Falsch", "Wahr, Falsch", "Falsch, Wahr"],
 }
 
-_FEWSHOT_ROW = {
-    "answer": 2,
+_FEWSHOT_ROW: dict[str] = {
+    "answer": 2,  # -> few-shot answer "Antwort: C"
     "question_de": (
         "Aussage 1 | Tiger sind die größte lebende Katzenart und haben ein Streifenmuster wie ein Fingerabdruck. "
         "Aussage 2 | Ein Test-Tiger in diesem Offline-Benchmark springt zuverlässig 50 Meter weit, wenn niemand hinschaut."
@@ -47,83 +48,47 @@ _FEWSHOT_ROW = {
     "choices_de": ["Wahr, Wahr", "Falsch, Falsch", "Wahr, Falsch", "Falsch, Wahr"],
 }
 
-
-def _fictional_dataset(task: MMLU_DE) -> DatasetDict:
-    return DatasetDict(
-        {
-            task.SAMPLE_SPLIT: Dataset.from_list([_EVAL_ROW]),
-            task.FEWSHOT_SPLIT: Dataset.from_list([_FEWSHOT_ROW]),
-        }
-    )
-
-
-def _first_sample(*, num_fewshot: int) -> Sample:
-    """Same entry points as production: ``with_overwrite`` + ``iterate_samples``."""
-    task = MMLU_DE.with_overwrite(
-        num_fewshot=num_fewshot,
-        custom_subjects=[_SUBJECT],
-        custom_hf_revision=None,
-    )
-    with patch.object(task, "_load_hf_dataset", return_value=_fictional_dataset(task)):
-        return next(iter(task.iterate_samples(1)))
-
-
-class TestMMLU_DEWithHardcodedData:
-    """Offline prompt, ground-truth, and completion formatting for MMLU_DE."""
-
-    def test_0shot_prompt(self) -> None:
-        sample = _first_sample(num_fewshot=0)
-
-        assert sample.messages == _EXPECTED_0SHOT_EVAL_MESSAGES
-        assert sample.ground_truth == " B"
-        assert sample.possible_completions == [" A", " B", " C", " D"]
-
-    def test_1shot_prompt(self) -> None:
-        sample = _first_sample(num_fewshot=1)
-
-        assert sample.messages == _EXPECTED_1SHOT_MESSAGES
-        assert sample.ground_truth == " B"
-        assert sample.possible_completions == [" A", " B", " C", " D"]
-
-
-INTRO_PROMPT = """Die folgenden sind Multiple Choice Fragen (mit Antworten) über Abstrakte Algebra.
+# Expected prompts (messages, flat concat, ground truth, completions).
+_INTRO = """\
+Die folgenden sind Multiple Choice Fragen (mit Antworten) über Abstrakte Algebra.
 
 """
 
-EVAL_QUESTION_PROMPT = (
-    "Frage: Aussage 1 | Papageien können keine Farben sehen und leben nur in Schwarz-Weiß. "
-    "Aussage 2 | Graupapageien sind berühmt dafür, dass sie niemals Menschenstimmen nachahmen.\n"
-    "A. Wahr, Wahr\n"
-    "B. Falsch, Falsch\n"
-    "C. Wahr, Falsch\n"
-    "D. Falsch, Wahr\n"
-)
+_EVAL_QUESTION = """\
+Frage: Aussage 1 | Papageien können keine Farben sehen und leben nur in Schwarz-Weiß. Aussage 2 | Graupapageien sind berühmt dafür, dass sie niemals Menschenstimmen nachahmen.
+A. Wahr, Wahr
+B. Falsch, Falsch
+C. Wahr, Falsch
+D. Falsch, Wahr
+"""
 
-FEWSHOT_QUESTION_PROMPT = (
-    "Frage: Aussage 1 | Tiger sind die größte lebende Katzenart und haben ein Streifenmuster wie ein Fingerabdruck. "
-    "Aussage 2 | Ein Test-Tiger in diesem Offline-Benchmark springt zuverlässig 50 Meter weit, wenn niemand hinschaut.\n"
-    "A. Wahr, Wahr\n"
-    "B. Falsch, Falsch\n"
-    "C. Wahr, Falsch\n"
-    "D. Falsch, Wahr\n"
-)
+_FEWSHOT_QUESTION = """\
+Frage: Aussage 1 | Tiger sind die größte lebende Katzenart und haben ein Streifenmuster wie ein Fingerabdruck. Aussage 2 | Ein Test-Tiger in diesem Offline-Benchmark springt zuverlässig 50 Meter weit, wenn niemand hinschaut.
+A. Wahr, Wahr
+B. Falsch, Falsch
+C. Wahr, Falsch
+D. Falsch, Wahr
+"""
 
-ANSWER_CUE = "Antwort:"
-FEWSHOT_ANSWER = "Antwort: C"
+_CUE = "Antwort:"
+_FEWSHOT_ANSWER = "Antwort: C"
+_GROUND_TRUTH = " B"
+_COMPLETIONS = [" A", " B", " C", " D"]
 
-_EXPECTED_0SHOT_EVAL_MESSAGES = [
-    Message(role=Role.USER, content=INTRO_PROMPT + EVAL_QUESTION_PROMPT),
-    Message(role=Role.ASSISTANT, content=ANSWER_CUE),
-]
+# _INTRO + _EVAL_QUESTION + _CUE
+_EXPECTED_CONCAT_0SHOT = """\
+Die folgenden sind Multiple Choice Fragen (mit Antworten) über Abstrakte Algebra.
 
-_EXPECTED_1SHOT_MESSAGES = [
-    Message(role=Role.USER, content=INTRO_PROMPT + FEWSHOT_QUESTION_PROMPT),
-    Message(role=Role.ASSISTANT, content=FEWSHOT_ANSWER),
-    Message(role=Role.USER, content=EVAL_QUESTION_PROMPT),
-    Message(role=Role.ASSISTANT, content=ANSWER_CUE),
-]
+Frage: Aussage 1 | Papageien können keine Farben sehen und leben nur in Schwarz-Weiß. Aussage 2 | Graupapageien sind berühmt dafür, dass sie niemals Menschenstimmen nachahmen.
+A. Wahr, Wahr
+B. Falsch, Falsch
+C. Wahr, Falsch
+D. Falsch, Wahr
+Antwort:"""
 
-EXPECTED_FULL_CONCAT_OUTPUT = """Die folgenden sind Multiple Choice Fragen (mit Antworten) über Abstrakte Algebra.
+# _INTRO + _FEWSHOT_QUESTION + _FEWSHOT_ANSWER + _EXAMPLE_SEPARATOR + _EVAL_QUESTION + _CUE
+_EXPECTED_CONCAT_1SHOT = """\
+Die folgenden sind Multiple Choice Fragen (mit Antworten) über Abstrakte Algebra.
 
 Frage: Aussage 1 | Tiger sind die größte lebende Katzenart und haben ein Streifenmuster wie ein Fingerabdruck. Aussage 2 | Ein Test-Tiger in diesem Offline-Benchmark springt zuverlässig 50 Meter weit, wenn niemand hinschaut.
 A. Wahr, Wahr
@@ -139,7 +104,35 @@ C. Wahr, Falsch
 D. Falsch, Wahr
 Antwort:"""
 
+_ZEROSHOT = ExpectedPrompt(
+    messages=[
+        Message(role=Role.USER, content=_INTRO + _EVAL_QUESTION),
+        Message(role=Role.ASSISTANT, content=_CUE),
+    ],
+    concat=_EXPECTED_CONCAT_0SHOT,
+    ground_truth=_GROUND_TRUTH,
+    completions=_COMPLETIONS,
+)
 
-concat_formater = ConcatFormatter()
-concat_formatted = concat_formater.format(_EXPECTED_1SHOT_MESSAGES, output_mode="string")
-assert concat_formatted == EXPECTED_FULL_CONCAT_OUTPUT
+_FEWSHOT = ExpectedPrompt(
+    messages=[
+        Message(role=Role.USER, content=_INTRO + _FEWSHOT_QUESTION),
+        Message(role=Role.ASSISTANT, content=_FEWSHOT_ANSWER),
+        Message(role=Role.USER, content=_EVAL_QUESTION),
+        Message(role=Role.ASSISTANT, content=_CUE),
+    ],
+    concat=_EXPECTED_CONCAT_1SHOT,
+    ground_truth=_GROUND_TRUTH,
+    completions=_COMPLETIONS,
+)
+
+
+def test_mmlu_de_offline_prompt_formatting() -> None:
+    assert_offline_prompt_formatting(
+        MMLU_DE,
+        eval_rows=[_EVAL_ROW],
+        fewshot_rows=[_FEWSHOT_ROW],
+        subjects=[_SUBJECT],
+        zeroshot=_ZEROSHOT,
+        fewshot=_FEWSHOT,
+    )

--- a/tests/tests_eval_framework/tasks/benchmarks/test_mmlu_de.py
+++ b/tests/tests_eval_framework/tasks/benchmarks/test_mmlu_de.py
@@ -6,7 +6,8 @@ from eval_framework.tasks.benchmarks.mmlu_de import MMLU_DE
 from template_formatting.formatter import BaseFormatter, ConcatFormatter, Llama3Formatter, Message, Role
 from tests.tests_eval_framework.tasks.benchmarks.utils import (
     ExpectedPrompt,
-    assert_offline_prompt_formatting,
+    assert_offline_oneshot_prompt,
+    assert_offline_zeroshot_prompt,
     get_task_names_for_module,
     run_formatter_hash_test,
 )
@@ -128,11 +129,16 @@ _FEWSHOT = ExpectedPrompt(
 
 
 def test_mmlu_de_offline_prompt_formatting() -> None:
-    assert_offline_prompt_formatting(
+    assert_offline_zeroshot_prompt(
         MMLU_DE,
-        eval_rows=[_EVAL_ROW],
-        fewshot_rows=[_FEWSHOT_ROW],
+        eval_row=_EVAL_ROW,
         subjects=[_SUBJECT],
-        zeroshot=_ZEROSHOT,
-        fewshot=_FEWSHOT,
+        expected=_ZEROSHOT,
+    )
+    assert_offline_oneshot_prompt(
+        MMLU_DE,
+        eval_row=_EVAL_ROW,
+        fewshot_row=_FEWSHOT_ROW,
+        subjects=[_SUBJECT],
+        expected=_FEWSHOT,
     )

--- a/tests/tests_eval_framework/tasks/benchmarks/utils.py
+++ b/tests/tests_eval_framework/tasks/benchmarks/utils.py
@@ -2,16 +2,20 @@
 
 import random
 import sys
+from dataclasses import dataclass
+from unittest.mock import patch
 
 import pytest
+from datasets import Dataset, DatasetDict
 
+from eval_framework.tasks.base import BaseTask, Sample
 from eval_framework.tasks.registry import (
     _REGISTRY,
     TaskPlaceholder,
     get_task,
     registered_task_names,
 )
-from template_formatting.formatter import BaseFormatter
+from template_formatting.formatter import BaseFormatter, ConcatFormatter, Message
 from tests.tests_eval_framework.utils import assert_hash_string
 
 
@@ -121,3 +125,67 @@ def run_formatter_hash_test(task_name: str, formatter_cls: type[BaseFormatter], 
         suffix_key=formatter_cls.__name__,
         tested_string=formatted_sample_with_completions,
     )
+
+
+# ---------------------------------------------------------------------------
+# Shared util functions for offline prompt tests
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ExpectedPrompt:
+    messages: list[Message]
+    concat: str
+    ground_truth: str | list[str] | None
+    completions: list[str] | None
+
+
+def _get_first_offline_sample(
+    task_cls: type[BaseTask],
+    eval_rows: list[dict],
+    fewshot_rows: list[dict],
+    *,
+    num_fewshot: int,
+    subjects: list[str],
+) -> Sample:
+    """Same entry points as production: ``with_overwrite`` + ``iterate_samples``."""
+    task = task_cls.with_overwrite(num_fewshot=num_fewshot, custom_subjects=subjects, custom_hf_revision=None)
+    if task.FEWSHOT_SPLIT != task.SAMPLE_SPLIT:
+        fictional_dataset = DatasetDict(
+            {
+                task.SAMPLE_SPLIT: Dataset.from_list(eval_rows),
+                task.FEWSHOT_SPLIT: Dataset.from_list(fewshot_rows),
+            }
+        )
+    else:
+        fictional_dataset = DatasetDict(
+            # Use fewshot row first such that after shuffling (with seed 42) the eval row is the first item
+            {task.SAMPLE_SPLIT: Dataset.from_list(fewshot_rows + eval_rows)},
+        )
+    with patch.object(task, "_load_hf_dataset", return_value=fictional_dataset):
+        return next(iter(task.iterate_samples(1)))
+
+
+def assert_offline_prompt_formatting(
+    task_cls: type[BaseTask],
+    eval_rows: list[dict],
+    fewshot_rows: list[dict],
+    *,
+    subjects: list[str],
+    zeroshot: ExpectedPrompt,
+    fewshot: ExpectedPrompt | None = None,  # toggle: skip 1-shot when None
+) -> None:
+    for num_fewshot, expected in [(0, zeroshot), (1, fewshot)]:
+        if expected is None:
+            continue
+        sample = _get_first_offline_sample(
+            task_cls,
+            eval_rows,
+            fewshot_rows,
+            num_fewshot=num_fewshot,
+            subjects=subjects,
+        )
+        assert sample.messages == expected.messages
+        assert ConcatFormatter().format(sample.messages, output_mode="string") == expected.concat
+        assert sample.ground_truth == expected.ground_truth
+        assert sample.possible_completions == expected.completions

--- a/tests/tests_eval_framework/tasks/benchmarks/utils.py
+++ b/tests/tests_eval_framework/tasks/benchmarks/utils.py
@@ -140,52 +140,54 @@ class ExpectedPrompt:
     completions: list[str] | None
 
 
-def _get_first_offline_sample(
-    task_cls: type[BaseTask],
-    eval_rows: list[dict],
-    fewshot_rows: list[dict],
-    *,
-    num_fewshot: int,
-    subjects: list[str],
-) -> Sample:
-    """Same entry points as production: ``with_overwrite`` + ``iterate_samples``."""
-    task = task_cls.with_overwrite(num_fewshot=num_fewshot, custom_subjects=subjects, custom_hf_revision=None)
-    if task.FEWSHOT_SPLIT != task.SAMPLE_SPLIT:
-        fictional_dataset = DatasetDict(
-            {
-                task.SAMPLE_SPLIT: Dataset.from_list(eval_rows),
-                task.FEWSHOT_SPLIT: Dataset.from_list(fewshot_rows),
-            }
-        )
-    else:
-        fictional_dataset = DatasetDict(
-            # Use fewshot row first such that after shuffling (with seed 42) the eval row is the first item
-            {task.SAMPLE_SPLIT: Dataset.from_list(fewshot_rows + eval_rows)},
-        )
+def _iterate_samples_over_mock_dataset(task: BaseTask, fictional_dataset: DatasetDict) -> Sample:
+    """Same entry points as production: ``iterate_samples`` over a patched HF load."""
     with patch.object(task, "_load_hf_dataset", return_value=fictional_dataset):
         return next(iter(task.iterate_samples(1)))
 
 
-def assert_offline_prompt_formatting(
+def _assert_sample_matches(sample: Sample, expected: ExpectedPrompt) -> None:
+    assert sample.messages == expected.messages
+    assert ConcatFormatter().format(sample.messages, output_mode="string") == expected.concat
+    assert sample.ground_truth == expected.ground_truth
+    assert sample.possible_completions == expected.completions
+
+
+def assert_offline_zeroshot_prompt(
     task_cls: type[BaseTask],
-    eval_rows: list[dict],
-    fewshot_rows: list[dict],
+    eval_row: dict,
     *,
     subjects: list[str],
-    zeroshot: ExpectedPrompt,
-    fewshot: ExpectedPrompt | None = None,  # toggle: skip 1-shot when None
+    expected: ExpectedPrompt,
 ) -> None:
-    for num_fewshot, expected in [(0, zeroshot), (1, fewshot)]:
-        if expected is None:
-            continue
-        sample = _get_first_offline_sample(
-            task_cls,
-            eval_rows,
-            fewshot_rows,
-            num_fewshot=num_fewshot,
-            subjects=subjects,
+    """Assert the 0-shot prompt. Only ``eval_row`` is needed with ``num_fewshot=0`` so a dataset
+    with just the sample split suffices."""
+    task = task_cls.with_overwrite(num_fewshot=0, custom_subjects=subjects, custom_hf_revision=None)
+    mock_dataset = DatasetDict({task.SAMPLE_SPLIT: Dataset.from_list([eval_row])})
+    _assert_sample_matches(_iterate_samples_over_mock_dataset(task, mock_dataset), expected)
+
+
+def assert_offline_oneshot_prompt(
+    task_cls: type[BaseTask],
+    eval_row: dict,
+    fewshot_row: dict,
+    *,
+    subjects: list[str],
+    expected: ExpectedPrompt,
+) -> None:
+    """Assert the 1-shot prompt. The dataset layout depends on whether the task draws
+    fewshot examples from a separate split (``FEWSHOT_SPLIT != SAMPLE_SPLIT``) or the same one."""
+    task = task_cls.with_overwrite(num_fewshot=1, custom_subjects=subjects, custom_hf_revision=None)
+    if task.FEWSHOT_SPLIT != task.SAMPLE_SPLIT:
+        mock_dataset = DatasetDict(
+            {
+                task.SAMPLE_SPLIT: Dataset.from_list([eval_row]),
+                task.FEWSHOT_SPLIT: Dataset.from_list([fewshot_row]),
+            }
         )
-        assert sample.messages == expected.messages
-        assert ConcatFormatter().format(sample.messages, output_mode="string") == expected.concat
-        assert sample.ground_truth == expected.ground_truth
-        assert sample.possible_completions == expected.completions
+    else:
+        mock_dataset = DatasetDict(
+            # Use fewshot row first such that after shuffling (with seed 42) the eval row is the first item
+            {task.SAMPLE_SPLIT: Dataset.from_list([fewshot_row, eval_row])},
+        )
+    _assert_sample_matches(_iterate_samples_over_mock_dataset(task, mock_dataset), expected)


### PR DESCRIPTION
This PR extracts the shared prompt test utilities (e.g. checking for quality between prompt, message, etc.).
Will be useful as we extend the prompt tests to more evals.

## PR Checklist

- [x] Use descriptive commit messages.
- [x] Provide tests for your changes.
- [x] Update any related documentation and include any relevant screenshots.
- [x] Check if changes need to be made to docs (README or any guides in `/docs/`).

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update