### PR TITLE
fix: add reasoning fixes to Squad_ma and TriviaQA_ma tasks

### DIFF
--- a/src/eval_framework/tasks/benchmarks/squad.py
+++ b/src/eval_framework/tasks/benchmarks/squad.py
@@ -244,6 +244,11 @@ class SQuAD2_MA(SQUAD2):
 
     METRICS = [AccuracyCompletion, F1, F1SquadNormalized]
 
+    def __init__(self, num_fewshot: int = 0) -> None:
+        super().__init__(num_fewshot)
+        self.stop_sequences = []
+        self.max_tokens = None
+
     def _get_system_prompt_text(self, item: dict[str, Any]) -> str | None:
         return (
             "You are a helpful assistant and will answer the user's questions carefully, "

--- a/src/eval_framework/tasks/benchmarks/triviaqa.py
+++ b/src/eval_framework/tasks/benchmarks/triviaqa.py
@@ -52,6 +52,11 @@ class TriviaQA_MA(TRIVIAQA):
     METRICS = [AccuracyCompletion, F1, F1SquadNormalized]
     PERTURBATION_UNMODIFIABLE_WORDS = ["Question", "Answer", "Context", "unanswerable"]
 
+    def __init__(self, num_fewshot: int = 0) -> None:
+        super().__init__(num_fewshot)
+        self.stop_sequences = []
+        self.max_tokens = None
+
     def _get_context_text(self, item: dict[str, Any]) -> str:
         return "\n\n".join(item["entity_pages"]["wiki_context"])
 


### PR DESCRIPTION
Fix a bug that stopped MA models from reasoning on Squad and TriviaQA tasks