### PR TITLE
feat: register FullTextMMLU task for use in data ablations

### DIFF
--- a/src/eval_framework/tasks/task_names.py
+++ b/src/eval_framework/tasks/task_names.py
@@ -63,6 +63,7 @@ def register_all_tasks() -> None:
     register_lazy_task("eval_framework.tasks.benchmarks.mmlu.MMLU")
     register_lazy_task("eval_framework.tasks.benchmarks.mmlu.MMLU_IDK")
     register_lazy_task("eval_framework.tasks.benchmarks.mmlu.MMLU_OLMES")
+    register_lazy_task("eval_framework.tasks.benchmarks.mmlu.FullTextMMLU")
     register_lazy_task("eval_framework.tasks.benchmarks.mmlu_pro.MMLU_PRO")
     register_lazy_task("eval_framework.tasks.benchmarks.mmlu_pro.MMLU_PRO_IDK")
     register_lazy_task("eval_framework.tasks.benchmarks.mmlu_pro.MMLU_PRO_OLMES")


### PR DESCRIPTION
Registers the FullTextMMLU task variant, which is reported to show signal for relevant pre-training data ablation scales, e.g.:
1. see Figure 5 of [the DCLM paper](https://arxiv.org/pdf/2406.11794) and accompany text which reads "The key difference between LightEval and LLM Foundry for multiple choice tasks like MMLU is that LightEval considers the log probabilities of entire answer sequences, whereas LLM Foundry only considers log probabilities of single letters"
2. see Figure 1 of [the OLMES paper](https://arxiv.org/pdf/2406.08446), showing early above-chance MMLU performance on the Cloze form variant compared to the multiple-choice format.