### PR TITLE
ci: auto-merge release-please PRs

### DIFF
--- a/.github/workflows/release_please_auto_merge.yml
+++ b/.github/workflows/release_please_auto_merge.yml
@@ -1,0 +1,63 @@
+# release-please opens/updates a PR on every push to `main` (see
+# `release_please.yml`). Merging that PR is what cuts a public
+# release: `release.yml` then publishes to PyPI and the Docker
+# registry. Landing every release-please update immediately would
+# publish many releases per day, so this workflow runs once per
+# night to enable GitHub auto-merge on any open release-please PR.
+# It then merges as soon as required CI checks pass, capping
+# public releases at at most one per day.
+#
+# After the merge, the rest of the lifecycle is handled by our
+# existing automation. `release.yml` ships the artifacts, and
+# Renovate (the other automated PR author in this repo) keeps
+# dependencies moving via `automerge: true` in `renovate.json`.
+# So both bots have a symmetric path from open → merge without
+# manual intervention; release-please is just batched nightly.
+
+name: Auto-merge release-please PRs
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # daily at 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Create bot token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: bot-token
+        with:
+          app-id: ${{ vars.AAR_PUBLIC_VERSION_BUMP_BOT_APP_ID }}
+          private-key: ${{ secrets.AAR_PUBLIC_VERSION_BUMP_BOT_PRIVATE_KEY }}
+          repositories: eval-framework
+
+      - name: Enable auto-merge on open release-please PRs
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          prs=$(gh pr list \
+            --state open \
+            --label "autorelease: pending" \
+            --json number,headRefName,author \
+            --jq '.[]
+              | select(.author.login == "app/aar-public-version-bump-bot")
+              | select(.headRefName | startswith("release-please--"))
+              | .number')
+          if [ -z "$prs" ]; then
+            echo "No open release-please PRs found."
+            exit 0
+          fi
+          for pr in $prs; do
+            echo "Enabling auto-merge for PR #$pr"
+            gh pr merge --auto --squash "$pr"
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ We use [release-please](https://github.com/googleapis/release-please) to automat
 
 Behind the scenes, merging also runs [release-please.yml](https://github.com/Aleph-Alpha-Research/eval-framework/blob/main/.github/workflows/release_please.yml) once more to create the GitHub release and tag; that event is what triggers `release.yml`. You do not need to run or trigger anything yourself beyond the merge.
 
-Release cadence is controlled by when the release PR is merged. To release at most once per day with no manual steps, add a scheduled workflow that auto-merges the release-please PR when CI passes.
+Release cadence is controlled by when the release PR is merged. [release_please_auto_merge.yml](https://github.com/Aleph-Alpha-Research/eval-framework/blob/main/.github/workflows/release_please_auto_merge.yml) runs daily at 03:00 UTC (and on manual dispatch) and enables GitHub auto-merge on any open release-please PR, so it lands once required CI checks pass. This caps releases at at most one per day with no manual steps, and mirrors the `automerge: true` behavior already configured for Renovate in [`.github/renovate.json`](https://github.com/Aleph-Alpha-Research/eval-framework/blob/main/.github/renovate.json).
 
 ### Manual Release
 


### PR DESCRIPTION
Caps public releases to at most one per day by auto-merging the release-please PR overnight, instead of leaving it open for a manual merge. Same shape as our existing `automerge: true` for Renovate. Also flips the "add auto-merge" TODO in `CONTRIBUTING.md` to a description of what got added.