### PR TITLE
refactor: EvalFactory provides response_type and metrics

### DIFF
--- a/src/eval_framework/evaluation_generator.py
+++ b/src/eval_framework/evaluation_generator.py
@@ -18,7 +18,7 @@ from eval_framework.result_processors.base import Result, ResultProcessor
 from eval_framework.shared.types import Completion, Loglikelihood
 from eval_framework.tasks.base import ResponseType
 from eval_framework.tasks.eval_config import EvalConfig
-from eval_framework.tasks.registry import get_task
+from eval_framework.tasks.registry import registry
 from eval_framework.utils.constants import RED, RESET
 from eval_framework.utils.tqdm_handler import get_disable_bar_flag, safe_tqdm_write
 
@@ -36,13 +36,9 @@ class EvaluationGenerator:
         self.result_processor = result_processor
         self.save_intermediate_results = config.save_intermediate_results
 
-        task_class = get_task(config.task_name)
-        if hasattr(task_class, "TASK_STYLER"):
-            response_type = task_class.TASK_STYLER.response_type
-            task_metrics = list(task_class.TASK_STYLER.metrics)
-        else:
-            response_type = task_class.RESPONSE_TYPE
-            task_metrics = task_class.METRICS
+        eval_ = registry()[config.task_name]
+        response_type = eval_.response_type()
+        task_metrics = eval_.metrics()
 
         if response_type == ResponseType.COMPLETION:
             self.metrics = task_metrics + [BytesCompletion, SequencePositionsCompletion]
@@ -51,7 +47,7 @@ class EvaluationGenerator:
         else:
             raise NotImplementedError
 
-        self.task_name = task_class.NAME
+        self.task_name = eval_.task_class().NAME
 
     def _run_metric_calculators(self, responses: list[Completion | Loglikelihood]) -> list[Result]:
         results: list[Result] = self.result_processor.load_metrics_results()

--- a/src/eval_framework/tasks/eval_config.py
+++ b/src/eval_framework/tasks/eval_config.py
@@ -10,7 +10,7 @@ from eval_framework.llm.base import BaseLLM
 from eval_framework.metrics.llm.base import BaseLLMJudgeMetric
 from eval_framework.tasks.base import BaseTask
 from eval_framework.tasks.perturbation import PerturbationConfig
-from eval_framework.tasks.registry import get_task, validate_task_name
+from eval_framework.tasks.registry import get_task, registry, validate_task_name
 from eval_framework.utils.constants import ROOT_DIR
 
 # Keys that don't impact actual evaluation results and should be excluded from config dumps for hashing purposes.
@@ -115,8 +115,7 @@ class EvalConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_llm_judge_defined(self) -> "EvalConfig":
-        task = get_task(self.task_name)
-        task_metrics = task(num_fewshot=0).get_metrics()
+        task_metrics = registry()[self.task_name].metrics()
         for metric_class in task_metrics:
             if issubclass(metric_class, BaseLLMJudgeMetric):
                 assert self.llm_judge_class is not None, "The LLM Judge must be defined for this evaluation task."

--- a/src/eval_framework/tasks/registry.py
+++ b/src/eval_framework/tasks/registry.py
@@ -3,11 +3,14 @@ import importlib
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterator, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from eval_framework.tasks.base import BaseTask
+from eval_framework.tasks.base import BaseTask, ResponseType
 from eval_framework.tasks.perturbation import PerturbationConfig, create_perturbation_class
 from eval_framework.utils.packaging import is_extra_installed, validate_package_extras
+
+if TYPE_CHECKING:
+    from eval_framework.metrics.base import BaseMetric
 
 __all__ = [
     "register_task",
@@ -41,6 +44,14 @@ class EvalFactory(ABC):
     @abstractmethod
     def source_module(self) -> str:
         """Module the task class is defined in, resolvable without importing it."""
+
+    @abstractmethod
+    def response_type(self) -> ResponseType:
+        """The eval's response type"""
+
+    @abstractmethod
+    def metrics(self) -> list[type["BaseMetric"]]:
+        """The eval's metrics"""
 
     @abstractmethod
     def create(
@@ -107,6 +118,14 @@ class _Lazy(EvalFactory):
             custom_hf_revision=custom_hf_revision,
         )
 
+    def response_type(self) -> ResponseType:
+        """The eval's response type"""
+        return self.task_class().get_response_type()
+
+    def metrics(self) -> list[type["BaseMetric"]]:
+        """The eval's metrics"""
+        return self.task_class().get_metrics()
+
 
 class _Eager(EvalFactory):
     """Wraps an already-imported task class."""
@@ -140,6 +159,14 @@ class _Eager(EvalFactory):
             custom_hf_revision=custom_hf_revision,
         )
 
+    def response_type(self) -> ResponseType:
+        """The eval's response type"""
+        return self.task_class().get_response_type()
+
+    def metrics(self) -> list[type["BaseMetric"]]:
+        """The eval's metrics"""
+        return self.task_class().get_metrics()
+
 
 class Registry:
     """A registry for tasks with support for lazy loading.
@@ -171,7 +198,6 @@ class Registry:
 
     def __getitem__(self, name: str, /) -> EvalFactory:
         task_key = self._task_key(name)
-        print(f"task_key: {task_key}")
         try:
             _, factory = self._registry[task_key]
         except KeyError:

--- a/src/eval_framework/utils/generate_task_docs.py
+++ b/src/eval_framework/utils/generate_task_docs.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import tqdm
 
-from eval_framework.tasks.registry import get_task, registered_task_names
+from eval_framework.tasks.registry import registered_task_names, registry
 from eval_framework.tasks.task_loader import load_extra_tasks
 from template_formatting.formatter import BaseFormatter, ConcatFormatter, Llama3Formatter
 
@@ -69,7 +69,8 @@ def generate_docs_for_task(
     output_docs_directory: Path, task_name: str, formatters: list[BaseFormatter], add_prompt_examples: bool
 ) -> None:
     """Generate documentation for a specific task."""
-    task_class = get_task(task_name)
+    eval_ = registry()[task_name]
+    task_class = eval_.task_class()
 
     try:
         num_fewshot = 1
@@ -98,16 +99,9 @@ def generate_docs_for_task(
             f.write(f"SAMPLE_SPLIT = {task.SAMPLE_SPLIT}".strip() + "\n")
         if hasattr(task, "FEWSHOT_SPLIT"):
             f.write(f"FEWSHOT_SPLIT = {task.FEWSHOT_SPLIT}".strip() + "\n")
-        if hasattr(task, "TASK_STYLER"):
-            f.write(f"RESPONSE_TYPE = {task.TASK_STYLER.response_type.name}".strip() + "\n")
-            metrics_list = [f"{m.__name__}" for m in task.TASK_STYLER.metrics]
-            f.write(f"METRICS = [{', '.join(metrics_list)}]".strip() + "\n")
-        else:
-            if hasattr(task, "RESPONSE_TYPE"):
-                f.write(f"RESPONSE_TYPE = {task.RESPONSE_TYPE.name}".strip() + "\n")
-            if hasattr(task, "METRICS"):
-                metrics_list = [f"{m.__name__}" for m in task.METRICS]
-                f.write(f"METRICS = [{', '.join(metrics_list)}]".strip() + "\n")
+        f.write(f"RESPONSE_TYPE = {eval_.response_type().name}".strip() + "\n")
+        metrics_list = [f"{m.__name__}" for m in eval_.metrics()]
+        f.write(f"METRICS = [{', '.join(metrics_list)}]".strip() + "\n")
         if hasattr(task, "SUBJECTS"):
             f.write(f"SUBJECTS = {repr(task.SUBJECTS)}".strip() + "\n")
         if hasattr(task, "LANGUAGE"):


### PR DESCRIPTION
- **refactor: Introduce EvalFactory.response_type and metric**
- **refactor: Use factories response_type and metrics in evaluation_generator.py**
- **refactor: Do not construct throwaway task in validate_llm_judge_defined**
- **refactor: Use response_type and metrics from eval factor to generate docs**
