### PR TITLE
feat: add mathminerva version without double-new-line stop sequence

### DIFF
--- a/src/eval_framework/tasks/benchmarks/math_reasoning.py
+++ b/src/eval_framework/tasks/benchmarks/math_reasoning.py
@@ -10,10 +10,7 @@ from eval_framework.metrics.completion.math_minerva_completion import (
     MathMinervaCompletionRelaxed,
 )
 from eval_framework.metrics.completion.math_reasoning_completion import MathReasoningCompletion
-from eval_framework.metrics.completion.minerva_math_utils import (
-    extract_answers,
-    normalized_gold_from_solution,
-)
+from eval_framework.metrics.completion.minerva_math_utils import extract_answers, normalized_gold_from_solution
 from eval_framework.tasks.base import NO_SUBJECT, RANDOM_SEED, BaseTask, Language, ResponseType, Sample, SubjectType
 from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.task_style import BPBStyle
@@ -773,6 +770,16 @@ class MATHMinerva_OLMES(MATHMinerva):
 
     def _sample_fewshot_examples(self, item: dict[str, Any]) -> list[dict]:
         return _OLMES_FEWSHOTS[: self.num_fewshot]
+
+
+class MATHMinerva_OLMES_NONL(MATHMinerva_OLMES):
+    NAME = "MATHMinerva_OLMES_NONL"
+
+    def __init__(self, num_fewshot: int = 4) -> None:
+        if num_fewshot != 4:
+            logger.warning("MATHMinerva_OLMES_NONL supports a fixed num_fewshot of 4.")
+        super().__init__(num_fewshot=4)
+        self.stop_sequences = ["Problem:"]
 
 
 class MATHMinervaBPB(MATHMinerva_OLMES):

--- a/src/eval_framework/tasks/task_names.py
+++ b/src/eval_framework/tasks/task_names.py
@@ -36,6 +36,7 @@ def register_all_tasks() -> None:
     register_lazy_task("eval_framework.tasks.benchmarks.ifeval.IFEvalDe")
     register_lazy_task("eval_framework.tasks.benchmarks.math_reasoning.MATH500")
     register_lazy_task("eval_framework.tasks.benchmarks.math_reasoning.MATHMinerva_OLMES")
+    register_lazy_task("eval_framework.tasks.benchmarks.math_reasoning.MATHMinerva_OLMES_NONL")
     register_lazy_task("eval_framework.tasks.benchmarks.multipl_e.MultiPLEHumanEvalCpp")
     register_lazy_task("eval_framework.tasks.benchmarks.multipl_e.MultiPLEHumanEvalJava")
     register_lazy_task("eval_framework.tasks.benchmarks.multipl_e.MultiPLEHumanEvalJs")

--- a/tests/tests_eval_framework/tasks/benchmarks/task-prompts-hashes.json
+++ b/tests/tests_eval_framework/tasks/benchmarks/task-prompts-hashes.json
@@ -108,6 +108,8 @@
     "MATHMinervaEvalHarness.Llama3Formatter": "fe79ac3a345d7a03a532a619047c4dfd",
     "MATHMinerva_OLMES.ConcatFormatter": "d5546aaa75084c9fe0521143eaa51e99",
     "MATHMinerva_OLMES.Llama3Formatter": "0522fd0ac3f9e5c462029112884ce308",
+    "MATHMinerva_OLMES_NONL.ConcatFormatter": "d5546aaa75084c9fe0521143eaa51e99",
+    "MATHMinerva_OLMES_NONL.Llama3Formatter": "0522fd0ac3f9e5c462029112884ce308",
     "MBPP.ConcatFormatter": "47d4cc9ce93b26daab05e7af058ea3e7",
     "MBPP.Llama3Formatter": "259ba4fc8290421f3e0b0c19e220896e",
     "MBPPBPB.ConcatFormatter": "3d8536c15549c6c30d6c7154110456c4",


### PR DESCRIPTION
## Description

Add a `MATHMinerva_OLMES` variant that does not use `\n\n` as a stop sequence.
I kept `MATHMinerva_OLMES` as is for reproducibility. The new version is called `MATHMinerva_OLMES_NONL` to indicates it uses **"No** **N**ew **L**ines as stop sequences.

The hash tests show that the prompt remains identical.