### PR TITLE
fix: stop judge_model_args serializer from mutating the config

### DIFF
--- a/src/eval_framework/tasks/eval_config.py
+++ b/src/eval_framework/tasks/eval_config.py
@@ -135,9 +135,7 @@ class EvalConfig(BaseConfig):
 
     @field_serializer("judge_model_args")
     def serialize_judge_model_args(self, value: dict[str, Any]) -> dict[str, Any]:
-        value.pop("api_key", None)
-        value.pop("base_url", None)
-        return value
+        return {k: v for k, v in value.items() if k not in ("api_key", "base_url")}
 
     def model_json_dump(self) -> str:
         model_dump = self.model_dump(mode="json")

--- a/tests/tests_eval_framework/test_eval_config_validation.py
+++ b/tests/tests_eval_framework/test_eval_config_validation.py
@@ -314,3 +314,5 @@ class TestEvalConfigJudgeModelArgsValidation:
             "max_tokens": 100,
             "model_name": "gpt-4",
         }
+        assert config.judge_model_args["api_key"] == "sk-1234567890"
+        assert config.judge_model_args["base_url"] == "https://api.openai.com"


### PR DESCRIPTION
Since 2adc4ed the `judge_model_args` field serializer pops `api_key` and `base_url` from the live dict on the config instance. `model_dump` runs before the judge is constructed. by the time `llm_judge()` builds the client, the credentials are gone and the base URL has reverted to the default endpoint. Every judge-configured task fails with:

```
File ".../eval_framework/evaluation_generator.py", line 71, in _run_metric_calculators
    llm_judge = self.config.llm_judge()
File ".../eval_framework/tasks/eval_config.py", line 70, in llm_judge
    return self.llm_judge_class(**self.judge_model_args)
File ".../eval_framework/llm/openai.py", line 88, in __init__
    self._client = OpenAI(
openai.OpenAIError: Missing credentials. ...
```

The serializer now returns a filtered copy, and the existing serialization test additionally asserts the config still carries `api_key` and `base_url` after a dump.
