### PR TITLE
feat: add MCCompletionStyle task styler

### DIFF
--- a/src/eval_framework/tasks/task_style.py
+++ b/src/eval_framework/tasks/task_style.py
@@ -63,6 +63,7 @@ import random
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Self
 
+from eval_framework.metrics.completion.accuracy_completion import AccuracyCompletion
 from eval_framework.metrics.loglikelihood.accuracy_loglikelihood import (
     AccuracyLoglikelihood,
     AccuracyNormLoglikelihood,
@@ -115,8 +116,8 @@ class TaskStyler(ABC):
         """Return the ground-truth string for scoring."""
 
     @abstractmethod
-    def get_possible_completions(self, choices: list[str], correct_index: int | None = None) -> list[str]:
-        """Return the list of completion strings to be evaluated.
+    def get_possible_completions(self, choices: list[str], correct_index: int | None = None) -> list[str] | None:
+        """Return completion candidates for scoring, or ``None`` for free generation tasks.
 
         ``correct_index`` is only required by ``BPBStyle``, which scores solely the
         ground-truth completion. ``MCStyle`` and ``ClozeStyle`` score all choices and
@@ -208,6 +209,67 @@ class MCStyle(TaskStyler):
     def get_possible_completions(self, choices: list[str], correct_index: int | None = None) -> list[str]:
         """Note: `correct_index` is ignored for `MCStyle` and only used for `BPBStyle`."""
         return [f" {label}" for label in get_n_letters(len(choices))]
+
+
+class MCCompletionStyle(TaskStyler):
+    """Multiple-choice prompt style with generative completion output.
+
+    Prompt formatting is identical to ``MCStyle`` (choices shown in prompt), but
+    ground truth is the full answer text (for example ``"Paris"`` instead of
+    ``"D"``). Responses are generated via ``ResponseType.COMPLETION`` and scored
+    with ``AccuracyCompletion``.
+
+    This style is useful for instruction-following or CoT prompts where the model
+    is expected to generate an answer text rather than be scored via loglikelihood
+    over fixed label candidates.
+
+    Args:
+        question_prefix:        Prepended to the raw question (default ``"Question: "``).
+        cue_text:               Assistant cue after the prompt (default ``"Answer:"``).
+        space_prefixed_labels:  When ``True``, each option line starts with a space
+                                (``" A. choice"`` — OLMES-style). Default ``False``.
+
+    Assembled prompt example (default settings, 4 choices)::
+
+        "Question: What is the capital of France?\\nA. Munich\\nB. Stuttgart\\nC. Berlin\\nD. Paris\\n"
+
+        Ground truth: "Paris"
+    """
+
+    response_type = ResponseType.COMPLETION
+    metrics: list[type["BaseMetric"]] = [AccuracyCompletion]
+    task_style = TaskStyle.MULTIPLE_CHOICE
+
+    def __init__(
+        self,
+        question_prefix: str = "Question: ",
+        cue_text: str = "Answer:",
+        space_prefixed_labels: bool = False,
+    ) -> None:
+        self.question_prefix = question_prefix
+        self._cue_text = cue_text
+        self.space_prefixed_labels = space_prefixed_labels
+
+    def get_cue_text(self) -> str:
+        return self._cue_text
+
+    def get_instruction_text(self, raw_question: str, choices: list[str]) -> str:
+        return format_mc_prompt(
+            self.get_question_text(raw_question),
+            choices,
+            space_prefixed_labels=self.space_prefixed_labels,
+        )
+
+    def get_ground_truth(self, choices: list[str], correct_index: int) -> str:
+        return choices[correct_index]
+
+    def get_fewshot_target_text(self, choices: list[str], correct_index: int) -> str:
+        """Override to insert a space between cue and answer text."""
+        return f"{self.get_cue_text()} {self.get_ground_truth(choices, correct_index)}"
+
+    def get_possible_completions(self, choices: list[str], correct_index: int | None = None) -> list[str] | None:
+        """Completion-mode tasks do not provide fixed candidate completions."""
+        return None
 
 
 class ClozeStyle(TaskStyler):

--- a/src/eval_framework/tasks/task_style.py
+++ b/src/eval_framework/tasks/task_style.py
@@ -231,7 +231,7 @@ class MCCompletionStyle(TaskStyler):
 
     Assembled prompt example (default settings, 4 choices)::
 
-        "Question: What is the capital of France?\\nA. Munich\\nB. Stuttgart\\nC. Berlin\\nD. Paris\\n"
+        "Question: What is the capital of France?\\nA. Munich\\nB. Stuttgart\\nC. Berlin\\nD. Paris\\nAnswer:"
 
         Ground truth: "Paris"
     """

--- a/tests/tests_eval_framework/tasks/test_task_style.py
+++ b/tests/tests_eval_framework/tasks/test_task_style.py
@@ -10,6 +10,7 @@ from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseTy
 from eval_framework.tasks.task_style import (
     BPBStyle,
     ClozeStyle,
+    MCCompletionStyle,
     MCStyle,
     answer_key_to_index,
     format_mc_prompt,
@@ -228,6 +229,39 @@ class TestClozeStyle:
 
 
 # ---------------------------------------------------------------------------
+# MCCompletionStyle tests
+# ---------------------------------------------------------------------------
+
+
+class TestMCCompletionStyle:
+    def setup_method(self) -> None:
+        self.styler = MCCompletionStyle()
+
+    def test_get_instruction_text(self) -> None:
+        text = self.styler.get_instruction_text(_TEST_QUESTION, _TEST_CHOICES)
+        assert text == "Question: Capital of France?\nA. Berlin\nB. Paris\nC. London\n"
+
+    def test_get_ground_truth(self) -> None:
+        assert self.styler.get_ground_truth(_TEST_CHOICES, _TEST_CORRECT_INDEX) == "Paris"
+
+    def test_get_fewshot_target_text(self) -> None:
+        assert self.styler.get_fewshot_target_text(_TEST_CHOICES, _TEST_CORRECT_INDEX) == "Answer: Paris"
+
+    def test_get_possible_completions_none(self) -> None:
+        assert self.styler.get_possible_completions(_TEST_CHOICES) is None
+
+    def test_get_cue_text(self) -> None:
+        assert self.styler.get_cue_text() == "Answer:"
+
+    def test_response_type(self) -> None:
+        assert self.styler.response_type == ResponseType.COMPLETION
+
+    def test_extra_metadata(self) -> None:
+        meta = self.styler.get_extra_metadata()
+        assert meta["task_style"] == TaskStyle.MULTIPLE_CHOICE.value
+
+
+# ---------------------------------------------------------------------------
 # BaseTask task styler integration tests
 # ---------------------------------------------------------------------------
 
@@ -265,6 +299,28 @@ class _ConcreteClozeTask(BaseTask[str]):
     PERTURBATION_UNMODIFIABLE_WORDS = ["Question"]
     LANGUAGE = Language.ENG
     TASK_STYLER = ClozeStyle()
+
+    def _get_raw_question(self, item: dict) -> str:
+        return item["question"]
+
+    def _get_choices(self, item: dict) -> list[str]:
+        return item["choices"]
+
+    def _get_correct_index(self, item: dict) -> int:
+        return item["answer"]
+
+
+class _ConcreteMCCompletionTask(BaseTask[str]):
+    """Minimal concrete task for testing BaseTask with MCCompletionStyle."""
+
+    NAME = "TestMCCompletionTask"
+    DATASET_PATH = "test/dataset"
+    SAMPLE_SPLIT = "test"
+    FEWSHOT_SPLIT = "train"
+    SUBJECTS = [NO_SUBJECT]
+    PERTURBATION_UNMODIFIABLE_WORDS = ["Question"]
+    LANGUAGE = Language.ENG
+    TASK_STYLER = MCCompletionStyle()
 
     def _get_raw_question(self, item: dict) -> str:
         return item["question"]
@@ -344,6 +400,34 @@ class TestBaseTaskClozeStyle:
     def test_metadata_includes_task_style(self) -> None:
         meta = self.task.get_metadata()
         assert meta["task_style"] == TaskStyle.CLOZE.value
+
+
+class TestBaseTaskMCCompletionStyle:
+    def setup_method(self) -> None:
+        self.task = _ConcreteMCCompletionTask()
+
+    def test_instruction_text(self) -> None:
+        text = self.task._get_instruction_text(_TEST_ITEM)
+        assert text == "Question: Capital of France?\nA. Berlin\nB. Paris\nC. London\n"
+
+    def test_ground_truth(self) -> None:
+        assert self.task._get_ground_truth(_TEST_ITEM) == "Paris"
+
+    def test_fewshot_target(self) -> None:
+        assert self.task._get_fewshot_target_text(_TEST_ITEM) == "Answer: Paris"
+
+    def test_possible_completions_none(self) -> None:
+        assert self.task._get_possible_completions(_TEST_ITEM) is None
+
+    def test_cue_text(self) -> None:
+        assert self.task._get_cue_text(_TEST_ITEM) == "Answer:"
+
+    def test_metadata_response_type_completion(self) -> None:
+        meta = self.task.get_metadata()
+        assert meta["response_type"] == ResponseType.COMPLETION.value
+
+    def test_response_type_from_styler(self) -> None:
+        assert self.task.TASK_STYLER.response_type == ResponseType.COMPLETION
 
 
 class TestBaseTaskStylerVariants:


### PR DESCRIPTION
Add a new task styler that uses MC-style prompt formatting (labeled choices A/B/C/D shown in prompt) but with ResponseType.COMPLETION and AccuracyCompletion metric. Ground truth is the full answer text (e.g. "Paris") rather than the letter label.

- MCCompletionStyle extends TaskStyler directly
- get_ground_truth returns the choice text without leading space
- get_fewshot_target_text overrides base to insert space after cue
- get_possible_completions returns None (free generation)
- TaskStyler.get_possible_completions abstract return type widened to list[str] | None
- Add unit tests for styler and BaseTask integration

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## PR Checklist

- [x] Use descriptive commit messages.
- [x] Provide tests for your changes.
- [ ] Update any related documentation and include any relevant screenshots.
- [x] Check if changes need to be made to docs (README or any guides in `/docs/`).

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the hardware and config this has been tested on, as well as any relevant
additional information._

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
