### PR TITLE
chore: removed logging of tqdm progress bars

### DIFF
--- a/src/eval_framework/evaluation_generator.py
+++ b/src/eval_framework/evaluation_generator.py
@@ -20,7 +20,7 @@ from eval_framework.tasks.base import ResponseType
 from eval_framework.tasks.eval_config import EvalConfig
 from eval_framework.tasks.registry import registry
 from eval_framework.utils.constants import RED, RESET
-from eval_framework.utils.tqdm_handler import get_disable_bar_flag, safe_tqdm_write
+from eval_framework.utils.tqdm_handler import get_disable_bar_flag
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,6 @@ class EvaluationGenerator:
             metric.fail_on_error = self.config.fail_on_error
 
             logger.info(f"Starting calculation of {metric.NAME}")
-            safe_tqdm_write(f"INFO: Calculating {metric.NAME}")
             for response in tqdm(responses, desc=f"Calculating {metric.NAME}", disable=get_disable_bar_flag()):
                 if f"{response.subject}_{response.id}_{metric.__class__.__name__}" in subject_result_id_existing:
                     continue
@@ -117,7 +116,6 @@ class EvaluationGenerator:
                         self.result_processor.save_metrics_result(result)
 
             logger.info(f"Completed calculation of {metric.NAME}")
-            safe_tqdm_write(f"INFO: Completed {metric.NAME}")
 
         if not self.save_intermediate_results:
             self.result_processor.save_metrics_results(results)

--- a/src/eval_framework/response_generator.py
+++ b/src/eval_framework/response_generator.py
@@ -30,7 +30,7 @@ from eval_framework.tasks.base import Language, ResponseType, Sample
 from eval_framework.tasks.eval_config import EvalConfig
 from eval_framework.tasks.utils import raise_errors
 from eval_framework.utils.constants import RED, RESET
-from eval_framework.utils.tqdm_handler import get_disable_bar_flag, safe_tqdm_write
+from eval_framework.utils.tqdm_handler import get_disable_bar_flag
 
 logger = logging.getLogger(__name__)
 
@@ -232,9 +232,7 @@ class ResponseGenerator:
             if not samples_batch:
                 return
             if len(samples_batch) > 1:
-                log_msg = "Processing batch..."
-                logger.info(log_msg)  # For log files
-                safe_tqdm_write(log_msg)  # For console display with tqdm
+                logger.info("Processing batch...")
 
             responses_batch = generative_output_function(samples_batch)
             responses.extend(responses_batch)
@@ -268,17 +266,13 @@ class ResponseGenerator:
                 sample_index = i + 1
 
                 if sample.id in subject_response_id_mapping.get(sample.subject, []):
-                    log_msg = (
+                    logger.info(
                         f"Task: {self.response_type.value}{subject} - Sample: {sample_index} - skipping, already done."
                     )
-                    logger.info(log_msg)  # For log files
-                    safe_tqdm_write(log_msg)  # For console display with tqdm
                     pbar.update(1)
                     continue
 
-                log_msg = f"Task: {self.response_type.value}{subject} - Sample: {sample_index}/{total_num_samples}"
-                logger.info(log_msg)  # For log files
-                safe_tqdm_write(log_msg)  # For console display with tqdm
+                logger.info(f"Task: {self.response_type.value}{subject} - Sample: {sample_index}/{total_num_samples}")
                 pbar.set_postfix_str(f"Sample {sample_index}/{total_num_samples}")
                 pbar.update(1)
 
@@ -289,9 +283,7 @@ class ResponseGenerator:
                     samples_batch = []
 
                 if should_preempt_callable():
-                    log_msg = "Preempt"
-                    logger.info(log_msg)  # For log files
-                    safe_tqdm_write(log_msg)  # For console display with tqdm
+                    logger.info("Preempt")
                     if not self.save_intermediate_results:
                         self.result_processor.save_responses(responses)
                     return responses, True

--- a/src/eval_framework/utils/logging.py
+++ b/src/eval_framework/utils/logging.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from pathlib import Path
 
 VERBOSITY_MAP = {
@@ -16,7 +15,7 @@ def setup_logging(
     Set up centralized logging configuration for the entire framework.
 
     Args:
-        output_dir: Directory to save log files. If None, logs only to console.
+        output_dir: Directory to save log files. If None, no file handler is attached.
         log_level: Logging level (default: INFO)
         log_filename: Name of the log file
 
@@ -26,9 +25,6 @@ def setup_logging(
     # Map verbosity integer to logging level
     mapped_log_level = VERBOSITY_MAP.get(log_level, logging.INFO)
 
-    # Basic configuration
-    logging.basicConfig(level=mapped_log_level)
-
     # Create formatter
     formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
 
@@ -37,13 +33,7 @@ def setup_logging(
     root_logger.handlers.clear()
     root_logger.setLevel(mapped_log_level)
 
-    # Console handler (always present)
-    console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setLevel(mapped_log_level)
-    console_handler.setFormatter(formatter)
-    root_logger.addHandler(console_handler)
-
-    # File handler (if output directory provided)
+    # File handler (if output directory provided). No console handler: keeps stdout free for tqdm.
     if output_dir:
         output_dir.mkdir(parents=True, exist_ok=True)
         log_file = output_dir / log_filename
@@ -54,9 +44,5 @@ def setup_logging(
         root_logger.addHandler(file_handler)
 
         root_logger.info(f"Logging configured. File: {log_file}")
-    else:
-        root_logger.info("Logging configured (console only)")
-
-    root_logger.info(f"Output directory for logs: {output_dir if output_dir else 'None'}")
 
     return root_logger

--- a/src/eval_framework/utils/tqdm_handler.py
+++ b/src/eval_framework/utils/tqdm_handler.py
@@ -1,13 +1,6 @@
 import logging
 
-from tqdm import tqdm
-
 logger = logging.getLogger(__name__)
-
-
-def safe_tqdm_write(msg: str, level: int = logging.INFO) -> None:
-    if logger.isEnabledFor(level):
-        tqdm.write(msg)
 
 
 def get_disable_bar_flag() -> bool:

--- a/tests/tests_eval_framework/utils/test_logger.py
+++ b/tests/tests_eval_framework/utils/test_logger.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 
 from eval_framework.utils.logging import setup_logging
-from eval_framework.utils.tqdm_handler import get_disable_bar_flag, safe_tqdm_write
+from eval_framework.utils.tqdm_handler import get_disable_bar_flag
 from eval_framework.utils.tqdm_handler import logger as tqdm_logger
 
 
@@ -27,9 +27,6 @@ def test_tqdm_logging(tmp_path: Path) -> None:
     """
     # Set up logging
     setup_logging(output_dir=tmp_path, log_level=1)
-
-    # Ensure safe_tqdm_write works without error
-    safe_tqdm_write("This is a test message.", level=logging.INFO)
 
     # Test get_disable_bar_flag
     disable_flag = get_disable_bar_flag()


### PR DESCRIPTION
The current eval generator's progress logs flood the screen with multiple lines of tqdm progress bars. These are rarely informative for any sort of debugging. This PR removes this clutter and sticks to the basic tqdm progress bar. This also retains the file logging intact. 

