### PR TITLE
chore: serializing EvalConfig doesn't dump api key and base url

### DIFF
--- a/src/eval_framework/tasks/eval_config.py
+++ b/src/eval_framework/tasks/eval_config.py
@@ -135,6 +135,12 @@ class EvalConfig(BaseConfig):
             return value.__name__
         return None
 
+    @field_serializer("judge_model_args")
+    def serialize_judge_model_args(self, value: dict[str, Any]) -> dict[str, Any]:
+        value.pop("api_key", None)
+        value.pop("base_url", None)
+        return value
+
     def model_json_dump(self) -> str:
         model_dump = self.model_dump(mode="json")
         return json.dumps(model_dump, sort_keys=True)

--- a/tests/tests_eval_framework/test_eval_config_validation.py
+++ b/tests/tests_eval_framework/test_eval_config_validation.py
@@ -292,3 +292,25 @@ class TestEvalConfigJudgeModelArgsValidation:
         # Note: The old approach doesn't convert booleans
         assert config.judge_model_args["use_cache"] == "True"
         assert isinstance(config.judge_model_args["use_cache"], str)
+
+    def test_judge_model_args_serialization(self) -> None:
+        config_data = {
+            "llm_class": OpenAIModel,
+            "llm_judge_class": OpenAIModel,
+            "judge_model_args": {
+                "temperature": "0.7",
+                "max_tokens": "100",
+                "model_name": "gpt-4",
+                "api_key": "sk-1234567890",
+                "base_url": "https://api.openai.com",
+            },
+            "task_name": "MMLU",
+        }
+
+        config = EvalConfig(**config_data)
+        config_dump = config.model_dump()
+        assert config_dump["judge_model_args"] == {
+            "temperature": 0.7,
+            "max_tokens": 100,
+            "model_name": "gpt-4",
+        }


### PR DESCRIPTION
## Description

Removing the api_key and base_url from being serialized in LLM as Judge. 