### PR TITLE
Template formatter fixes

### DIFF
--- a/src/template_formatting/formatter.py
+++ b/src/template_formatting/formatter.py
@@ -196,7 +196,7 @@ class BaseFormatter:
             if self.strip_content:
                 text = text.strip()
             elif output_mode == "string":
-                if is_last or (self.template.end_user_id != "" and not self.never_strip):
+                if not self.never_strip and (is_last or self.template.end_user_id != ""):
                     text = text.strip()
             if output_mode == "string" or (output_mode == "list" and not is_last):
                 # start assistant message after user message

--- a/src/template_formatting/formatter.py
+++ b/src/template_formatting/formatter.py
@@ -103,14 +103,12 @@ class BaseFormatter:
         for message in messages:
             if output_mode == "string":
                 # eval-framework style
-                if not hasattr(message, "role"):
-                    raise ValueError("Message is missing 'role' property.")
-                if (getattr(message, "type", None) is not None) or (getattr(message, "has_loss", None) is not None):
-                    raise ValueError()
+                if message.type is not None or message.has_loss is not None:
+                    raise ValueError("Message must not set 'type' or 'has_loss' property in 'string' output mode.")
 
             elif output_mode == "list":
                 # scaling style
-                if not hasattr(message, "type") or not hasattr(message, "has_loss"):
+                if message.type is None or message.has_loss is None:
                     raise ValueError("Message is missing 'type' or 'has_loss' property.")
 
     @staticmethod

--- a/tests/tests_template_formatting/test_formatter_eval.py
+++ b/tests/tests_template_formatting/test_formatter_eval.py
@@ -230,6 +230,24 @@ def test_stripping_of_whitespace(llama3_formatter: BaseFormatter, hf_formatter: 
     assert hf_formatted_conversation == expected_output
 
 
+def test_never_strip_preserves_trailing_whitespace_of_final_turn() -> None:
+    class NeverStripConcatFormatter(ConcatFormatter):
+        never_strip = True
+
+    formatter = NeverStripConcatFormatter()
+
+    # A trailing newline in a cue such as "```python\n" decides whether the model
+    # continues on a new line, so it must survive formatting.
+    final_user_turn = [Message(role=Role.USER, content="def f(x):\n    ")]
+    assert formatter.format(final_user_turn, output_mode="string") == "def f(x):\n    "
+
+    final_assistant_cue = [
+        Message(role=Role.USER, content="Solve this"),
+        Message(role=Role.ASSISTANT, content="```python\n"),
+    ]
+    assert formatter.format(final_assistant_cue, output_mode="string") == "Solve this```python\n"
+
+
 @pytest.mark.parametrize(
     "model_name, expected_formatter",
     [

--- a/tests/tests_template_formatting/test_formatter_scaling.py
+++ b/tests/tests_template_formatting/test_formatter_scaling.py
@@ -95,6 +95,20 @@ def test_base_verify_messages_raises_exception() -> None:
         BaseFormatter._verify_messages(messages)
 
 
+def test_verify_message_fields_list_mode_requires_scaling_fields() -> None:
+    messages = [Message(role=Role.USER, content="dummy", type="text")]
+
+    with pytest.raises(ValueError, match="missing 'type' or 'has_loss'"):
+        BaseFormatter._verify_message_fields(messages, "list")
+
+
+def test_verify_message_fields_string_mode_rejects_scaling_fields() -> None:
+    messages = [Message(role=Role.USER, content="dummy", has_loss=False, type="text")]
+
+    with pytest.raises(ValueError, match="must not set 'type' or 'has_loss'"):
+        BaseFormatter._verify_message_fields(messages, "string")
+
+
 def test_reasoning_verify_messages() -> None:
     defaults = {"content": "dummy", "has_loss": False, "type": "text"}
 


### PR DESCRIPTION
Go commit-by-commit. 

Commit-1: 
Changes the order of checking so that never_strip is checked before other checks. 
Small test for this behaviour. 

Commit-2: 
Removes a very pointless hasattr checks in `_verify_message_fields` that will always be true. 
Replaced it with checking if value is None instead. 