### PR TITLE
fix: close sandbox container pools instead of at exit

### DIFF
--- a/src/eval_framework/run.py
+++ b/src/eval_framework/run.py
@@ -13,6 +13,7 @@ except ImportError:
 from eval_framework.context.local import LocalContext
 from eval_framework.main import main
 from eval_framework.tasks.task_loader import load_extra_tasks
+from eval_framework.tasks.utils import close_pools
 from eval_framework.utils.logging import setup_logging
 
 logger = logging.getLogger(__name__)
@@ -392,19 +393,22 @@ def _run_single_task(kwargs: dict) -> None:
 def run_with_kwargs(kwargs: dict) -> None:
     task_suite_path = kwargs.pop("task_suite", None)
 
-    if task_suite_path is not None:
-        from eval_framework.suite import TaskSuite, run_suite
+    try:
+        if task_suite_path is not None:
+            from eval_framework.suite import TaskSuite, run_suite
 
-        output_dir = kwargs.get("output_dir", "outputs")
-        log_level = kwargs.get("verbosity", 1)
-        setup_logging(output_dir, log_level=log_level)
+            output_dir = kwargs.get("output_dir", "outputs")
+            log_level = kwargs.get("verbosity", 1)
+            setup_logging(output_dir, log_level=log_level)
 
-        suite = TaskSuite.load(task_suite_path)
-        logger.info(f"Loaded task suite '{suite.name}' from {task_suite_path}")
-        result = run_suite(suite, kwargs)
-        logger.info(f"Suite '{suite.name}' completed. Aggregates: {result.aggregates}")
-    else:
-        _run_single_task(kwargs)
+            suite = TaskSuite.load(task_suite_path)
+            logger.info(f"Loaded task suite '{suite.name}' from {task_suite_path}")
+            result = run_suite(suite, kwargs)
+            logger.info(f"Suite '{suite.name}' completed. Aggregates: {result.aggregates}")
+        else:
+            _run_single_task(kwargs)
+    finally:
+        close_pools()
 
 
 def run() -> None:

--- a/src/eval_framework/tasks/utils.py
+++ b/src/eval_framework/tasks/utils.py
@@ -78,11 +78,14 @@ def get_or_create_pool(
 
 
 def close_pools() -> None:
-    for pool in _pools.values():
+    with _pools_lock:
+        pools = list(_pools.values())
+        _pools.clear()
+    for pool in pools:
         try:
             pool.close()
         except Exception:
-            pass
+            logger.exception("Error closing sandbox container pool")
 
 
 atexit.register(close_pools)

--- a/tests/tests_eval_framework/conftest.py
+++ b/tests/tests_eval_framework/conftest.py
@@ -10,8 +10,13 @@ from eval_framework.llm.base import BaseLLM, Sample
 from eval_framework.llm.huggingface import Pythia410m, SmolLM135M, Smollm135MInstruct
 from eval_framework.llm.vllm import Qwen3_0_6B_VLLM
 from eval_framework.shared.types import RawCompletion, RawLoglikelihood
+from eval_framework.tasks.utils import close_pools
 from template_formatting.formatter import Message
 from tests.tests_eval_framework.mock_wandb import MockArtifact, MockWandb, MockWandbApi, MockWandbRun
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int | pytest.ExitCode) -> None:
+    close_pools()
 
 
 class MockLLM(BaseLLM):


### PR DESCRIPTION
Call close_pools() in a finally block after a run completes and in pytest's sessionfinish, so pools shut down while the process is still fully alive. Relying on the atexit hook alone means shutdown logging can fire, producing spurious "--- Logging error ---" noise.

Example of logger noise in previous runs: 
```
ValueError: I/O operation on closed file.
Call stack:
  File "/usr/lib/python3.12/threading.py", line 1030, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/__w/eval-framework/eval-framework/.venv/lib/python3.12/site-packages/llm_sandbox/pool/base.py", line 550, in _health_check_loop
    self.logger.info("Health check loop stopped")
Message: 'Health check loop stopped'
```
From the run: https://github.com/Aleph-Alpha-Research/eval-framework/actions/runs/29905318237/job/88875791824?pr=494#step:6:1795

Current test run's absence of noise: https://github.com/Aleph-Alpha-Research/eval-framework/actions/runs/29860066494/job/88735107070?pr=495#step:6:1937

