### PR TITLE
refactor: pinning job now updates hf-dataset-revisions.json

### DIFF
--- a/.github/workflows/weekly_dataset_revisions.yml
+++ b/.github/workflows/weekly_dataset_revisions.yml
@@ -33,12 +33,7 @@ jobs:
       - name: Update pinned dataset revisions
         env:
           HF_TOKEN: ${{ secrets.HUGGINGFACE_API_KEY }}
-        run: |
-          uv run python -c "
-          import eval_framework.tasks  # registers all benchmark tasks
-          from eval_framework.tasks.dataset_revisions import main
-          main()
-          "
+        run: uv run python -m eval_framework.tasks.dataset_revisions
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8
@@ -51,7 +46,7 @@ jobs:
             ## Summary
 
             Automated weekly update of pinned Hugging Face dataset commit SHAs in
-            `task-dataset-revisions.json`.
+            `hf-dataset-revisions.json`.
 
             ## Review
 

--- a/src/eval_framework/tasks/dataset_revisions.py
+++ b/src/eval_framework/tasks/dataset_revisions.py
@@ -1,6 +1,7 @@
-"""Fetch latest Hugging Face dataset commit SHAs for registered tasks.
+"""Refresh the pinned Hugging Face dataset revisions in ``hf-dataset-revisions.json``.
 
-Overwrites ``task-dataset-revisions.json`` in this package with task class name → SHA.
+The lock file's keys (dataset paths) define which datasets are pinned; refreshing updates
+each pin to the latest commit SHA.
 
 Usage::
 
@@ -93,17 +94,51 @@ def dataset_revision_collection(
     return revisions
 
 
-def main() -> None:
-    from eval_framework.tasks.registry import registered_eval_factories
+class HfDatasetRevisions:
+    """Pinned revisions of Hugging Face datasets, mapping dataset path → commit SHA."""
 
+    def __init__(self, revisions: dict[str, str]) -> None:
+        self._revisions = dict(revisions)
+
+    @classmethod
+    def from_file(cls, path: Path) -> "HfDatasetRevisions":
+        return cls(json.loads(path.read_text(encoding="utf-8")))
+
+    def to_dict(self) -> dict[str, str]:
+        return dict(self._revisions)
+
+    def to_file(self, path: Path) -> None:
+        path.write_text(
+            json.dumps(dict(sorted(self._revisions.items())), indent=4, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    def num_revisions(self) -> int:
+        return len(self._revisions)
+
+    def update_to_latest(self, api: HfApi) -> None:
+        """Update every pin to its dataset's latest commit SHA.
+
+        Intended to run on CI to ensure the pinned revisions are up-to-date. If the lookup for a
+        dataset fails, its existing pin is kept.
+        """
+        for path, sha in self._revisions.items():
+            try:
+                latest = api.dataset_info(path, timeout=100.0).sha
+            except Exception as exc:
+                logger.warning("Could not refresh %s (%s); keeping pinned revision %s", path, exc, sha)
+                continue
+            if latest and latest != sha:
+                logger.info("%s: %s -> %s", path, sha, latest)
+            self._revisions[path] = latest or sha
+
+
+def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
-    revisions = dataset_revision_collection(registered_eval_factories(), HfApi())
-    REVISIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    REVISIONS_FILE.write_text(
-        json.dumps(dict(sorted(revisions.items())), indent=4, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
-    logger.info("Wrote %d revisions to %s", len(revisions), REVISIONS_FILE)
+    revisions = HfDatasetRevisions.from_file(HF_REVISIONS_LOCKFILE)
+    revisions.update_to_latest(HfApi())
+    revisions.to_file(HF_REVISIONS_LOCKFILE)
+    logger.info("Refreshed %d pinned revisions in %s", revisions.num_revisions(), HF_REVISIONS_LOCKFILE)
 
 
 if __name__ == "__main__":

--- a/tests/tests_eval_framework/tasks/test_dataset_revisions.py
+++ b/tests/tests_eval_framework/tasks/test_dataset_revisions.py
@@ -127,6 +127,49 @@ def test_get_pinned_dataset_revision_returns_none_for_unknown_task(fixture_revis
     assert dr.DatasetRevision.pinned_revision("NotARegisteredTask") is None
 
 
+def test_update_to_latest_updates_sha() -> None:
+    """Each pinned dataset is refreshed to the latest commit SHA."""
+    api = MagicMock()
+    api.dataset_info.return_value = SimpleNamespace(sha="new-sha")
+    revisions = dr.HfDatasetRevisions({"Some/evaltask": "old-sha"})
+
+    revisions.update_to_latest(api)
+
+    assert revisions.to_dict() == {"Some/evaltask": "new-sha"}
+    api.dataset_info.assert_called_once_with("Some/evaltask", timeout=100.0)
+
+
+def test_update_to_latest_keeps_pin_when_lookup_fails() -> None:
+    """A failing lookup must not drop the dataset or change its pin."""
+    api = MagicMock()
+    api.dataset_info.side_effect = RuntimeError("hf outage")
+    revisions = dr.HfDatasetRevisions({"Some/evaltask": "old-sha"})
+
+    revisions.update_to_latest(api)
+
+    assert revisions.to_dict() == {"Some/evaltask": "old-sha"}
+
+
+def test_hf_dataset_revisions_file_round_trip(tmp_path: Path) -> None:
+    """Revisions written with ``to_file`` load back identically with ``from_file``."""
+    lockfile = tmp_path / "hf-dataset-revisions.json"
+    pinned = {"org/b": "sha-b", "org/a": "sha-a"}
+
+    dr.HfDatasetRevisions(pinned).to_file(lockfile)
+    loaded = dr.HfDatasetRevisions.from_file(lockfile)
+
+    assert loaded.to_dict() == pinned
+
+
+def test_hf_dataset_revisions_file_is_sorted_by_dataset_path(tmp_path: Path) -> None:
+    """The lock file is written sorted, so refreshing produces stable diffs."""
+    lockfile = tmp_path / "hf-dataset-revisions.json"
+
+    dr.HfDatasetRevisions({"org/b": "sha-b", "org/a": "sha-a"}).to_file(lockfile)
+
+    assert lockfile.read_text(encoding="utf-8").index('"org/a"') < lockfile.read_text(encoding="utf-8").index('"org/b"')
+
+
 def test_dataset_revision_collection_reuses_sha_for_shared_dataset() -> None:
     """Multiple tasks sharing one DATASET_PATH should trigger a single API call."""
 


### PR DESCRIPTION
It does now only depend on the file and is decoupled from the registry
