### PR TITLE
fix: recycle pooled containers to prevent blank exec output

### DIFF
--- a/src/eval_framework/metrics/completion/code_assertion.py
+++ b/src/eval_framework/metrics/completion/code_assertion.py
@@ -2,7 +2,7 @@ from llm_sandbox.exceptions import SandboxTimeoutError
 
 from eval_framework.metrics.base import BaseMetric, MetricResult
 from eval_framework.shared.types import Completion
-from eval_framework.tasks.utils import run_python_code
+from eval_framework.tasks.utils import DockerReturnedEmptyOutput, run_python_code
 
 
 class CodeCompletionAssertion(BaseMetric[Completion]):
@@ -16,7 +16,7 @@ class CodeCompletionAssertion(BaseMetric[Completion]):
         code = response.completion
         try:
             output = run_python_code(code, image="python:3.12-slim", runtime_configs={"mem_limit": "512m"})
-        except SandboxTimeoutError:
+        except (SandboxTimeoutError, DockerReturnedEmptyOutput):
             # The submitted code timed out (e.g. an infinite loop) -- a failing sample, not an infra
             # problem.
             import traceback

--- a/src/eval_framework/tasks/utils.py
+++ b/src/eval_framework/tasks/utils.py
@@ -58,6 +58,7 @@ def get_or_create_pool(
     lang: str = "python",
     min_pool_size: int = 1,
     max_pool_size: int = 1,
+    max_container_uses: int = 100,
     runtime_configs: dict[str, str] | None = None,
 ) -> ContainerPoolManager:
     assert image or dockerfile, "Either image or dockerfile must be provided"
@@ -65,7 +66,9 @@ def get_or_create_pool(
     with _pools_lock:
         if key not in _pools:
             pool = create_pool_manager(
-                config=PoolConfig(min_pool_size=min_pool_size, max_pool_size=max_pool_size),
+                config=PoolConfig(
+                    min_pool_size=min_pool_size, max_container_uses=max_container_uses, max_pool_size=max_pool_size
+                ),
                 lang=lang,
                 image=image,
                 dockerfile=dockerfile,
@@ -105,6 +108,10 @@ def get_n_letters(n: int) -> list[str]:
     return list(string.ascii_uppercase)[: max(0, n)]
 
 
+class DockerReturnedEmptyOutput(Exception):
+    """Raised when the docker returns an empty output."""
+
+
 def run_python_code(
     code: str,
     image: str | None = None,
@@ -142,6 +149,9 @@ def run_python_code(
         out = (output.stderr + output.stdout).strip()
         if isinstance(out, bytes):
             out = out.decode("utf-8")
+
+        if not out.strip():
+            raise DockerReturnedEmptyOutput("Docker returned an empty output.")
         return out
 
 

--- a/tests/tests_eval_framework/metrics/test_code_assertion.py
+++ b/tests/tests_eval_framework/metrics/test_code_assertion.py
@@ -5,6 +5,7 @@ from llm_sandbox.exceptions import ImagePullError, SandboxTimeoutError
 
 from eval_framework.metrics.completion.code_assertion import CodeCompletionAssertion
 from eval_framework.shared.types import Completion, Error
+from eval_framework.tasks.utils import DockerReturnedEmptyOutput
 
 
 @pytest.mark.parametrize(
@@ -372,6 +373,19 @@ def test_code_assertion_scores_timeout_as_failure() -> None:
     with patch(
         "eval_framework.metrics.completion.code_assertion.run_python_code",
         side_effect=SandboxTimeoutError("too slow"),
+    ):
+        results = metric.calculate(_completion())
+    assert results[0].value == 0.0
+    assert results[0].error is None
+    assert results[0].code_execution_trace is not None
+
+
+def test_code_assertion_scores_empty_output_as_failure() -> None:
+    # A code-execution timeout is the model's fault and stays a per-sample value=0.
+    metric = CodeCompletionAssertion()
+    with patch(
+        "eval_framework.metrics.completion.code_assertion.run_python_code",
+        side_effect=DockerReturnedEmptyOutput("too slow"),
     ):
         results = metric.calculate(_completion())
     assert results[0].value == 0.0

--- a/tests/tests_eval_framework/tasks/test_utils.py
+++ b/tests/tests_eval_framework/tasks/test_utils.py
@@ -43,8 +43,9 @@ def test_run_python_code_timeout() -> None:
 def test_run_python_code_with_packages() -> None:
     output = run_python_code("import pytest", image="python:3.13-slim")
     assert "ModuleNotFoundError" in output
-    output = run_python_code("import pytest", image="python:3.13-slim", packages=["pytest"])
+    output = run_python_code("import pytest\nprint(pytest.__name__)", image="python:3.13-slim", packages=["pytest"])
     assert "ModuleNotFoundError" not in output
+    assert "pytest" in output
 
 
 class TestParseUnittestOutput:


### PR DESCRIPTION
## Description

Container pools accumulate docker exec instances, which are only released when the container stops. After a few hundred executions this can exhaust daemon resources, causing exec_run to return empty stdout/stderr with exit code 0 and no error


Unlikely to be testable because it deals with transient issue. 