### PR TITLE
fix(tests): expect DatasetNotFoundError for invalid hf revision

### DIFF
--- a/tests/tests_eval_framework/test_response_generator.py
+++ b/tests/tests_eval_framework/test_response_generator.py
@@ -4,8 +4,8 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from datasets.exceptions import DatasetNotFoundError
 from dateutil import parser
-from huggingface_hub.errors import RevisionNotFoundError
 
 from eval_framework.llm.base import BaseLLM
 from eval_framework.response_generator import ResponseGenerator, repeat_samples
@@ -338,7 +338,7 @@ def test_hf_revisions(task_name: str, hf_revision: str, raises: bool) -> None:
     )
 
     if raises:
-        with pytest.raises(RevisionNotFoundError):
+        with pytest.raises(DatasetNotFoundError):
             for _ in response_generator.task.iterate_samples(num_samples=config.num_samples):
                 pass
     else:


### PR DESCRIPTION
datasets v5.0.0 unconditionally re-wraps huggingface_hub's RevisionNotFoundError as datasets.exceptions.DatasetNotFoundError when a dataset revision does not exist. test_hf_revisions still asserted the pre-v5 RevisionNotFoundError, so the invalid-revision case failed against the pinned datasets v5. Update the expectation and import to match the exception that actually propagates under datasets>=5.
