### PR TITLE
ci: change to rebase merge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "automerge": true,
+    "automergeStrategy": "rebase",
     "enabledManagers": [
         "pep621",
         "github-actions",

--- a/.github/workflows/release_please_auto_merge.yml
+++ b/.github/workflows/release_please_auto_merge.yml
@@ -59,5 +59,5 @@ jobs:
           fi
           for pr in $prs; do
             echo "Enabling auto-merge for PR #$pr"
-            gh pr merge --auto --squash "$pr"
+            gh pr merge --auto --rebase "$pr"
           done

--- a/.github/workflows/third_party_licenses.yml
+++ b/.github/workflows/third_party_licenses.yml
@@ -64,4 +64,4 @@ jobs:
         if: steps.pr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ steps.bot-token.outputs.token }}
-        run: gh pr merge --auto --squash "${{ steps.pr.outputs.pull-request-number }}"
+        run: gh pr merge --auto --rebase "${{ steps.pr.outputs.pull-request-number }}"


### PR DESCRIPTION
The repo ruleset now allows only rebase merges, so `gh pr merge --auto --squash` in our automation-authored PRs silently fails and auto-merge never gets enabled. Same for Renovate, which defaults to squash on GitHub. Switching the release-please auto-merger, the third-party-licenses workflow, and Renovate over to rebase.