### PR TITLE
fix: removes a second newline in markdown doc when dataset path is provided

### DIFF
--- a/src/eval_framework/tasks/markdown_doc.py
+++ b/src/eval_framework/tasks/markdown_doc.py
@@ -47,7 +47,7 @@ def markdown_doc(
     buf.write(f"- Module: `{module}`\n\n")
 
     if http_path:
-        buf.write(f"- Link to dataset: [{http_path}]({http_path})\n\n")
+        buf.write(f"- Link to dataset: [{http_path}]({http_path})\n")
     else:
         assert example_messages is not None, "a task without a dataset link must supply an example sample"
         for split, size in (split_sizes or {}).items():

--- a/tests/tests_eval_framework/tasks/test_markdown_doc.py
+++ b/tests/tests_eval_framework/tasks/test_markdown_doc.py
@@ -68,3 +68,44 @@ SUBJECTS = ['no_subject']
 ````
 """
     )
+
+
+def test_markdown_doc_with_dataset_link() -> None:
+    doc = markdown_doc(
+        name="MyTask",
+        module="eval_framework.tasks.benchmarks.mytask",
+        dataset_path="datasets/mytask",
+        sample_split="test",
+        fewshot_split="train",
+        response_type="COMPLETION",
+        metrics=["Accuracy", "F1"],
+        subjects=["no_subject"],
+        language=None,
+        num_fewshot=1,
+        formatters=[ExampleFormatter()],
+        example_messages=[Message(role=Role.USER, content="Q")],
+        split_sizes={"test": 3, "train": 5},
+        possible_completions=["A", "B"],
+        ground_truth="A",
+    )
+
+    assert (
+        doc
+        == """\
+# MyTask
+
+````
+NAME = MyTask
+DATASET_PATH = datasets/mytask
+SAMPLE_SPLIT = test
+FEWSHOT_SPLIT = train
+RESPONSE_TYPE = COMPLETION
+METRICS = [Accuracy, F1]
+SUBJECTS = ['no_subject']
+````
+
+- Module: `eval_framework.tasks.benchmarks.mytask`
+
+- Link to dataset: [https://huggingface.co/datasets/datasets/mytask](https://huggingface.co/datasets/datasets/mytask)
+"""
+    )


### PR DESCRIPTION
## Description

Removes an  extra new line when `markdown_doc` takes the `if http_path`. 

