### PR TITLE
refactor: each leaf task has an associated revision lockfile

### DIFF
--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -95,6 +95,12 @@ class BaseTask[SubjectType](ABC):
     SUBJECTS: list[SubjectType]
     HF_REVISION: str | None = None  # tag name, or branch name, or commit hash to ensure reproducibility
 
+    # The lock file this task resolves its pinned dataset revision from, keyed by ``DATASET_PATH``.
+    # Each task sets this explicitly: point it at a lock file (e.g. ``HF_REVISIONS_LOCKFILE`` or a
+    # frozen one), or ``None`` to opt out of pinning. Deliberately not defaulted so it is never
+    # inherited implicitly (a subclass in another package would otherwise resolve the wrong file).
+    REVISION_LOCKFILE: Path | None
+
     # Words in _get_instruction_text() not to be perturbed. List of words is case insensitive. No special characters
     # or whitespace should be included.
     PERTURBATION_UNMODIFIABLE_WORDS: list[str] | None

--- a/src/eval_framework/tasks/benchmarks/arc.py
+++ b/src/eval_framework/tasks/benchmarks/arc.py
@@ -9,11 +9,14 @@ from eval_framework.metrics.loglikelihood.confidence_weighted_accuracy import Co
 from eval_framework.metrics.loglikelihood.dcs import DistributionalCorrectnessScore
 from eval_framework.metrics.loglikelihood.ternary import TernaryScore
 from eval_framework.tasks.base import BaseTask, Language, ResponseType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 
 class ARC(BaseTask[str]):
     """ARC dataset: https://huggingface.co/datasets/allenai/ai2_arc"""
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "ARC"
     DATASET_PATH = "allenai/ai2_arc"
@@ -55,6 +58,8 @@ class ARC_OLMES(ARC):
     loglikelihood over " A"/" B"/ etc.
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "ARC_OLMES"
 
     def _get_instruction_text(self, item: dict[str, Any]) -> str:
@@ -76,6 +81,7 @@ class ARC_OLMES(ARC):
 
 
 class ARC_IDK(ARC):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "ARC_IDK"
     METRICS = [
         AccuracyLoglikelihood,

--- a/src/eval_framework/tasks/benchmarks/arc_de.py
+++ b/src/eval_framework/tasks/benchmarks/arc_de.py
@@ -6,11 +6,14 @@ from eval_framework.metrics.loglikelihood.accuracy_loglikelihood import (
 )
 from eval_framework.metrics.loglikelihood.bits_per_byte import BitsPerByteLoglikelihood
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 
 class ARC_DE(BaseTask[str]):
     """ARC-DE dataset: https://huggingface.co/datasets/LeoLM/ArcChallenge_de"""
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "ARC German"
     DATASET_PATH = "LeoLM/ArcChallenge_de"

--- a/src/eval_framework/tasks/benchmarks/bigcodebench.py
+++ b/src/eval_framework/tasks/benchmarks/bigcodebench.py
@@ -16,6 +16,7 @@ from eval_framework.tasks.base import (
     Sample,
     SubjectType,
 )
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import (
     BIG_CODE_BENCH_PACKAGE_MAPPING,
     CallableSerializer,
@@ -122,6 +123,8 @@ class BigCodeBench_OLMES(BigCodeBench):
     Recommended run settings for parity with oe_eval: temperature=0.6, top_p=0.6, repeats=5 (n=5),
     then compute pass@1 over the 5 samples per problem (post-process if needed).
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "BigCodeBench_OLMES"
     SAMPLE_SPLIT = "v0.1.2"

--- a/src/eval_framework/tasks/benchmarks/copa.py
+++ b/src/eval_framework/tasks/benchmarks/copa.py
@@ -8,6 +8,7 @@ from eval_framework.metrics.loglikelihood.confidence_weighted_accuracy import Co
 from eval_framework.metrics.loglikelihood.dcs import DistributionalCorrectnessScore
 from eval_framework.metrics.loglikelihood.ternary import TernaryScore
 from eval_framework.tasks.base import BaseTask, Language, ResponseType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 
@@ -50,6 +51,8 @@ class COPA_OLMES(COPAEvalHarness):
     COPA multiple choice (OLMES/oe_eval style): prompt shows premise + connector and options with
     space-prefixed labels (" A.", " B."); loglikelihood over " A"/" B".
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "COPA_OLMES"
 

--- a/src/eval_framework/tasks/benchmarks/csqa.py
+++ b/src/eval_framework/tasks/benchmarks/csqa.py
@@ -6,6 +6,7 @@ from eval_framework.metrics.loglikelihood.accuracy_loglikelihood import (
 )
 from eval_framework.metrics.loglikelihood.bits_per_byte import BitsPerByteLoglikelihood
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 
@@ -85,6 +86,8 @@ class CommonsenseQAMC_OLMES(CommonsenseQAMC):
     """
     CommonsenseQA MC with OLMES-style prompt: space before each label in the prompt (" A.", " B.", ...).
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "CommonsenseQAMC_OLMES"
     SAMPLE_SPLIT = "train"  # Use train split (largest) to best match OLMES, which evaluates all splits

--- a/src/eval_framework/tasks/benchmarks/drop.py
+++ b/src/eval_framework/tasks/benchmarks/drop.py
@@ -10,6 +10,7 @@ from eval_framework.metrics.loglikelihood.accuracy_loglikelihood import (
 )
 from eval_framework.metrics.loglikelihood.bits_per_byte import BitsPerByteLoglikelihood
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 
@@ -139,6 +140,8 @@ class DropCompletion(BaseTask[str]):
 class DropCompletion_OLMES(DropCompletion):
     """DropCompletion matching OLMES, using train split for fewshot and max tokens 100."""
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "DropCompletion_OLMES"
     FEWSHOT_SPLIT = "train"
 
@@ -209,6 +212,8 @@ class DropMC_OLMES(DropMC):
     """
     DropMC with OLMES-style prompt: space before each label in the prompt (" A.", " B.", ...).
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "DropMC_OLMES"
 

--- a/src/eval_framework/tasks/benchmarks/global_mmlu.py
+++ b/src/eval_framework/tasks/benchmarks/global_mmlu.py
@@ -9,6 +9,7 @@ from eval_framework.metrics.loglikelihood.accuracy_loglikelihood import (
 from eval_framework.metrics.loglikelihood.bits_per_byte import BitsPerByteLoglikelihood
 from eval_framework.tasks.base import RANDOM_SEED, BaseTask, Language, ResponseType
 from eval_framework.tasks.benchmarks.mmlu import MMLU_SUBJECTS
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 GLOBAL_MMLU_LANGUAGES = ["fr", "de", "es", "it", "pt", "ar"]
@@ -469,6 +470,8 @@ class GlobalMMLU(BaseTask[tuple[str, str]]):
     https://github.com/aisingapore/SEA-HELM/blob/main/seahelm_tasks/knowledge/global_mmlu/abstract_algebra/config.yaml
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "GlobalMMLU"
     DATASET_PATH = "CohereLabs/Global-MMLU"
     SAMPLE_SPLIT = "test"
@@ -534,6 +537,7 @@ class GlobalMMLU(BaseTask[tuple[str, str]]):
 
 
 class GlobalMMLU_German(GlobalMMLU):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "GlobalMMLU_German"
     SUBJECTS = [("de", subject) for subject in MMLU_SUBJECTS]
     LANGUAGE = Language.DEU

--- a/src/eval_framework/tasks/benchmarks/goldenswag.py
+++ b/src/eval_framework/tasks/benchmarks/goldenswag.py
@@ -8,11 +8,14 @@ from eval_framework.metrics.loglikelihood.confidence_weighted_accuracy import Co
 from eval_framework.metrics.loglikelihood.dcs import DistributionalCorrectnessScore
 from eval_framework.metrics.loglikelihood.ternary import TernaryScore
 from eval_framework.tasks.benchmarks.hellaswag import HELLASWAG
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 
 
 class GOLDENSWAG(HELLASWAG):
     """GoldenSwag dataset: https://huggingface.co/datasets/PleIAs/GoldenSwag
     available data set sections: validation"""
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "GoldenSwag"
     DATASET_PATH = "PleIAs/GoldenSwag"
@@ -21,6 +24,7 @@ class GOLDENSWAG(HELLASWAG):
 
 
 class GOLDENSWAG_IDK(GOLDENSWAG):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "GoldenSwag_IDK"
     METRICS = [
         AccuracyLoglikelihood,

--- a/src/eval_framework/tasks/benchmarks/gpqa.py
+++ b/src/eval_framework/tasks/benchmarks/gpqa.py
@@ -13,6 +13,7 @@ from eval_framework.metrics.loglikelihood.confidence_weighted_accuracy import Co
 from eval_framework.metrics.loglikelihood.dcs import DistributionalCorrectnessScore
 from eval_framework.metrics.loglikelihood.ternary import TernaryScore
 from eval_framework.tasks.base import NO_SUBJECT, RANDOM_SEED, BaseTask, Language, ResponseType, Sample, SubjectType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 logger = logging.getLogger(__name__)
@@ -125,6 +126,8 @@ class GPQA_OLMES(GPQA):
     GPQA multiple choice (OLMES/oe_eval style): prompt shows options with space-prefixed labels
     (" A.", " B.", " C.", " D."); loglikelihood over " A"/" B"/" C"/" D".
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "GPQA_OLMES"
 

--- a/src/eval_framework/tasks/benchmarks/gsm8k.py
+++ b/src/eval_framework/tasks/benchmarks/gsm8k.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from eval_framework.metrics.completion.accuracy_completion import AccuracyCompletion, AccuracyCompletionOLMES
 from eval_framework.tasks.base import BaseTask, Language, ResponseType, Sample
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.task_style import BPBStyle
 
 logger = logging.getLogger(__name__)
@@ -155,6 +156,7 @@ class GSM8K(GSM8KEvalHarness):
 
 
 class GSM8K_OLMES(GSM8K):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "GSM8K_OLMES"
     METRICS = [AccuracyCompletionOLMES]
 
@@ -219,6 +221,7 @@ class GSM8K_OLMES(GSM8K):
 
 
 class GSM8KBPB(GSM8K_OLMES):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "GSM8KBPB"
     TASK_STYLER = BPBStyle(cue_text="Answer:", leading_space_continuations=False)
 

--- a/src/eval_framework/tasks/benchmarks/hellaswag.py
+++ b/src/eval_framework/tasks/benchmarks/hellaswag.py
@@ -10,11 +10,14 @@ from eval_framework.metrics.loglikelihood.confidence_weighted_accuracy import Co
 from eval_framework.metrics.loglikelihood.dcs import DistributionalCorrectnessScore
 from eval_framework.metrics.loglikelihood.ternary import TernaryScore
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 
 
 class HELLASWAG(BaseTask[str]):
     """Hellaswag dataset: https://huggingface.co/datasets/Rowan/hellaswag
     available data set sections: train, validation, test"""
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "HellaSwag"
     DATASET_PATH = "Rowan/hellaswag"
@@ -49,6 +52,7 @@ class HELLASWAG(BaseTask[str]):
 
 
 class HELLASWAG_OLMES(HELLASWAG):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "HellaSwag_OLMES"
     SAMPLE_SPLIT = "train"
 

--- a/src/eval_framework/tasks/benchmarks/humaneval.py
+++ b/src/eval_framework/tasks/benchmarks/humaneval.py
@@ -4,6 +4,7 @@ from eval_framework.metrics.completion.code_assertion import CodeCompletionAsser
 from eval_framework.metrics.loglikelihood.bits_per_byte import BitsPerByteLoglikelihood
 from eval_framework.shared.types import BaseMetricContext
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType, Sample
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 
 CODE_TO_EXECUTE = """
 {start_of_code}
@@ -84,6 +85,8 @@ class HumanEvalBPB(HumanEval):
     Reports bits-per-byte on the reference completion.
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "Human Eval BPB"
     RESPONSE_TYPE = ResponseType.LOGLIKELIHOODS
     METRICS = [BitsPerByteLoglikelihood]
@@ -106,6 +109,8 @@ class HumanEval_OLMES(HumanEval):
         repeats: 32
         llm_args: {sampling_params: {temperature: 0.6, top_p: 0.6}}
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "Human Eval OLMES"
 

--- a/src/eval_framework/tasks/benchmarks/ifeval.py
+++ b/src/eval_framework/tasks/benchmarks/ifeval.py
@@ -3,10 +3,13 @@ from typing import Any
 from eval_framework.metrics.completion.ifeval import IFEvalMetric, IFEvalMetricContext
 from eval_framework.metrics.completion.language_checker import LanguageRawConsistencyChecker
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 
 
 class IFEval(BaseTask[str]):
     """IFEval: Instruction Following Eval (https://arxiv.org/pdf/2311.07911)."""
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "IFEval"
     DATASET_PATH = "google/IFEval"
@@ -72,6 +75,8 @@ class IFEvalFiSv(IFEval):
 
 class IFEvalDe(IFEval):
     """German version of the Instruction Following Evaluation (IFEval) benchmark."""
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "IFEval German"
     DATASET_PATH = "jzhang86/de_ifeval"

--- a/src/eval_framework/tasks/benchmarks/math_reasoning.py
+++ b/src/eval_framework/tasks/benchmarks/math_reasoning.py
@@ -15,6 +15,7 @@ from eval_framework.metrics.completion.minerva_math_utils import (
     normalized_gold_from_solution,
 )
 from eval_framework.tasks.base import NO_SUBJECT, RANDOM_SEED, BaseTask, Language, ResponseType, Sample, SubjectType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.task_style import BPBStyle
 
 # Hendrycks MATH subject splits (shared by MATH, MATHMinervaEvalHarness, MATHMinervaBPB)
@@ -331,6 +332,8 @@ class AIME2024(MATHReasoning):
     pass@1 evaluation
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "AIME2024"
     DATASET_PATH = "HuggingFaceH4/aime_2024"
     SAMPLE_SPLIT = "train"
@@ -387,6 +390,8 @@ class AIME2025(AIME2024):
     pass@1 evaluation
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "AIME2025"
     DATASET_PATH = "math-ai/aime25"
     SAMPLE_SPLIT = "test"
@@ -405,6 +410,8 @@ class AIME2026(AIME2024):
 
     pass@1 evaluation
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "AIME2026"
     DATASET_PATH = "math-ai/aime26"
@@ -425,6 +432,8 @@ class MATH500(MATHReasoning):
 
     pass@1 evaluation
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MATH500"
     DATASET_PATH = "HuggingFaceH4/MATH-500"
@@ -642,6 +651,8 @@ class GSM8KReasoning(MATHReasoning):
     Zero-shot reasoning version that expects answers in boxed format.
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "GSM8KReasoning"
     DATASET_PATH = "openai/gsm8k"
     SAMPLE_SPLIT = "test"
@@ -742,6 +753,7 @@ _OLMES_FEWSHOTS = [
 
 
 class MATHMinerva_OLMES(MATHMinerva):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "MATHMinerva_OLMES"
     METRICS = [MathMinervaCompletion, MathMinervaCompletionRelaxed]
 
@@ -755,6 +767,7 @@ class MATHMinerva_OLMES(MATHMinerva):
 
 
 class MATHMinervaBPB(MATHMinerva_OLMES):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "MATHMinervaBPB"
     TASK_STYLER = BPBStyle(cue_text="Solution:")
 

--- a/src/eval_framework/tasks/benchmarks/mbpp.py
+++ b/src/eval_framework/tasks/benchmarks/mbpp.py
@@ -9,6 +9,7 @@ from eval_framework.metrics.completion.code_assertion import (
 from eval_framework.metrics.loglikelihood.bits_per_byte import BitsPerByteLoglikelihood
 from eval_framework.shared.types import BaseMetricContext
 from eval_framework.tasks.base import BaseTask, Language, ResponseType, Sample
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +124,8 @@ class MBPPBPB(MBPP):
     MBPP variant that scores loglikelihood of the gold reference code.
     Reports bits-per-byte on the reference solution.
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MBPP BPB"
     RESPONSE_TYPE = ResponseType.LOGLIKELIHOODS
@@ -270,6 +273,8 @@ class MBPP_OLMES(MBPP):
         top_p: 0.6
         repeats: 32
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MBPP_OLMES"
     FEWSHOT_SPLIT = "test"

--- a/src/eval_framework/tasks/benchmarks/medqa.py
+++ b/src/eval_framework/tasks/benchmarks/medqa.py
@@ -10,6 +10,7 @@ from eval_framework.metrics.loglikelihood.accuracy_loglikelihood import (
 )
 from eval_framework.metrics.loglikelihood.bits_per_byte import BitsPerByteLoglikelihood
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 
@@ -78,6 +79,8 @@ class MedQAMC_OLMES(MedQAMC):
     """
     MedQA multiple choice with OLMES-style prompt: space before each label (" A.", " B.", ...).
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MedQAMC_OLMES"
     FEWSHOT_SPLIT = "train"

--- a/src/eval_framework/tasks/benchmarks/mmlu.py
+++ b/src/eval_framework/tasks/benchmarks/mmlu.py
@@ -11,6 +11,7 @@ from eval_framework.metrics.loglikelihood.confidence_weighted_accuracy import Co
 from eval_framework.metrics.loglikelihood.dcs import DistributionalCorrectnessScore
 from eval_framework.metrics.loglikelihood.ternary import TernaryScore
 from eval_framework.tasks.base import BaseTask, Language, ResponseType, Sample
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 MMLU_SUBJECTS = [
@@ -77,6 +78,8 @@ MMLU_SUBJECTS = [
 class MMLU(BaseTask[str]):
     """MMLU dataset: https://huggingface.co/datasets/cais/mmlu"""
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "MMLU"
     DATASET_PATH = "cais/mmlu"
     SAMPLE_SPLIT = "test"
@@ -123,6 +126,8 @@ class MMLU_OLMES(MMLU):
     MMLU with OLMES-style prompt: space before each label in the prompt (" A.", " B.", ...).
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "MMLU_OLMES"
 
     def _get_instruction_text(self, item: dict[str, Any]) -> str:
@@ -156,6 +161,7 @@ Answer with the full text of the correct answer."""
 
 
 class MMLU_IDK(MMLU):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "MMLU_IDK"
     METRICS = [
         AccuracyLoglikelihood,
@@ -182,6 +188,8 @@ class MMLU_COT(MMLU):
     MMLU dataset with instruction to summarize reasoning and conclude with answer.
     Inspired by https://arxiv.org/pdf/2411.15124 (Table 44)
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MMLU_COT"
     RESPONSE_TYPE = ResponseType.COMPLETION

--- a/src/eval_framework/tasks/benchmarks/mmlu_pro.py
+++ b/src/eval_framework/tasks/benchmarks/mmlu_pro.py
@@ -11,6 +11,7 @@ from eval_framework.metrics.loglikelihood.confidence_weighted_accuracy import Co
 from eval_framework.metrics.loglikelihood.dcs import DistributionalCorrectnessScore
 from eval_framework.metrics.loglikelihood.ternary import TernaryScore
 from eval_framework.tasks.base import NO_SUBJECT, RANDOM_SEED, BaseTask, Language, ResponseType, Sample
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 MMLU_PRO_SUBJECTS = [
@@ -33,6 +34,8 @@ MMLU_PRO_SUBJECTS = [
 
 class MMLU_PRO(BaseTask[str]):
     """MMLU_PRO dataset: https://huggingface.co/datasets/TIGER-Lab/MMLU-Pro"""
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MMLU Pro"
     DATASET_PATH = "TIGER-Lab/MMLU-Pro"
@@ -96,6 +99,8 @@ class MMLU_PRO_OLMES(MMLU_PRO):
     MMLU Pro with OLMES-style prompt: space before each label in the prompt (" A.", " B.", ...).
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "MMLU Pro_OLMES"
 
     def _get_instruction_text(self, item: dict[str, Any]) -> str:
@@ -105,6 +110,7 @@ class MMLU_PRO_OLMES(MMLU_PRO):
 
 
 class MMLU_PRO_IDK(MMLU_PRO):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "MMLU Pro_IDK"
     METRICS = [
         AccuracyLoglikelihood,
@@ -127,6 +133,7 @@ class MMLU_PRO_IDK(MMLU_PRO):
 
 
 class MMLU_PRO_COT(MMLU_PRO):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "MMLU_PRO_COT"
     RESPONSE_TYPE = ResponseType.COMPLETION
     METRICS = [AccuracyCompletion]

--- a/src/eval_framework/tasks/benchmarks/multipl_e.py
+++ b/src/eval_framework/tasks/benchmarks/multipl_e.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from eval_framework.metrics.completion.multipl_e_assertion import MultiPLECodeAssertion, MultiPLEMetricContext
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType, Sample
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 
 MULTIPL_E_STOP_TOKENS: dict[str, list[str]] = {
     "cpp": ["\n}", "}\n//"],
@@ -105,6 +106,8 @@ class MultiPLEHumanEvalCpp(_BaseMPLEHumanEval):
     Recommended: 0-shot, temp=0.6, top_p=0.6, repeats=32.
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "MultiPL-E HumanEval C++ OLMES"
     MULTIPL_E_LANGUAGE = "cpp"
 
@@ -115,6 +118,8 @@ class MultiPLEHumanEvalJava(_BaseMPLEHumanEval):
     Corresponds to ``multipl_e_humaneval:java::olmo3:n32:v2`` in oe_eval.
     Recommended: 0-shot, temp=0.6, top_p=0.6, repeats=32.
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MultiPL-E HumanEval Java OLMES"
     MULTIPL_E_LANGUAGE = "java"
@@ -127,6 +132,8 @@ class MultiPLEHumanEvalJs(_BaseMPLEHumanEval):
     Recommended: 0-shot, temp=0.6, top_p=0.6, repeats=32.
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "MultiPL-E HumanEval JS OLMES"
     MULTIPL_E_LANGUAGE = "js"
 
@@ -137,6 +144,8 @@ class MultiPLEHumanEvalPhp(_BaseMPLEHumanEval):
     Corresponds to ``multipl_e_humaneval:php::olmo3:n32:v2`` in oe_eval.
     Recommended: 0-shot, temp=0.6, top_p=0.6, repeats=32.
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MultiPL-E HumanEval PHP OLMES"
     MULTIPL_E_LANGUAGE = "php"
@@ -149,6 +158,8 @@ class MultiPLEHumanEvalRs(_BaseMPLEHumanEval):
     Recommended: 0-shot, temp=0.6, top_p=0.6, repeats=32.
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "MultiPL-E HumanEval Rust OLMES"
     MULTIPL_E_LANGUAGE = "rs"
 
@@ -159,6 +170,8 @@ class MultiPLEHumanEvalSh(_BaseMPLEHumanEval):
     Corresponds to ``multipl_e_humaneval:sh::olmo3:n32:v2`` in oe_eval.
     Recommended: 0-shot, temp=0.6, top_p=0.6, repeats=32.
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MultiPL-E HumanEval Bash OLMES"
     MULTIPL_E_LANGUAGE = "sh"
@@ -175,6 +188,8 @@ class MultiPLEMBPPCpp(_BaseMPLEMBPP):
     Recommended: 0-shot, temp=0.6, top_p=0.6, repeats=32.
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "MultiPL-E MBPP C++ OLMES"
     MULTIPL_E_LANGUAGE = "cpp"
 
@@ -185,6 +200,8 @@ class MultiPLEMBPPJava(_BaseMPLEMBPP):
     Corresponds to ``multipl_e_mbpp:java::olmo3:n32:v2`` in oe_eval.
     Recommended: 0-shot, temp=0.6, top_p=0.6, repeats=32.
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MultiPL-E MBPP Java OLMES"
     MULTIPL_E_LANGUAGE = "java"
@@ -197,6 +214,8 @@ class MultiPLEMBPPJs(_BaseMPLEMBPP):
     Recommended: 0-shot, temp=0.6, top_p=0.6, repeats=32.
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "MultiPL-E MBPP JS OLMES"
     MULTIPL_E_LANGUAGE = "js"
 
@@ -207,6 +226,8 @@ class MultiPLEMBPPPhp(_BaseMPLEMBPP):
     Corresponds to ``multipl_e_mbpp:php::olmo3:n32:v2`` in oe_eval.
     Recommended: 0-shot, temp=0.6, top_p=0.6, repeats=32.
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MultiPL-E MBPP PHP OLMES"
     MULTIPL_E_LANGUAGE = "php"
@@ -219,6 +240,8 @@ class MultiPLEMBPPRs(_BaseMPLEMBPP):
     Recommended: 0-shot, temp=0.6, top_p=0.6, repeats=32.
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "MultiPL-E MBPP Rust OLMES"
     MULTIPL_E_LANGUAGE = "rs"
 
@@ -229,6 +252,8 @@ class MultiPLEMBPPSh(_BaseMPLEMBPP):
     Corresponds to ``multipl_e_mbpp:sh::olmo3:n32:v2`` in oe_eval.
     Recommended: 0-shot, temp=0.6, top_p=0.6, repeats=32.
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MultiPL-E MBPP Bash OLMES"
     MULTIPL_E_LANGUAGE = "sh"

--- a/src/eval_framework/tasks/benchmarks/naturalqs_open.py
+++ b/src/eval_framework/tasks/benchmarks/naturalqs_open.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from eval_framework.metrics.completion.drop_completion import DropF1ExactMatch, DropMetricContext
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.task_style import (
     BPBStyle,
     ClozeStyle,
@@ -11,6 +12,7 @@ from eval_framework.tasks.task_style import (
 
 
 class NaturalQsOpen(BaseTask[str]):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "NaturalQsOpen"
     DATASET_PATH = "google-research-datasets/nq_open"
     SAMPLE_SPLIT = "validation"
@@ -91,6 +93,8 @@ class NaturalQsOpenMC(_NaturalQsOpenChoice_Base):
 
 class NaturalQsOpenMC_OLMES(_NaturalQsOpenChoice_Base):
     """NaturalQsOpenMC with OLMES-style prompt: space before each label in the prompt (" A.", " B.", ...)."""
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "NaturalQsOpenMC_OLMES"
     TASK_STYLER = MCStyle(space_prefixed_labels=True)

--- a/src/eval_framework/tasks/benchmarks/piqa.py
+++ b/src/eval_framework/tasks/benchmarks/piqa.py
@@ -9,11 +9,14 @@ from eval_framework.metrics.loglikelihood.confidence_weighted_accuracy import Co
 from eval_framework.metrics.loglikelihood.dcs import DistributionalCorrectnessScore
 from eval_framework.metrics.loglikelihood.ternary import TernaryScore
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 
 class PIQA(BaseTask[str]):
     """PIQA dataset: https://huggingface.co/datasets/ybisk/piqa"""
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "PIQA"
     DATASET_PATH = "ybisk/piqa"
@@ -51,6 +54,8 @@ class PIQA_OLMES(PIQA):
     loglikelihood over " A"/" B".
     """
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "PIQA_OLMES"
     SAMPLE_SPLIT = "train"  # Use train split (largest) to best match OLMES, which evaluates all splits
     FEWSHOT_SPLIT = "train"
@@ -74,6 +79,7 @@ class PIQA_OLMES(PIQA):
 
 
 class PIQA_IDK(PIQA):
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "PIQA_IDK"
     METRICS = [
         AccuracyLoglikelihood,

--- a/src/eval_framework/tasks/benchmarks/sciq.py
+++ b/src/eval_framework/tasks/benchmarks/sciq.py
@@ -11,6 +11,7 @@ from eval_framework.metrics.loglikelihood.confidence_weighted_accuracy import Co
 from eval_framework.metrics.loglikelihood.dcs import DistributionalCorrectnessScore
 from eval_framework.metrics.loglikelihood.ternary import TernaryScore
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 
@@ -68,6 +69,8 @@ class SCIQ_OLMES(SCIQ):
     SciQ with OLMES-style prompt: options shown with space-prefixed labels (" A.", " B.", " C.", " D.");
     loglikelihood over " A"/" B"/" C"/" D". Answer choices are deterministically shuffled per example.
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "SciQ_OLMES"
     SAMPLE_SPLIT = "train"  # Use train split (largest) to best match OLMES, which evaluates all splits

--- a/src/eval_framework/tasks/benchmarks/social_iqa.py
+++ b/src/eval_framework/tasks/benchmarks/social_iqa.py
@@ -19,6 +19,7 @@ from eval_framework.metrics.loglikelihood.accuracy_loglikelihood import (
 )
 from eval_framework.metrics.loglikelihood.bits_per_byte import BitsPerByteLoglikelihood
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 
 SOCIAL_I_QA_DATASET_PATH = "allenai/social_i_qa"
@@ -196,6 +197,8 @@ class SocialIQAMC_OLMES(SocialIQACloze):
     Social IQA multiple choice (OLMES/oe_eval style): loglikelihood over " A"/" B"/" C".
     Uses space-prefixed labels in prompt (" A.", " B.", " C.") for tokenization parity with oe_eval.
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "SocialIQAMC_OLMES"
     SAMPLE_SPLIT = "train"  # Use train split (largest) to best match OLMES, which evaluates all splits

--- a/src/eval_framework/tasks/benchmarks/squad.py
+++ b/src/eval_framework/tasks/benchmarks/squad.py
@@ -12,6 +12,7 @@ from eval_framework.metrics.completion.accuracy_completion import AccuracyComple
 from eval_framework.metrics.completion.f1 import F1, F1SquadNormalized
 from eval_framework.metrics.loglikelihood.bits_per_byte import BitsPerByteLoglikelihood
 from eval_framework.tasks.base import NO_SUBJECT, RANDOM_SEED, BaseTask, Language, ResponseType, SubjectType
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 
 
 class SQUAD2(BaseTask[str]):
@@ -239,6 +240,8 @@ class SQUAD(SQUAD2):
 class SQuAD2_MA(SQUAD2):
     """SQuAD v2 with the exact system prompt used in MA training"""
 
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
     NAME = "SQuAD2_MA"
     UNANSWERABLE_STR = "unanswerable"
 
@@ -264,6 +267,8 @@ class SQuAD2_MA(SQUAD2):
 
 class SQuAD_OLMES(SQUAD):
     """SQuAD variant matching OLMES implementation."""
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "SQuAD_OLMES"
     SAMPLE_SPLIT = "validation"

--- a/src/eval_framework/tasks/benchmarks/triviaqa.py
+++ b/src/eval_framework/tasks/benchmarks/triviaqa.py
@@ -4,10 +4,13 @@ from typing import Any
 from eval_framework.metrics.completion.accuracy_completion import AccuracyCompletion
 from eval_framework.metrics.completion.f1 import F1, F1SquadNormalized
 from eval_framework.tasks.base import BaseTask, Language, ResponseType, Sample
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 
 
 class TRIVIAQA(BaseTask[str]):
     """Trivia QA dataset: https://huggingface.co/datasets/mandarjoshi/trivia_qa"""
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "TriviaQA"
     DATASET_PATH = "mandarjoshi/trivia_qa"
@@ -44,6 +47,8 @@ class TRIVIAQA(BaseTask[str]):
 
 class TriviaQA_MA(TRIVIAQA):
     """TriviaQA with the exact system prompt used in MA training"""
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "TriviaQA_MA"
     SUBJECTS = ["rc.wikipedia"]

--- a/src/eval_framework/tasks/benchmarks/winogrande.py
+++ b/src/eval_framework/tasks/benchmarks/winogrande.py
@@ -10,6 +10,7 @@ from eval_framework.metrics.loglikelihood.confidence_weighted_accuracy import Co
 from eval_framework.metrics.loglikelihood.dcs import DistributionalCorrectnessScore
 from eval_framework.metrics.loglikelihood.ternary import TernaryScore
 from eval_framework.tasks.base import BaseTask, Language, ResponseType, Sample
+from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.utils import get_n_letters
 from template_formatting.formatter import Message, Role
 
@@ -118,6 +119,8 @@ class WINOGRANDECloze(WINOGRANDE):
     In this implementation, we fix this by having `_create_samples` create two samples per dataset item,
     and then use a custom metric (`PartialEvalAccuracy`) that pairs them up and compares them.
     """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "WinograndeCloze"
     SAMPLE_SPLIT = "train"  # Use train split (largest) to best match OLMES, which evaluates all splits

--- a/src/eval_framework/tasks/dataset_revisions.py
+++ b/src/eval_framework/tasks/dataset_revisions.py
@@ -23,6 +23,10 @@ logger = logging.getLogger(__name__)
 DEFAULT_REVISIONS_FILE = Path(__file__).resolve().parent / "task-dataset-revisions.json"
 REVISIONS_FILE = DEFAULT_REVISIONS_FILE
 
+# The revision of the datasets used by the benchmarks is declared in a file, so we can automatically
+# update them in CI without having to parse python code.
+HF_REVISIONS_LOCKFILE = Path(__file__).resolve().parent / "hf-dataset-revisions.json"
+
 
 @lru_cache
 def _pinned_revisions(revisions_file: Path) -> dict[str, str]:


### PR DESCRIPTION
## Description

Goal: Starting to isolate the decision what revision to use in each Task, while still enabling reuse of the same lock-file mechanism.

This is a large, mechanical step, associating each leaf task explicitly with its lock-file. Consciously not inheriting this decision.

This should answer some questions about what to do if we do want different revisions of the same dataset, etc.

It also shows the path of how to combine with the companion package. It simply specifies its own lock-file.

How will the task registry, factory, etc. interact with all of this going forward: Not at all.

Next steps: Read path, i.e. using the specified lock-file and doing the same for the companion package.

<!-- Please provide a description of the changes you made. Feel free to add extra sections if needed, e.g. for related issues, testing instructions, review suggestions, etc. Please use conventional commits in both the commit messages and the PR title. -->
