### PR TITLE
fix: skip sympy equivalence for candidates too long to be answers

### DIFF
--- a/src/eval_framework/metrics/completion/minerva_math_utils.py
+++ b/src/eval_framework/metrics/completion/minerva_math_utils.py
@@ -350,8 +350,17 @@ def strip_string_hendrycks(string: str) -> str:
     return string
 
 
+# MATH gold answers stay under ~80 chars.
+_PLAUSIBLE_ANSWER_LEN = 128
+
+
 def is_equiv_minerva(x1: str, x2: str, timeout_seconds: int = 5) -> bool:
     """Sympy-based equivalence (Minerva)."""
+    # extract_answers can fall back to the whole completion; sympy grinds on such
+    # 1000+ char strings until the timeout. A side far longer than the other can't
+    # be an equivalent final answer, so refuse it before parsing.
+    if max(len(x1), len(x2)) > max(_PLAUSIBLE_ANSWER_LEN, 3 * min(len(x1), len(x2))):
+        return False
 
     def _timeout_handler(signum: Any, frame: Any) -> None:
         raise TimeoutError()

--- a/tests/tests_eval_framework/metrics/test_minerva_completion.py
+++ b/tests/tests_eval_framework/metrics/test_minerva_completion.py
@@ -1,5 +1,7 @@
+import time
+
 from eval_framework.metrics.completion.math_minerva_completion import MathMinervaCompletion
-from eval_framework.metrics.completion.minerva_math_utils import extract_answers
+from eval_framework.metrics.completion.minerva_math_utils import extract_answers, is_equiv_minerva
 from eval_framework.shared.types import Completion
 
 
@@ -38,6 +40,21 @@ class TestMathMinervaCompletion:
 
         assert extract_answers(german, cot_style="minerva_de", relaxed=True)[0] == "24"
         assert extract_answers(german, relaxed=True)[0] != "24"
+
+    def test_is_equiv_minerva_refuses_implausibly_long_candidates_without_running_sympy(self) -> None:
+        # Unguarded, parsing this burns the full 5s timeout.
+        babble = "1.111011111011101111101111011011111111111011111111111.11111011" * 16
+
+        start = time.perf_counter()
+        result = is_equiv_minerva(babble, "\\sqrt{241}")
+
+        assert result is False
+        assert time.perf_counter() - start < 2.0
+
+    def test_is_equiv_minerva_still_checks_long_strings_of_similar_length(self) -> None:
+        long_expr = "+".join(["\\frac{1}{2}"] * 15)
+
+        assert is_equiv_minerva(long_expr, long_expr) is True
 
     def test_metric_defaults_to_english_but_can_select_german(self) -> None:
         german = "Finale Antwort: Die finale Antwort lautet 24. Ich hoffe, die Antwort ist korrekt."


### PR DESCRIPTION
Scoring `MATHMinervaDE_OLMES_NONL` takes over an hour per eval on current Phoenix-2 checkpoints, 41 min per Minerva metric (execution `p2-checkpoint-upload-test-2-260808`, pod `...faii1oji-0`; worst observed 3h44m on a 400M ablation):

```
Calculating Math Minerva Completion DE:         100%|██████████| 4947/4947 [41:09<00:00]
Calculating Math Minerva Completion Relaxed DE: 100%|██████████| 4947/4947 [41:09<00:00]
```

Degenerate completions contain no "Finale Antwort" line, no `\boxed` and fewer than two `$`, so `extract_answers` falls back to the whole ~1,200-char completion, and every `is_equiv_minerva` call on it burns the full 5s sympy timeout, up to 4x per sample x 4,947 samples. The guard refuses sides too long to be a final answer before sympy runs.

Verified by replaying both NONL benchmarks in full against production results: scoring drops from 82 min to 2.2 min, and of 39,788 compared metric values 20 flip (5 samples), all babble that happens to simplify to gold ("4.000...0" scored as correct for gold 4). Gold answers across both datasets: median 3 chars, max 72.

It's unfortunate this shows up only because Savanna has assumption about how long a vllm deployment should be kept alive after not receiving requests. Have we considered emitting per-metric scoring-duration metric so outliers like this alert early?