### PR TITLE
fix: limit memory used by code exec sandbox

### DIFF
--- a/src/eval_framework/metrics/completion/code_assertion.py
+++ b/src/eval_framework/metrics/completion/code_assertion.py
@@ -15,7 +15,7 @@ class CodeCompletionAssertion(BaseMetric[Completion]):
         # this will always be a list, if return is "" this will be an empty list
         code = response.completion
         try:
-            output = run_python_code(code, image="python:3.12-slim")
+            output = run_python_code(code, image="python:3.12-slim", runtime_configs={"mem_limit": "512m"})
         except SandboxTimeoutError:
             # The submitted code timed out (e.g. an infinite loop) -- a failing sample, not an infra
             # problem.

--- a/src/eval_framework/tasks/utils.py
+++ b/src/eval_framework/tasks/utils.py
@@ -58,6 +58,7 @@ def get_or_create_pool(
     lang: str = "python",
     min_pool_size: int = 1,
     max_pool_size: int = 1,
+    runtime_configs: dict[str, str] | None = None,
 ) -> ContainerPoolManager:
     assert image or dockerfile, "Either image or dockerfile must be provided"
     key = (image or dockerfile, tuple(packages) if packages else None)
@@ -70,6 +71,7 @@ def get_or_create_pool(
                 dockerfile=dockerfile,
                 keep_template=True,
                 libraries=packages,
+                runtime_configs=runtime_configs,
             )
             _pools[key] = pool
         return _pools[key]
@@ -107,6 +109,7 @@ def run_python_code(
     input_files: list[tuple[str, str]] | None = None,
     timeout: int = 60,
     packages: list[str] | None = None,
+    runtime_configs: dict[str, str] | None = None,
 ) -> str:
     """
     Run code in a sandboxed environment.
@@ -122,7 +125,12 @@ def run_python_code(
     # Only one of image or dockerfile should be provided.
     # we fallback to the default python image if no dockerfile is provided.
     resolved_image = image or (DefaultImage.PYTHON if not dockerfile else None)
-    pool = get_or_create_pool(resolved_image, packages=packages, dockerfile=dockerfile)
+    pool = get_or_create_pool(
+        resolved_image,
+        packages=packages,
+        dockerfile=dockerfile,
+        runtime_configs=runtime_configs,
+    )
     with SandboxSession(pool=pool, lang="python") as session:
         for host_file, docker_file in input_files or []:
             session.copy_to_runtime(host_file, docker_file)


### PR DESCRIPTION
Tested with code: 

```python
from llm_sandbox import SandboxSession

from eval_framework.tasks.utils import get_or_create_pool

OOM_EXIT_CODE = 137

code = """
data = []
i = 0
while True:
    data.append(bytearray(100 * 1024 * 1024))  # fresh 100MB block, real allocation
    i += 1
    print(f"Allocated {i * 100}MB", flush=True)
"""


pool = get_or_create_pool(
    image="python:3.12-slim",
    runtime_configs={
        "mem_limit": "512m",
    },
)

with SandboxSession(
    pool=pool,
) as session:
    result = session.run(code)
    print("exit_code:", result.exit_code)
    print("stdout:", result.stdout)
    print("stderr:", result.stderr)
    if result.exit_code == OOM_EXIT_CODE:
        print("✅ Killed gracefully due to memory limit.")


code = """
import random
print(random.randint(0, 100))
print(random.randint(0, 100))
print(random.randint(0, 100))
"""

with SandboxSession(
    pool=pool,
) as session:
    result = session.run(code)
    print("exit_code:", result.exit_code)
    print("stdout:", result.stdout)
    print("stderr:", result.stderr)
    if result.exit_code == OOM_EXIT_CODE:
        print("✅ Killed gracefully due to memory limit.")
```