### PR TITLE
ci: drive release-please with public version-bump bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ env:
   REPO_OWNER: research/public-registry
   IMAGE_NAME: eval_framework
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -71,6 +74,26 @@ jobs:
           skip-existing: true
           print-hash: true
 
+  deploy-gitlab:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    needs: ["build"]
+
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v8
+        with:
+          name: 'pypi-dist'
+          path: './dist'
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "~=0.9.16"
+
+      - name: Publish to GitLab Package Registry
+        run: uv publish dist/*
+
   # Deploy to our pypi test instance
   deploy-pypi-test:
     if: github.event_name == 'workflow_dispatch'
@@ -103,7 +126,7 @@ jobs:
     if: github.event_name == 'release'
     runs-on: cpu-runner-8c-32gb-01
     container: docker:dind
-    needs: ["deploy-pypi"]
+    needs: ["deploy-pypi", "deploy-gitlab"]
     permissions:
       contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,7 @@ jobs:
           path: './dist'
           if-no-files-found: 'error'
 
-  # Deploy to our pypi main instance
-  deploy-pypi:
+  publish-pypi:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     needs: ["build"]
@@ -74,28 +73,7 @@ jobs:
           skip-existing: true
           print-hash: true
 
-  deploy-gitlab:
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    needs: ["build"]
-
-    steps:
-      - name: Download dist
-        uses: actions/download-artifact@v8
-        with:
-          name: 'pypi-dist'
-          path: './dist'
-
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v8.2.0
-        with:
-          version: "~=0.9.16"
-
-      - name: Publish to GitLab Package Registry
-        run: uv publish dist/*
-
-  # Deploy to our pypi test instance
-  deploy-pypi-test:
+  publish-testpypi:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: ["build"]
@@ -112,7 +90,7 @@ jobs:
           name: 'pypi-dist'
           path: './dist'
 
-      - name: Publish to PyPI
+      - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
@@ -121,12 +99,11 @@ jobs:
           skip-existing: false
           print-hash: true
 
-  # Deploy Docker images with version tags
-  deploy-docker:
+  publish-docker-image:
     if: github.event_name == 'release'
     runs-on: cpu-runner-8c-32gb-01
     container: docker:dind
-    needs: ["deploy-pypi", "deploy-gitlab"]
+    needs: ["build"]
     permissions:
       contents: read
 

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -1,7 +1,6 @@
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: '0 3 * * *'
   workflow_dispatch:
 
 env:
@@ -26,11 +25,22 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
+      - name: Create GitHub token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: gh-token
+        with:
+          app-id: ${{ vars.AAR_PUBLIC_VERSION_BUMP_BOT_APP_ID }}
+          private-key: ${{ secrets.AAR_PUBLIC_VERSION_BUMP_BOT_PRIVATE_KEY }}
+          repositories: eval-framework
       - id: release
         uses: googleapis/release-please-action@v5
+        with:
+          token: ${{ steps.gh-token.outputs.token }}
       - if: ${{ steps.release.outputs.release_created }}
         name: Checkout
         uses: actions/checkout@v7
+        with:
+          token: ${{ steps.gh-token.outputs.token }}
       - if: ${{ steps.release.outputs.release_created }}
         name: Install uv
         uses: astral-sh/setup-uv@v8.2.0

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -1,17 +1,10 @@
 on:
-  schedule:
-    - cron: '0 3 * * *'
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
-env:
-  REGISTRY: registry.gitlab.aleph-alpha.de
-  REPO_OWNER: research/public-registry
-  IMAGE_NAME: eval_framework
-
 permissions:
-  # This permission is mandatory for Trusted Publishing
-  # https://docs.pypi.org/trusted-publishers/using-a-publisher/
-  id-token: write
   contents: write
   issues: write
   pull-requests: write
@@ -21,9 +14,6 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - name: Create GitHub token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -32,66 +22,7 @@ jobs:
           app-id: ${{ vars.AAR_PUBLIC_VERSION_BUMP_BOT_APP_ID }}
           private-key: ${{ secrets.AAR_PUBLIC_VERSION_BUMP_BOT_PRIVATE_KEY }}
           repositories: eval-framework
-      - id: release
+      - name: Run release-please
         uses: googleapis/release-please-action@v5
         with:
           token: ${{ steps.gh-token.outputs.token }}
-      - if: ${{ steps.release.outputs.release_created }}
-        name: Checkout
-        uses: actions/checkout@v7
-        with:
-          token: ${{ steps.gh-token.outputs.token }}
-      - if: ${{ steps.release.outputs.release_created }}
-        name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
-      - if: ${{ steps.release.outputs.release_created }}
-        name: Publish to GitLab Package Registry
-        run: |
-          uv build
-          uv publish
-
-  # Deploy Docker images with version tags
-  deploy-docker:
-    runs-on: cpu-runner-8c-32gb-01
-    container: docker:dind
-    permissions:
-      contents: read
-    needs: release-please   # <--- this is crucial
-
-    steps:
-      - if: ${{ needs.release-please.outputs.release_created }}
-        name: Checkout Repository
-        uses: actions/checkout@v7
-
-      - if: ${{ needs.release-please.outputs.release_created }}
-        name: Extract version from tag
-        id: version
-        run: |
-          VERSION=${{ needs.release-please.outputs.tag_name }}
-          MAJOR_MINOR=$(echo $VERSION | cut -d. -f1-2)
-
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "major_minor=$MAJOR_MINOR" >> $GITHUB_OUTPUT
-
-      - if: ${{ needs.release-please.outputs.release_created }}
-        name: Registry Authentication
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: token
-          password: ${{ secrets.GL_PUBLIC_REGISTRY_READ_WRITE_TOKEN }}
-
-      - if: ${{ needs.release-please.outputs.release_created }}
-        name: Setup Docker BuildX
-        uses: docker/setup-buildx-action@v4
-
-      - if: ${{ needs.release-please.outputs.release_created }}
-        name: Build and Push Image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major_minor }}
-            ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ We use [release-please](https://github.com/googleapis/release-please) to automat
 
 1. Wait for the release-please PR to reflect your changes (CI runs automatically when the PR is opened or updated)
 2. Approve and merge the PR to `main`
-3. [release.yml](https://github.com/Aleph-Alpha-Research/eval-framework/blob/main/.github/workflows/release.yml) publishes to PyPI, GitLab, and the Docker registry
+3. [release.yml](https://github.com/Aleph-Alpha-Research/eval-framework/blob/main/.github/workflows/release.yml) publishes to PyPI and the Docker registry
 
 Behind the scenes, merging also runs [release-please.yml](https://github.com/Aleph-Alpha-Research/eval-framework/blob/main/.github/workflows/release_please.yml) once more to create the GitHub release and tag; that event is what triggers `release.yml`. You do not need to run or trigger anything yourself beyond the merge.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,11 +108,15 @@ aim for backwards-compatible changes within minor version changes and compatibil
 ### Automated Release
 
 We use [release-please](https://github.com/googleapis/release-please) to automate our package releases.
-Automatically, release-please will create a PR that logs changes committed after the last release and updates it for each merge. To release, the contributor must merge the release-please PR to main. This will take care of running [release-please.yml](https://github.com/Aleph-Alpha-Research/eval-framework/blob/main/.github/workflows/release_please.yml), pushing to PyPI and GitLab. However, tests will not automatically run on the release-please PR. Please follow these steps to release:
+[release-please.yml](https://github.com/Aleph-Alpha-Research/eval-framework/blob/main/.github/workflows/release_please.yml) runs on every push to `main`. It opens or updates a PR that logs changes committed since the last release. To release:
 
-1. Add a tag to the PR: this will trigger CI tests
-2. Approve the PR
-3. Merge the PR
+1. Wait for the release-please PR to reflect your changes (CI runs automatically when the PR is opened or updated)
+2. Approve and merge the PR to `main`
+3. [release.yml](https://github.com/Aleph-Alpha-Research/eval-framework/blob/main/.github/workflows/release.yml) publishes to PyPI, GitLab, and the Docker registry
+
+Behind the scenes, merging also runs [release-please.yml](https://github.com/Aleph-Alpha-Research/eval-framework/blob/main/.github/workflows/release_please.yml) once more to create the GitHub release and tag; that event is what triggers `release.yml`. You do not need to run or trigger anything yourself beyond the merge.
+
+Release cadence is controlled by when the release PR is merged. To release at most once per day with no manual steps, add a scheduled workflow that auto-merges the release-please PR when CI passes.
 
 ### Manual Release
 


### PR DESCRIPTION
## Summary

- Use the **aar-public-version-bump-bot** App token for `release-please-action`, so release PRs opened by the bot identity (not `GITHUB_TOKEN`) trigger downstream workflows — `tests.yml` runs on the release PR and auto-merge can complete on its own.
- **Deduplicate release automation** by adopting the standard release-please split: `release_please.yml` only manages version PRs and GitHub releases; `release.yml` is the single publish pipeline for PyPI, GitLab, and Docker.
- Move GitLab publishing into `release.yml` and remove all build/publish jobs from `release_please.yml` (including duplicate Docker deploy).
- Update `CONTRIBUTING.md` to describe the merge → GitHub release → `release.yml` flow.

## Why

Release PRs (e.g. #323) currently sit open because the required tests check never appears — workflows triggered by the default token can't trigger other workflows. That has led to humans cutting tags manually (v0.4.0, v0.4.1), which then break `release.yml`'s tag check because `pyproject.toml` wasn't bumped to match.

On top of that, `release_please.yml` and `release.yml` overlapped: both could deploy Docker, and GitLab lived in release-please while PyPI/Docker lived in release — unclear ownership and redundant work on every release.

This PR fixes both problems:

1. **Bot token** — same pattern as eval-framework-companion, `renovate.yaml`, and `third_party_licenses.yml` (`AAR_PUBLIC_VERSION_BUMP_BOT_*`).
2. **Clear split** — merge the release PR → release-please creates the GitHub release/tag → `release.yml` publishes everything once.

## Workflow after this PR

Push to main 
→ release-please opens/updates release PR (CI runs automatically) 
Merge release PR (so far manually, but will be done in the future with auto-merge on a cron-job based schedule)
→ release-please creates GitHub Release 
→ release.yml publishes PyPI + GitLab + Docker Manual GitHub release