### PR TITLE
refactor: tasks are responsible for rendering their own documentation

### DIFF
--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -3,7 +3,7 @@ import os
 import random
 import traceback
 from abc import ABC
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self, TypeVar
@@ -14,8 +14,9 @@ from pydantic import BaseModel, ConfigDict
 
 from eval_framework.shared.types import BaseMetricContext, Completion, Error, RawCompletion
 from eval_framework.tasks.dataset_revisions import pinned_revision
+from eval_framework.tasks.markdown_doc import markdown_doc as render_markdown_doc
 from eval_framework.tasks.utils import classproperty, raise_errors
-from template_formatting.formatter import Message, Role
+from template_formatting.formatter import BaseFormatter, Message, Role
 
 if TYPE_CHECKING:
     from eval_framework.llm.base import BaseLLM
@@ -279,6 +280,35 @@ class BaseTask[SubjectType](ABC):
                     if index == num_samples:
                         done = True
                         break
+
+    def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
+        """Render this task's documentation as markdown."""
+        dataset_path = getattr(self, "DATASET_PATH", None)
+        example_messages = split_sizes = possible_completions = ground_truth = None
+        if dataset_path is None:
+            sample = next(iter(self.iterate_samples(1)))
+            example_messages = sample.messages
+            split_sizes = {split: len(self.dataset[split]) for split in self.dataset}
+            possible_completions = sample.possible_completions
+            ground_truth = sample.ground_truth
+
+        return render_markdown_doc(
+            name=self.NAME,
+            module=type(self).__module__,
+            dataset_path=dataset_path,
+            sample_split=getattr(self, "SAMPLE_SPLIT", None),
+            fewshot_split=getattr(self, "FEWSHOT_SPLIT", None),
+            response_type=self.get_response_type().name,
+            metrics=[m.__name__ for m in self.get_metrics()],
+            subjects=getattr(self, "SUBJECTS", None),
+            language=getattr(self, "LANGUAGE", None),
+            num_fewshot=self.num_fewshot,
+            formatters=formatters,
+            example_messages=example_messages,
+            split_sizes=split_sizes,
+            possible_completions=possible_completions,
+            ground_truth=ground_truth,
+        )
 
     def _create_samples(self, item: dict[str, Any], index: int, subject: str) -> list[Sample]:
         """Creates one or more samples from a single dataset item. Default implementation returns single sample."""

--- a/src/eval_framework/tasks/markdown_doc.py
+++ b/src/eval_framework/tasks/markdown_doc.py
@@ -1,0 +1,81 @@
+from collections.abc import Sequence
+from io import StringIO
+from typing import Any
+
+from template_formatting.formatter import BaseFormatter, Message
+
+
+def markdown_doc(
+    *,
+    name: str,
+    module: str,
+    dataset_path: str | None,
+    sample_split: str | None,
+    fewshot_split: str | None,
+    response_type: str,
+    metrics: Sequence[str],
+    subjects: Any,
+    language: Any,
+    num_fewshot: int,
+    formatters: Sequence[BaseFormatter],
+    example_messages: list[Message] | None,
+    split_sizes: dict[str, int] | None,
+    possible_completions: str | list[str] | None,
+    ground_truth: str | list[str] | None,
+) -> str:
+    """Render a task's documentation as markdown"""
+    buf = StringIO()
+    buf.write(f"# {name}\n\n")
+    http_path = f"https://huggingface.co/datasets/{dataset_path}" if dataset_path else None
+
+    buf.write("````\n")  # fence with 4 thicks because some prompts have code blocks with 3 thicks
+    buf.write(f"NAME = {name}".strip() + "\n")
+    if dataset_path is not None:
+        buf.write(f"DATASET_PATH = {dataset_path}".strip() + "\n")
+    if sample_split is not None:
+        buf.write(f"SAMPLE_SPLIT = {sample_split}".strip() + "\n")
+    if fewshot_split is not None:
+        buf.write(f"FEWSHOT_SPLIT = {fewshot_split}".strip() + "\n")
+    buf.write(f"RESPONSE_TYPE = {response_type}".strip() + "\n")
+    buf.write(f"METRICS = [{', '.join(metrics)}]".strip() + "\n")
+    if subjects is not None:
+        buf.write(f"SUBJECTS = {subjects!r}".strip() + "\n")
+    if language is not None:
+        buf.write(f"LANGUAGE = {language!r}".strip() + "\n")
+    buf.write("````\n\n")
+
+    buf.write(f"- Module: `{module}`\n\n")
+
+    if http_path:
+        buf.write(f"- Link to dataset: [{http_path}]({http_path})\n\n")
+    else:
+        assert example_messages is not None, "a task without a dataset link must supply an example sample"
+        for split, size in (split_sizes or {}).items():
+            buf.write(f"- `{split}` has {size} samples\n\n")
+
+        for formatter in formatters:
+            buf.write(f"## Example prompt with {formatter.__class__.__name__} ({num_fewshot}-shot)\n\n")
+            formatted_sample = formatter.format(example_messages, output_mode="string")
+            buf.write("````\n")
+            buf.write(f'"{formatted_sample}"')
+            buf.write("\n````\n\n")
+
+        buf.write("## Possible completions:\n\n")
+        buf.write("````\n")
+        if possible_completions:
+            for item in possible_completions if isinstance(possible_completions, list) else [possible_completions]:
+                buf.write(f'- "{item}"\n')
+        else:
+            buf.write("None\n")
+        buf.write("````\n\n")
+
+        buf.write("## Ground truth:\n\n")
+        buf.write("````\n")
+        if ground_truth:
+            for item in ground_truth if isinstance(ground_truth, list) else [ground_truth]:
+                buf.write(f'- "{item}"\n')
+        else:
+            buf.write("None\n")
+        buf.write("````\n")
+
+    return buf.getvalue()

--- a/src/eval_framework/utils/generate_task_docs.py
+++ b/src/eval_framework/utils/generate_task_docs.py
@@ -80,12 +80,8 @@ def generate_docs_for_task(
             num_fewshot = 0
             task = task_class(num_fewshot=num_fewshot)
         except (TypeError, ValueError, AssertionError):
-            try:
-                task = task_class()
-                num_fewshot = task.num_fewshot
-            except Exception as e:
-                print(f"Failed to instantiate task {task_name}: {e}")
-                return
+            task = task_class()
+            num_fewshot = task.num_fewshot
 
     with open(f"{output_docs_directory}/{task_name}.md", "w") as f:
         f.write(f"# {task_name}\n\n")

--- a/src/eval_framework/utils/generate_task_docs.py
+++ b/src/eval_framework/utils/generate_task_docs.py
@@ -1,7 +1,5 @@
 import argparse
-import inspect
 import os
-import re
 from pathlib import Path
 
 import tqdm
@@ -65,77 +63,16 @@ def parse_args(cli_args: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(args=cli_args)
 
 
-def generate_docs_for_task(
-    output_docs_directory: Path, task_name: str, formatters: list[BaseFormatter]
-) -> None:
+def generate_docs_for_task(output_docs_directory: Path, task_name: str, formatters: list[BaseFormatter]) -> None:
     """Generate documentation for a specific task."""
-    eval_ = registry()[task_name]
-    task_class = eval_.task_class()
+    task_class = registry()[task_name].task_class()
 
     try:
-        num_fewshot = 1
         task = task_class(num_fewshot=1)
     except (TypeError, ValueError, AssertionError):
         task = task_class(num_fewshot=0)
 
-    with open(f"{output_docs_directory}/{task_name}.md", "w") as f:
-        f.write(f"# {task_name}\n\n")
-        dataset_path = eval_.dataset_path()
-        http_path = f"https://huggingface.co/datasets/{dataset_path}" if dataset_path else None
-
-        f.write("````\n")  # fence with 4 thicks because some prompts have code blocks with 3 thicks
-        f.write(f"NAME = {task_name}".strip() + "\n")
-        if dataset_path is not None:
-            f.write(f"DATASET_PATH = {dataset_path}".strip() + "\n")
-        if hasattr(task, "SAMPLE_SPLIT"):
-            f.write(f"SAMPLE_SPLIT = {task.SAMPLE_SPLIT}".strip() + "\n")
-        if hasattr(task, "FEWSHOT_SPLIT"):
-            f.write(f"FEWSHOT_SPLIT = {task.FEWSHOT_SPLIT}".strip() + "\n")
-        f.write(f"RESPONSE_TYPE = {eval_.response_type().name}".strip() + "\n")
-        metrics_list = [f"{m.__name__}" for m in eval_.metrics()]
-        f.write(f"METRICS = [{', '.join(metrics_list)}]".strip() + "\n")
-        if hasattr(task, "SUBJECTS"):
-            f.write(f"SUBJECTS = {repr(task.SUBJECTS)}".strip() + "\n")
-        if hasattr(task, "LANGUAGE"):
-            f.write(f"LANGUAGE = {repr(task.LANGUAGE)}".strip() + "\n")
-        f.write("````\n\n")
-
-        f.write(f"- Module: `{task_class.__module__}`\n\n")
-
-        if http_path:
-            f.write(f"- Link to dataset: [{http_path}]({http_path})\n\n")
-
-        else:
-            s = next(iter(task.iterate_samples(1)))
-            for split in task.dataset:
-                f.write(f"- `{split}` has {len(task.dataset[split])} samples\n\n")
-
-            for formatter in formatters:
-                f.write(f"## Example prompt with {formatter.__class__.__name__} ({num_fewshot}-shot)\n\n")
-                formatted_sample = formatter.format(s.messages, output_mode="string")
-                f.write("````\n")
-                f.write(f'"{formatted_sample}"')
-                f.write("\n````\n\n")
-
-            f.write("## Possible completions:\n\n")
-            f.write("````\n")
-            if s.possible_completions:
-                for item in (
-                    s.possible_completions if isinstance(s.possible_completions, list) else [s.possible_completions]
-                ):
-                    f.write(f'- "{item}"\n')
-            else:
-                f.write("None\n")
-            f.write("````\n\n")
-
-            f.write("## Ground truth:\n\n")
-            f.write("````\n")
-            if s.ground_truth:
-                for item in s.ground_truth if isinstance(s.ground_truth, list) else [s.ground_truth]:
-                    f.write(f'- "{item}"\n')
-            else:
-                f.write("None\n")
-            f.write("````\n")
+    (output_docs_directory / f"{task_name}.md").write_text(task.markdown_doc(formatters), encoding="utf-8")
 
 
 def generate_readme_list(output_docs_directory: Path, total_tasks: int) -> None:

--- a/src/eval_framework/utils/generate_task_docs.py
+++ b/src/eval_framework/utils/generate_task_docs.py
@@ -27,7 +27,7 @@ def parse_args(cli_args: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         default=False,
         required=False,
-        help="If set, examples prompts for each of the formatters will be added in the generated docs.",
+        help="Unused. Only there for backwards compatibility",
     )
     parser.add_argument(
         "--exclude-tasks",
@@ -66,7 +66,7 @@ def parse_args(cli_args: list[str] | None = None) -> argparse.Namespace:
 
 
 def generate_docs_for_task(
-    output_docs_directory: Path, task_name: str, formatters: list[BaseFormatter], add_prompt_examples: bool
+    output_docs_directory: Path, task_name: str, formatters: list[BaseFormatter]
 ) -> None:
     """Generate documentation for a specific task."""
     eval_ = registry()[task_name]
@@ -104,13 +104,6 @@ def generate_docs_for_task(
 
         if http_path:
             f.write(f"- Link to dataset: [{http_path}]({http_path})\n\n")
-
-        if not add_prompt_examples:
-            f.write(
-                f"More detailed documentation, with prompt examples and ground truth completions, can be generated "
-                f"with `uv run -m eval_framework.utils.generate_task_docs --add-prompt-examples "
-                f'--only-tasks "{task_name}"`.\n'
-            )
 
         else:
             s = next(iter(task.iterate_samples(1)))
@@ -203,7 +196,6 @@ def generate_all_docs(args: argparse.Namespace, output_docs_directory: Path) -> 
                 output_docs_directory=output_docs_directory,
                 task_name=task_name,
                 formatters=formatters,
-                add_prompt_examples=args.add_prompt_examples,
             )
 
         except Exception as e:

--- a/src/eval_framework/utils/generate_task_docs.py
+++ b/src/eval_framework/utils/generate_task_docs.py
@@ -74,10 +74,9 @@ def generate_docs_for_task(
 
     try:
         num_fewshot = 1
-        task = task_class(num_fewshot=num_fewshot)
+        task = task_class(num_fewshot=1)
     except (TypeError, ValueError, AssertionError):
-        num_fewshot = 0
-        task = task_class(num_fewshot=num_fewshot)
+        task = task_class(num_fewshot=0)
 
     with open(f"{output_docs_directory}/{task_name}.md", "w") as f:
         f.write(f"# {task_name}\n\n")
@@ -102,21 +101,6 @@ def generate_docs_for_task(
         f.write("````\n\n")
 
         f.write(f"- Module: `{task_class.__module__}`\n\n")
-
-        try:
-            raw_file_path = inspect.getfile(task_class)
-            # Find the package root 'eval_framework' in the path
-            match = re.search(r"eval_framework.*", raw_file_path)
-            if match:
-                # Reconstruct relative path assuming standard 'src' structure
-                task_file = f"src/{match.group(0)}"
-                # Provide a local relative link (for VS Code) and an absolute link (for GitHub/Web)
-                f.write(f"- File: [{task_file}](../../{task_file}) | [View on GitHub]({REPO_URL}/{task_file})\n\n")
-            else:
-                # Fallback for tasks defined outside the main package (e.g., custom local tasks)
-                f.write(f"- File: `{raw_file_path}`\n\n")
-        except Exception:
-            f.write("- File: `Dynamic or Built-in`\n\n")
 
         if http_path:
             f.write(f"- Link to dataset: [{http_path}]({http_path})\n\n")

--- a/src/eval_framework/utils/generate_task_docs.py
+++ b/src/eval_framework/utils/generate_task_docs.py
@@ -76,12 +76,8 @@ def generate_docs_for_task(
         num_fewshot = 1
         task = task_class(num_fewshot=num_fewshot)
     except (TypeError, ValueError, AssertionError):
-        try:
-            num_fewshot = 0
-            task = task_class(num_fewshot=num_fewshot)
-        except (TypeError, ValueError, AssertionError):
-            task = task_class()
-            num_fewshot = task.num_fewshot
+        num_fewshot = 0
+        task = task_class(num_fewshot=num_fewshot)
 
     with open(f"{output_docs_directory}/{task_name}.md", "w") as f:
         f.write(f"# {task_name}\n\n")

--- a/tests/tests_eval_framework/tasks/test_markdown_doc.py
+++ b/tests/tests_eval_framework/tasks/test_markdown_doc.py
@@ -1,0 +1,70 @@
+from eval_framework.tasks.markdown_doc import markdown_doc
+from template_formatting.formatter import Message, Role
+
+
+class ExampleFormatter:
+    """Test double that renders each message as ``ROLE: content`` so the doc reflects the actual messages."""
+
+    def format(self, messages: list[Message], output_mode: str = "string") -> str:
+        return "\n".join(f"{message.role.name}: {message.content}" for message in messages)
+
+
+def test_markdown_doc_with_examples() -> None:
+    doc = markdown_doc(
+        name="MyTask",
+        module="eval_framework.tasks.benchmarks.mytask",
+        dataset_path=None,
+        sample_split="test",
+        fewshot_split="train",
+        response_type="COMPLETION",
+        metrics=["Accuracy", "F1"],
+        subjects=["no_subject"],
+        language=None,
+        num_fewshot=1,
+        formatters=[ExampleFormatter()],
+        example_messages=[Message(role=Role.USER, content="Q")],
+        split_sizes={"test": 3, "train": 5},
+        possible_completions=["A", "B"],
+        ground_truth="A",
+    )
+
+    assert (
+        doc
+        == """\
+# MyTask
+
+````
+NAME = MyTask
+SAMPLE_SPLIT = test
+FEWSHOT_SPLIT = train
+RESPONSE_TYPE = COMPLETION
+METRICS = [Accuracy, F1]
+SUBJECTS = ['no_subject']
+````
+
+- Module: `eval_framework.tasks.benchmarks.mytask`
+
+- `test` has 3 samples
+
+- `train` has 5 samples
+
+## Example prompt with ExampleFormatter (1-shot)
+
+````
+"USER: Q"
+````
+
+## Possible completions:
+
+````
+- "A"
+- "B"
+````
+
+## Ground truth:
+
+````
+- "A"
+````
+"""
+    )


### PR DESCRIPTION
- **chore: do not swallow errors silently then generating task documenation**
- **chore: remove dead defensive code during task construction for docs**
- **doc: remove file path from task documentation**
- **doc: prompt examples are always generated**
- **refactor: rendering markdown doc is now a responsibility of task base**
