### PR TITLE
chore: bump up cuda version to match pytorch defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Unlike scaling, a slim cuda container (without pre-packaged pytorch, etc.) is sufficient and gives us flexibility
 # But note: CUDA version matches the one in scaling and dev-nodes for good compatibility
-FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
+FROM nvidia/cuda:13.0.0-devel-ubuntu22.04
 
 ENV LC_ALL="en_US.UTF-8"
 ENV LANG="en_US.UTF-8"


### PR DESCRIPTION
Pytorch now defaults to Cuda 13 whereas our dockerfile still uses an older version resulting in pushes to main failing. This PR bumps the docker image to use Cuda 13 as well. Tested locally. 