### PR TITLE
feat(metrics): report reasoning token count per eval

### DIFF
--- a/src/eval_framework/llm/openai.py
+++ b/src/eval_framework/llm/openai.py
@@ -223,6 +223,8 @@ class OpenAIModel(BaseLLM):
                 prompt = "\n".join([f"{m.get('role', '')}: {m.get('content', '')}" for m in chat_messages])
                 prompt_tokens = getattr(chat_response.usage, "prompt_tokens", None)
                 completion_tokens = getattr(chat_response.usage, "completion_tokens", None)
+                completion_details = getattr(chat_response.usage, "completion_tokens_details", None)
+                reasoning_tokens = getattr(completion_details, "reasoning_tokens", None)
                 completion = chat_response.choices[0].message.content or ""
                 return RawCompletion(
                     prompt=prompt,
@@ -242,6 +244,7 @@ class OpenAIModel(BaseLLM):
                         if completion_tokens is not None
                         else (self._count_tokens(completion) if self._encoder is not None else None)
                     ),
+                    reasoning_num_tokens=reasoning_tokens,
                 )
 
         with concurrent.futures.ThreadPoolExecutor() as executor:

--- a/src/eval_framework/metrics/efficiency/reasoning_tokens.py
+++ b/src/eval_framework/metrics/efficiency/reasoning_tokens.py
@@ -1,0 +1,29 @@
+from eval_framework.metrics.base import BaseMetric, MetricResult
+from eval_framework.shared.types import Completion
+
+
+class NumReasoningTokens(BaseMetric[Completion]):
+    """Portion of the completion the model spent on reasoning (thinking).
+
+    Reads the count backends attach to the response when the model exposes it
+    (OpenAI reasoning models via `usage.completion_tokens_details.reasoning_tokens`;
+    vLLM when started with `--reasoning-parser`). Non-reasoning models and
+    backends that do not surface a per-response count return None.
+    """
+
+    NAME = "NumReasoningTokens"
+
+    def calculate(self, response: Completion) -> list[MetricResult]:
+        if response.error or response.raw_completion_reasoning_num_tokens is None:
+            value = None
+        else:
+            value = response.raw_completion_reasoning_num_tokens
+
+        return [
+            MetricResult(
+                metric_name=self.NAME,
+                value=value,
+                higher_is_better=False,
+                error=response.error,
+            )
+        ]

--- a/src/eval_framework/shared/types.py
+++ b/src/eval_framework/shared/types.py
@@ -91,6 +91,12 @@ class RawCompletion(BaseCompletion):
         int | None,
         "number of tokens the model generated for the completion, or None if the backend did not report it",
     ]
+    reasoning_num_tokens: Annotated[
+        int | None,
+        "portion of completion_num_tokens that the model spent on reasoning (thinking), "
+        "or None if the backend did not report it. Non-reasoning models and backends that "
+        "do not surface a reasoning-token count leave this None.",
+    ] = None
     raw_completion_error: Error | None = None
 
 
@@ -104,6 +110,11 @@ class Completion(BaseCompletion):
         int | None,
         "number of tokens the model generated for the raw completion, or None if the backend did not report it",
     ]
+    raw_completion_reasoning_num_tokens: Annotated[
+        int | None,
+        "portion of raw_completion_num_tokens that the model spent on reasoning, or None if the "
+        "backend did not report it",
+    ] = None
     context: list[BaseMetricContext] | BaseMetricContext | None = None
     error: Error | None = None
 

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -467,6 +467,7 @@ class BaseTask[SubjectType](Task):
                     completion=completion,
                     raw_completion=raw_completion.completion,
                     raw_completion_num_tokens=raw_completion.completion_num_tokens,
+                    raw_completion_reasoning_num_tokens=raw_completion.reasoning_num_tokens,
                     context=sample.context,
                     error=raw_completion.raw_completion_error or error,
                 )

--- a/src/eval_framework/tasks/benchmarks/bigcodebench.py
+++ b/src/eval_framework/tasks/benchmarks/bigcodebench.py
@@ -9,6 +9,7 @@ from eval_framework.metrics.completion.code_execution_pass_at_one import (
     CodeExecutionPassAtOneWithCodebench,
 )
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.tasks.base import (
     RANDOM_SEED,
     BaseTask,
@@ -47,7 +48,7 @@ class BigCodeBench(BaseTask[str]):
     SAMPLE_SPLIT = "v0.1.4"
     FEWSHOT_SPLIT = "v0.1.4"  # (there is no dedicated split, few-shot is not expected for this dataset)
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [CodeExecutionPassAtOne, NumCompletionTokens]
+    METRICS = [CodeExecutionPassAtOne, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = ["original", "calibrated"]
     LANGUAGE = Language.ENG
 
@@ -130,7 +131,7 @@ class BigCodeBench_OLMES(BigCodeBench):
     NAME = "BigCodeBench_OLMES"
     SAMPLE_SPLIT = "v0.1.2"
     FEWSHOT_SPLIT = "v0.1.2"
-    METRICS = [CodeExecutionPassAtOneWithCodebench, NumCompletionTokens]
+    METRICS = [CodeExecutionPassAtOneWithCodebench, NumCompletionTokens, NumReasoningTokens]
 
     def __init__(self, num_fewshot: int = 3) -> None:
         # Default 3-shot; config can override. Enforce 3 for this variant.

--- a/src/eval_framework/tasks/benchmarks/drop.py
+++ b/src/eval_framework/tasks/benchmarks/drop.py
@@ -5,6 +5,7 @@ from eval_framework.metrics.completion.drop_completion import (
     DropMetricContext,
 )
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.metrics.loglikelihood.accuracy_loglikelihood import (
     AccuracyLoglikelihood,
     AccuracyNormLoglikelihood,
@@ -83,7 +84,7 @@ class DropCompletion(BaseTask[str]):
     SAMPLE_SPLIT = "validation"
     FEWSHOT_SPLIT = "validation"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [DropF1ExactMatch, NumCompletionTokens]
+    METRICS = [DropF1ExactMatch, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = [NO_SUBJECT]
     LANGUAGE = Language.ENG
 

--- a/src/eval_framework/tasks/benchmarks/gpqa.py
+++ b/src/eval_framework/tasks/benchmarks/gpqa.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from eval_framework.metrics.completion.accuracy_completion import AccuracyCompletion
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.metrics.loglikelihood.accuracy_loglikelihood import (
     AccuracyLoglikelihood,
     AccuracyNormLoglikelihood,
@@ -177,7 +178,7 @@ class GPQA_COT(GPQA):
     REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "GPQA_COT"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [AccuracyCompletion, NumCompletionTokens]
+    METRICS = [AccuracyCompletion, NumCompletionTokens, NumReasoningTokens]
     ANS_RE = re.compile(r"Therefore, the answer is \(([ABCDEFGHIJ])\)")
 
     def __init__(self, num_fewshot: int = 0) -> None:

--- a/src/eval_framework/tasks/benchmarks/gsm8k.py
+++ b/src/eval_framework/tasks/benchmarks/gsm8k.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from eval_framework.metrics.completion.accuracy_completion import AccuracyCompletion, AccuracyCompletionOLMES
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.tasks.base import BaseTask, Language, ResponseType, Sample
 from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.task_style import BPBStyle
@@ -101,7 +102,7 @@ class GSM8KEvalHarness(BaseTask[str]):
     SAMPLE_SPLIT = "test"
     FEWSHOT_SPLIT = "train"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [AccuracyCompletion, NumCompletionTokens]
+    METRICS = [AccuracyCompletion, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = ["main"]
     LANGUAGE = Language.ENG
 
@@ -158,7 +159,7 @@ class GSM8K(GSM8KEvalHarness):
 class GSM8K_OLMES(GSM8K):
     REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "GSM8K_OLMES"
-    METRICS = [AccuracyCompletionOLMES, NumCompletionTokens]
+    METRICS = [AccuracyCompletionOLMES, NumCompletionTokens, NumReasoningTokens]
 
     def __init__(self, num_fewshot: int = 8) -> None:
         if num_fewshot != 8:

--- a/src/eval_framework/tasks/benchmarks/hendrycks_math_ellamind.py
+++ b/src/eval_framework/tasks/benchmarks/hendrycks_math_ellamind.py
@@ -11,6 +11,7 @@ from eval_framework.metrics.completion.math_minerva_completion import (
 )
 from eval_framework.metrics.completion.minerva_math_utils import extract_answers
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.tasks.base import Language, Sample
 from eval_framework.tasks.benchmarks.math_reasoning import MATHMinerva
 from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
@@ -44,7 +45,7 @@ class MATHMinervaDE_OLMES(MATHMinerva):
     FEWSHOT_SPLIT = "test"  # EllaMind only ships a test split
     SUBJECTS = ["deu"]
     LANGUAGE = Language.DEU
-    METRICS = [MathMinervaCompletionDE, MathMinervaCompletionRelaxedDE, NumCompletionTokens]
+    METRICS = [MathMinervaCompletionDE, MathMinervaCompletionRelaxedDE, NumCompletionTokens, NumReasoningTokens]
 
     def __init__(self, num_fewshot: int = 4) -> None:
         super().__init__(num_fewshot)

--- a/src/eval_framework/tasks/benchmarks/humaneval.py
+++ b/src/eval_framework/tasks/benchmarks/humaneval.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from eval_framework.metrics.completion.code_assertion import CodeCompletionAssertion
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.metrics.loglikelihood.bits_per_byte import BitsPerByteLoglikelihood
 from eval_framework.shared.types import BaseMetricContext
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType, Sample
@@ -36,7 +37,7 @@ class HumanEval(BaseTask[str]):
     SAMPLE_SPLIT = "test"
     FEWSHOT_SPLIT = "test"  # (there is no dedicated split, few-shot is not expected for this dataset)
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [CodeCompletionAssertion, NumCompletionTokens]
+    METRICS = [CodeCompletionAssertion, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = [NO_SUBJECT]
     LANGUAGE = Language.ENG
 

--- a/src/eval_framework/tasks/benchmarks/ifeval.py
+++ b/src/eval_framework/tasks/benchmarks/ifeval.py
@@ -3,6 +3,7 @@ from typing import Any
 from eval_framework.metrics.completion.ifeval import IFEvalMetric, IFEvalMetricContext
 from eval_framework.metrics.completion.language_checker import LanguageRawConsistencyChecker
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType
 from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 
@@ -17,7 +18,7 @@ class IFEval(BaseTask[str]):
     SAMPLE_SPLIT = "train"
     FEWSHOT_SPLIT = "train"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [IFEvalMetric, NumCompletionTokens]
+    METRICS = [IFEvalMetric, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = [NO_SUBJECT]
     LANGUAGE = {NO_SUBJECT: Language.ENG}
 
@@ -83,4 +84,4 @@ class IFEvalDe(IFEval):
     DATASET_PATH = "jzhang86/de_ifeval"
     SUBJECTS = [NO_SUBJECT]
     LANGUAGE = {NO_SUBJECT: Language.DEU}
-    METRICS = [IFEvalMetric, LanguageRawConsistencyChecker, NumCompletionTokens]
+    METRICS = [IFEvalMetric, LanguageRawConsistencyChecker, NumCompletionTokens, NumReasoningTokens]

--- a/src/eval_framework/tasks/benchmarks/math_reasoning.py
+++ b/src/eval_framework/tasks/benchmarks/math_reasoning.py
@@ -12,6 +12,7 @@ from eval_framework.metrics.completion.math_minerva_completion import (
 from eval_framework.metrics.completion.math_reasoning_completion import MathReasoningCompletion
 from eval_framework.metrics.completion.minerva_math_utils import extract_answers, normalized_gold_from_solution
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.tasks.base import NO_SUBJECT, RANDOM_SEED, BaseTask, Language, ResponseType, Sample, SubjectType
 from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.task_style import BPBStyle
@@ -40,7 +41,7 @@ class MATHReasoning(BaseTask[str]):
     """
 
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [MathReasoningCompletion, NumCompletionTokens]
+    METRICS = [MathReasoningCompletion, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = [NO_SUBJECT]
     ANSWER_PATTERN = r"(?i)Answer\s*:\s*(.*)"
     LANGUAGE = Language.ENG
@@ -337,7 +338,7 @@ class AIME2024(MATHReasoning):
     SAMPLE_SPLIT = "train"
     FEWSHOT_SPLIT = "train"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [MathReasoningCompletion, LanguageRawConsistencyChecker, NumCompletionTokens]
+    METRICS = [MathReasoningCompletion, LanguageRawConsistencyChecker, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = [NO_SUBJECT]
     LANGUAGE = Language.ENG
 
@@ -438,7 +439,7 @@ class MATH500(MATHReasoning):
     SAMPLE_SPLIT = "test"
     FEWSHOT_SPLIT = "test"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [MathReasoningCompletion, LanguageRawConsistencyChecker, NumCompletionTokens]
+    METRICS = [MathReasoningCompletion, LanguageRawConsistencyChecker, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = [NO_SUBJECT]
     LANGUAGE = Language.ENG
 
@@ -487,7 +488,7 @@ class MATH(MATHReasoning):
     SAMPLE_SPLIT = "test"
     FEWSHOT_SPLIT = "train"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [MathReasoningCompletion, LanguageRawConsistencyChecker, NumCompletionTokens]
+    METRICS = [MathReasoningCompletion, LanguageRawConsistencyChecker, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = MATH_SUBJECTS
     LANGUAGE = Language.ENG
 
@@ -566,7 +567,7 @@ class MATHMinervaEvalHarness(MATHReasoning):
     SAMPLE_SPLIT = "test"
     FEWSHOT_SPLIT = "train"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [MathMinervaCompletion, NumCompletionTokens]
+    METRICS = [MathMinervaCompletion, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = MATH_SUBJECTS
     LANGUAGE = Language.ENG
 
@@ -600,7 +601,7 @@ class MATHMinerva(MATHMinervaEvalHarness):
     REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "MATHMinerva"
-    METRICS = [MathMinervaCompletionRelaxed, NumCompletionTokens]
+    METRICS = [MathMinervaCompletionRelaxed, NumCompletionTokens, NumReasoningTokens]
 
     def post_process_generated_completion(self, completion_text: str, sample: Sample | None = None) -> str:
         """Primary answer for storage; uses relaxed final-answer extraction."""
@@ -665,7 +666,7 @@ class GSM8KReasoning(MATHReasoning):
     SAMPLE_SPLIT = "test"
     FEWSHOT_SPLIT = "train"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [AccuracyCompletion, LanguageRawConsistencyChecker, NumCompletionTokens]
+    METRICS = [AccuracyCompletion, LanguageRawConsistencyChecker, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = ["main"]
     LANGUAGE = Language.ENG
 
@@ -761,7 +762,7 @@ _OLMES_FEWSHOTS = [
 class MATHMinerva_OLMES(MATHMinerva):
     REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "MATHMinerva_OLMES"
-    METRICS = [MathMinervaCompletion, MathMinervaCompletionRelaxed, NumCompletionTokens]
+    METRICS = [MathMinervaCompletion, MathMinervaCompletionRelaxed, NumCompletionTokens, NumReasoningTokens]
 
     def __init__(self, num_fewshot: int = 4) -> None:
         if num_fewshot != 4:

--- a/src/eval_framework/tasks/benchmarks/mbpp.py
+++ b/src/eval_framework/tasks/benchmarks/mbpp.py
@@ -7,6 +7,7 @@ from eval_framework.metrics.completion.code_assertion import (
     CodeCompletionAssertion,
 )
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.metrics.loglikelihood.bits_per_byte import BitsPerByteLoglikelihood
 from eval_framework.shared.types import BaseMetricContext
 from eval_framework.tasks.base import BaseTask, Language, ResponseType, Sample
@@ -39,7 +40,7 @@ class MBPP(BaseTask[str]):
     SAMPLE_SPLIT = "test"
     FEWSHOT_SPLIT = "train"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [CodeCompletionAssertion, NumCompletionTokens]
+    METRICS = [CodeCompletionAssertion, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = ["full"]  # , "sanitized"]  # these are HF dataset SUBSETS!
     LANGUAGE = Language.ENG
 

--- a/src/eval_framework/tasks/benchmarks/mmlu.py
+++ b/src/eval_framework/tasks/benchmarks/mmlu.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from eval_framework.metrics.completion.accuracy_completion import AccuracyCompletion
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.metrics.loglikelihood.accuracy_loglikelihood import (
     AccuracyLoglikelihood,
     AccuracyNormLoglikelihood,
@@ -192,7 +193,7 @@ class MMLU_COT(MMLU):
 
     NAME = "MMLU_COT"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [AccuracyCompletion, NumCompletionTokens]
+    METRICS = [AccuracyCompletion, NumCompletionTokens, NumReasoningTokens]
 
     ANS_RE = re.compile(r"Therefore, the answer is: ([ABCD])")
 

--- a/src/eval_framework/tasks/benchmarks/mmlu_pro.py
+++ b/src/eval_framework/tasks/benchmarks/mmlu_pro.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from eval_framework.metrics.completion.accuracy_completion import AccuracyCompletion
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.metrics.loglikelihood.accuracy_loglikelihood import (
     AccuracyLoglikelihood,
     AccuracyNormLoglikelihood,
@@ -136,7 +137,7 @@ class MMLU_PRO_COT(MMLU_PRO):
     REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
     NAME = "MMLU_PRO_COT"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [AccuracyCompletion, NumCompletionTokens]
+    METRICS = [AccuracyCompletion, NumCompletionTokens, NumReasoningTokens]
     ANS_RE = re.compile(r"Therefore, the answer is \(([ABCDEFGHIJ])\)")
 
     def __init__(self, num_fewshot: int = 0) -> None:

--- a/src/eval_framework/tasks/benchmarks/multipl_e.py
+++ b/src/eval_framework/tasks/benchmarks/multipl_e.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from eval_framework.metrics.completion.multipl_e_assertion import MultiPLECodeAssertion, MultiPLEMetricContext
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType, Sample
 from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 
@@ -49,7 +50,7 @@ class _BaseMPLE(BaseTask[str]):
     SAMPLE_SPLIT = "test"
     FEWSHOT_SPLIT = "test"  # no dedicated fewshot split; 0-shot is expected
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [MultiPLECodeAssertion, NumCompletionTokens]
+    METRICS = [MultiPLECodeAssertion, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = [NO_SUBJECT]
     LANGUAGE = Language.ENG
 

--- a/src/eval_framework/tasks/benchmarks/naturalqs_open.py
+++ b/src/eval_framework/tasks/benchmarks/naturalqs_open.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from eval_framework.metrics.completion.drop_completion import DropF1ExactMatch, DropMetricContext
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.tasks.base import NO_SUBJECT, BaseTask, Language, ResponseType
 from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
 from eval_framework.tasks.task_style import (
@@ -19,7 +20,7 @@ class NaturalQsOpen(BaseTask[str]):
     SAMPLE_SPLIT = "validation"
     FEWSHOT_SPLIT = "train"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [DropF1ExactMatch, NumCompletionTokens]
+    METRICS = [DropF1ExactMatch, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = [NO_SUBJECT]
     LANGUAGE = Language.ENG
 

--- a/src/eval_framework/tasks/benchmarks/squad.py
+++ b/src/eval_framework/tasks/benchmarks/squad.py
@@ -11,6 +11,7 @@ from huggingface_hub.errors import RevisionNotFoundError
 from eval_framework.metrics.completion.accuracy_completion import AccuracyCompletion
 from eval_framework.metrics.completion.f1 import F1, F1SquadNormalized
 from eval_framework.metrics.efficiency.completion_tokens import NumCompletionTokens
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
 from eval_framework.metrics.loglikelihood.bits_per_byte import BitsPerByteLoglikelihood
 from eval_framework.tasks.base import NO_SUBJECT, RANDOM_SEED, BaseTask, Language, ResponseType, Sample, SubjectType
 from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
@@ -24,7 +25,7 @@ class SQUAD2(BaseTask[str]):
     SAMPLE_SPLIT = "validation"
     FEWSHOT_SPLIT = "train"
     RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = [AccuracyCompletion, F1, NumCompletionTokens]
+    METRICS = [AccuracyCompletion, F1, NumCompletionTokens, NumReasoningTokens]
     SUBJECTS = [NO_SUBJECT]
     UNANSWERABLE_STR = "unanswerable"
     LANGUAGE = Language.ENG
@@ -247,7 +248,7 @@ class SQuAD2_MA(SQUAD2):
     NAME = "SQuAD2_MA"
     UNANSWERABLE_STR = "unanswerable"
 
-    METRICS = [AccuracyCompletion, F1, F1SquadNormalized, NumCompletionTokens]
+    METRICS = [AccuracyCompletion, F1, F1SquadNormalized, NumCompletionTokens, NumReasoningTokens]
 
     def __init__(self, num_fewshot: int = 0) -> None:
         super().__init__(num_fewshot)
@@ -310,7 +311,7 @@ class SQuAD_OLMES(SQUAD):
     NAME = "SQuAD_OLMES"
     SAMPLE_SPLIT = "validation"
     FEWSHOT_SPLIT = "train"
-    METRICS = [F1SquadNormalized, NumCompletionTokens]
+    METRICS = [F1SquadNormalized, NumCompletionTokens, NumReasoningTokens]
 
     def __init__(self, num_fewshot: int = 0) -> None:
         super().__init__(num_fewshot)

--- a/tests/tests_eval_framework/metrics/efficiency_metrics/test_reasoning_tokens.py
+++ b/tests/tests_eval_framework/metrics/efficiency_metrics/test_reasoning_tokens.py
@@ -1,0 +1,41 @@
+from eval_framework.metrics.efficiency.reasoning_tokens import NumReasoningTokens
+from eval_framework.shared.types import Completion, Error
+
+
+def _completion(**overrides: object) -> Completion:
+    defaults: dict = {
+        "id": 1,
+        "subject": "x",
+        "ground_truth": "gt",
+        "prompt": "test",
+        "prompt_num_tokens": 1,
+        "messages": None,
+        "completion": "42",
+        "raw_completion": "the answer is 42",
+        "raw_completion_num_tokens": 10,
+        "raw_completion_reasoning_num_tokens": 6,
+    }
+    defaults.update(overrides)
+    return Completion(**defaults)  # type: ignore[arg-type]
+
+
+def test_num_reasoning_tokens_returns_reported_count() -> None:
+    results = NumReasoningTokens().calculate(_completion())
+    assert len(results) == 1
+    assert results[0].metric_name == "NumReasoningTokens"
+    assert results[0].value == 6
+    assert results[0].higher_is_better is False
+
+
+def test_num_reasoning_tokens_is_none_when_backend_did_not_report() -> None:
+    results = NumReasoningTokens().calculate(_completion(raw_completion_reasoning_num_tokens=None))
+    assert len(results) == 1
+    assert results[0].value is None
+
+
+def test_num_reasoning_tokens_is_none_when_sample_errored() -> None:
+    error = Error(error_class="", message="", traceback="")
+    results = NumReasoningTokens().calculate(_completion(error=error))
+    assert len(results) == 1
+    assert results[0].value is None
+    assert results[0].error is error


### PR DESCRIPTION
Follow-up to #657. Adds a `NumReasoningTokens` metric that reports the portion of the completion the model spent on thinking. OpenAI reasoning models (o-series, GPT-5 thinking) and vLLM served with `--reasoning-parser` both surface this via `usage.completion_tokens_details.reasoning_tokens`; the OpenAI backend extracts it, and non-reasoning models simply report None. Wired into the same generative task METRICS as `NumCompletionTokens`. Companion has a matching PR that plumbs `openai_compatible.py` for the vLLM path we use through savanna.

Rebase on top of #657 once that lands.