### PR TITLE
Drop PR title conventional-commits check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,3 @@
 ## Description
 
-<!-- Please provide a description of the changes you made. Feel free to add extra sections if needed, e.g. for related issues, testing instructions, review suggestions, etc. Please use conventional commits in both the commit messages and the PR title. -->
+<!-- Please provide a description of the changes you made. Feel free to add extra sections if needed, e.g. for related issues, testing instructions, review suggestions, etc. Please use conventional commits for the commit messages. -->

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,38 +24,8 @@ env:
 
 jobs:
 
-  lint-pr-title:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Skip PR title check (non-PR)
-        if: github.event_name != 'pull_request'
-        run: |
-          echo "Not a PR, skipping PR title check"
-
-      - name: Set up Python
-        if: github.event_name == 'pull_request'
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.11"
-
-      - name: Install commitizen
-        if: github.event_name == 'pull_request'
-        run: |
-          python -m pip install --upgrade pip
-          pip install commitizen
-
-      - name: Validate PR Title (only on PRs)
-        if: github.event_name == 'pull_request'
-        id: pr-check
-        run: |
-          cz check --message "${{ github.event.pull_request.title }}"
-
   lint:
     runs-on: ubuntu-latest # default runner runs out of disk space due to hf cache
-    needs: [lint-pr-title]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7


### PR DESCRIPTION
Removes the `lint-pr-title` CI job so PR titles no longer need to follow conventional commits. 
Only commit messages still need to follow it, as they are used for automated releases (e.g., still need "feat" for correct version bump). 