### PR TITLE
imp: access task subject through EvalFactory

### DIFF
--- a/src/eval_framework/tasks/registry.py
+++ b/src/eval_framework/tasks/registry.py
@@ -52,6 +52,10 @@ class EvalFactory(ABC):
         """The eval's metrics"""
 
     @abstractmethod
+    def subjects(self) -> list[Any]:
+        """The eval's subjects"""
+
+    @abstractmethod
     def display_name(self) -> str:
         """Human-readable display name. Is allowed to have special characters and whitespaces."""
 
@@ -153,6 +157,10 @@ class _Lazy(EvalFactory):
         """The eval's metrics"""
         return self.task_class().get_metrics()
 
+    def subjects(self) -> list[Any]:
+        """The eval's subjects"""
+        return self.task_class().SUBJECTS
+
     def display_name(self) -> str:
         """The eval's human-readable display name (the task's ``NAME``)."""
         return self.task_class().NAME
@@ -219,6 +227,10 @@ class _Eager(EvalFactory):
     def metrics(self) -> list[type["BaseMetric"]]:
         """The eval's metrics"""
         return self._task.get_metrics()
+
+    def subjects(self) -> list[Any]:
+        """The eval's subjects"""
+        return self._task.SUBJECTS
 
     def display_name(self) -> str:
         """The eval's human-readable display name (the task's ``NAME``)."""

--- a/tests/tests_eval_framework/tasks/test_registry.py
+++ b/tests/tests_eval_framework/tasks/test_registry.py
@@ -59,3 +59,13 @@ def test_lazy_registration() -> None:
     registry = Registry()
     registry.register_lazy(f"{MATH.__module__}.{MATH.__name__}")
     assert registry["Math"].display_name() == MATH.NAME
+
+
+def test_subjects() -> None:
+    registry = Registry()
+    registry.register(MATH)
+    assert registry["MATH"].subjects() == MATH.SUBJECTS
+
+    registry = Registry()
+    registry.register_lazy(f"{MATH.__module__}.{MATH.__name__}")
+    assert registry["Math"].subjects() == MATH.SUBJECTS


### PR DESCRIPTION
## Description

Adds a method `subjects` to the `EvalFactory` to access the underlying task's subjects. 