### PR TITLE
feat: humaneval v2 preserves trailing docstring newline

### DIFF
--- a/src/eval_framework/llm/base.py
+++ b/src/eval_framework/llm/base.py
@@ -175,7 +175,7 @@ class BaseLLM(ABC):
                 case "ConcatFormatter":
                     from template_formatting.formatter import ConcatFormatter
 
-                    return ConcatFormatter()
+                    return ConcatFormatter(**kwargs)
                 case "HFFormatter":
                     from template_formatting.formatter import HFFormatter
 

--- a/src/eval_framework/tasks/benchmarks/humaneval.py
+++ b/src/eval_framework/tasks/benchmarks/humaneval.py
@@ -147,6 +147,32 @@ class HumanEval_OLMES(HumanEval):
         return item["canonical_solution"] + "```"
 
 
+class HumanEval_V2(HumanEval):
+    """HumanEval variant that preserves the trailing newline after the closing docstring.
+
+    Motivation: on the canonical HumanEval prompt, the closing triple-quote is followed
+    by a newline in the reference dataset. When the harness right-strips the prompt,
+    the model is asked to continue directly after `\"\"\"`. For tokenizers that weld
+    `\"\"\"` and the following newline into a single token (e.g. Phoenix-2's `p2_t8`),
+    the requested continuation is off-manifold and the model emits EOS instead, so
+    completions come back empty. Restoring the trailing newline puts the prompt back
+    on a token boundary the model has seen during training.
+
+    Callers must pair this task with a formatter that does not strip the last turn.
+    For `ConcatFormatter`, pass `preserve_trailing_whitespace=True`.
+    """
+
+    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
+
+    NAME = "Human Eval V2"
+
+    def _get_instruction_text(self, item: dict[str, Any]) -> str:
+        prompt = item["prompt"].lstrip()
+        if not prompt.endswith("\n"):
+            prompt = prompt + "\n"
+        return f"```python\n{prompt}"
+
+
 class HumanEvalInstruct(HumanEval):
     # See https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/humaneval/humaneval_instruct.yaml
     REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE

--- a/src/eval_framework/tasks/task_names.py
+++ b/src/eval_framework/tasks/task_names.py
@@ -116,6 +116,7 @@ def register_humaneval_tasks(registry: Registry) -> None:
     register_lazy_task("eval_framework.tasks.benchmarks.humaneval.HumanEvalBPB", registry=registry)
     register_lazy_task("eval_framework.tasks.benchmarks.humaneval.HumanEvalBPB_V2", registry=registry)
     register_lazy_task("eval_framework.tasks.benchmarks.humaneval.HumanEval_OLMES", registry=registry)
+    register_lazy_task("eval_framework.tasks.benchmarks.humaneval.HumanEval_V2", registry=registry)
 
 
 def register_mbpp_tasks(registry: Registry) -> None:

--- a/src/template_formatting/formatter.py
+++ b/src/template_formatting/formatter.py
@@ -270,6 +270,14 @@ class ConcatFormatter(BaseFormatter):
     )
     # new lines are handled on task level, so we don't need to strip content here
 
+    def __init__(self, preserve_trailing_whitespace: bool = False) -> None:
+        # Tasks like HumanEval carry a load-bearing trailing "\n" after the
+        # closing docstring quotes; stripping it lands the prompt on a
+        # tokenizer boundary where the model emits EOS instead of continuing.
+        if preserve_trailing_whitespace:
+            self.never_strip = True
+        super().__init__()
+
 
 class Llama3Formatter(BaseFormatter):
     template = ChatTemplate(

--- a/tests/tests_eval_framework/tasks/benchmarks/task-prompts-hashes.json
+++ b/tests/tests_eval_framework/tasks/benchmarks/task-prompts-hashes.json
@@ -106,6 +106,8 @@
     "HumanEvalDE_OLMES.Llama3Formatter": "59c29b0d090e7dc9fa4ad0af98b6e4c9",
     "HumanEval_OLMES.ConcatFormatter": "8ce5a1465a77bfb558496d01f6684b04",
     "HumanEval_OLMES.Llama3Formatter": "6db1c1aeda39bc7485d183e1a3d28364",
+    "HumanEval_V2.ConcatFormatter": "2137d37b58c19b5e1c789f6cecea5f49",
+    "HumanEval_V2.Llama3Formatter": "80758d9903b75ab60dfcd03c2500198c",
     "IFEval.ConcatFormatter": "b517d9d281cd8d5db2ea72b47bd44314",
     "IFEval.Llama3Formatter": "7739c2862af662f2b146f4eae61ac208",
     "IFEvalDe.ConcatFormatter": "798e567efa346a45b42deff904a40b22",

--- a/tests/tests_eval_framework/tasks/benchmarks/test_humaneval.py
+++ b/tests/tests_eval_framework/tasks/benchmarks/test_humaneval.py
@@ -5,7 +5,6 @@ import pytest
 from eval_framework.tasks.benchmarks.humaneval import (
     HumanEval,
     HumanEval_OLMES,
-    HumanEval_V2,
     HumanEvalBPB_V2,
     HumanEvalInstruct,
 )
@@ -84,30 +83,6 @@ class TestHumanEvalOLMES:
         fewshot_target = human_eval_olmes_task._get_fewshot_target_text(item)
         assert fewshot_target.endswith("```")
         assert fewshot_target == item["canonical_solution"] + "```"
-
-
-class TestHumanEval_V2:
-    @pytest.fixture
-    def human_eval_v2_task(self) -> HumanEval_V2:
-        with DatasetPatcher(HumanEval_V2, num_fewshot=0) as patched_task:
-            return patched_task
-
-    def test_prompt_preserves_trailing_newline(self, human_eval_v2_task: HumanEval_V2) -> None:
-        # The docstring's closing quotes must be followed by "\n" so tokenizers
-        # that weld `"""` and the newline into one token do not stall on EOS.
-        human_eval_v2_task._load_dataset(human_eval_v2_task.SUBJECTS[0])
-        for item in human_eval_v2_task.dataset[human_eval_v2_task.SAMPLE_SPLIT][:5]:
-            instruction = human_eval_v2_task._get_instruction_text(item)
-            assert instruction.startswith("```python\n")
-            assert instruction.endswith("\n")
-
-    def test_code_is_executed(self, human_eval_v2_task: HumanEval_V2) -> None:
-        assert len(human_eval_v2_task.SUBJECTS) > 0
-        human_eval_v2_task._load_dataset(human_eval_v2_task.SUBJECTS[0])
-        for i, item in enumerate(human_eval_v2_task.dataset[human_eval_v2_task.SAMPLE_SPLIT][:5]):
-            sample = human_eval_v2_task._create_samples(item, i, human_eval_v2_task.SUBJECTS[0])[0]
-            formatted_code = human_eval_v2_task.post_process_generated_completion(item["canonical_solution"], sample)
-            assert run_python_code(formatted_code).endswith("True")
 
 
 class TestHumanEvalInstructCode:

--- a/tests/tests_eval_framework/tasks/benchmarks/test_humaneval.py
+++ b/tests/tests_eval_framework/tasks/benchmarks/test_humaneval.py
@@ -2,7 +2,13 @@ from typing import Any
 
 import pytest
 
-from eval_framework.tasks.benchmarks.humaneval import HumanEval, HumanEval_OLMES, HumanEvalBPB_V2, HumanEvalInstruct
+from eval_framework.tasks.benchmarks.humaneval import (
+    HumanEval,
+    HumanEval_OLMES,
+    HumanEval_V2,
+    HumanEvalBPB_V2,
+    HumanEvalInstruct,
+)
 from eval_framework.tasks.registry import Registry
 from eval_framework.tasks.task_names import register_humaneval_tasks
 from eval_framework.tasks.utils import run_python_code
@@ -78,6 +84,30 @@ class TestHumanEvalOLMES:
         fewshot_target = human_eval_olmes_task._get_fewshot_target_text(item)
         assert fewshot_target.endswith("```")
         assert fewshot_target == item["canonical_solution"] + "```"
+
+
+class TestHumanEval_V2:
+    @pytest.fixture
+    def human_eval_v2_task(self) -> HumanEval_V2:
+        with DatasetPatcher(HumanEval_V2, num_fewshot=0) as patched_task:
+            return patched_task
+
+    def test_prompt_preserves_trailing_newline(self, human_eval_v2_task: HumanEval_V2) -> None:
+        # The docstring's closing quotes must be followed by "\n" so tokenizers
+        # that weld `"""` and the newline into one token do not stall on EOS.
+        human_eval_v2_task._load_dataset(human_eval_v2_task.SUBJECTS[0])
+        for item in human_eval_v2_task.dataset[human_eval_v2_task.SAMPLE_SPLIT][:5]:
+            instruction = human_eval_v2_task._get_instruction_text(item)
+            assert instruction.startswith("```python\n")
+            assert instruction.endswith("\n")
+
+    def test_code_is_executed(self, human_eval_v2_task: HumanEval_V2) -> None:
+        assert len(human_eval_v2_task.SUBJECTS) > 0
+        human_eval_v2_task._load_dataset(human_eval_v2_task.SUBJECTS[0])
+        for i, item in enumerate(human_eval_v2_task.dataset[human_eval_v2_task.SAMPLE_SPLIT][:5]):
+            sample = human_eval_v2_task._create_samples(item, i, human_eval_v2_task.SUBJECTS[0])[0]
+            formatted_code = human_eval_v2_task.post_process_generated_completion(item["canonical_solution"], sample)
+            assert run_python_code(formatted_code).endswith("True")
 
 
 class TestHumanEvalInstructCode:

--- a/tests/tests_template_formatting/test_formatter_eval.py
+++ b/tests/tests_template_formatting/test_formatter_eval.py
@@ -248,6 +248,21 @@ def test_never_strip_preserves_trailing_whitespace_of_final_turn() -> None:
     assert formatter.format(final_assistant_cue, output_mode="string") == "Solve this```python\n"
 
 
+def test_concat_formatter_preserve_trailing_whitespace_kwarg() -> None:
+    # Given: a ConcatFormatter opting into the trailing-whitespace preservation.
+    formatter = ConcatFormatter(preserve_trailing_whitespace=True)
+
+    # When: the final user turn ends in a load-bearing "\n" (e.g. HumanEval V2 prompt).
+    final_user_turn = [Message(role=Role.USER, content='def f():\n    """docstring"""\n')]
+
+    # Then: the newline survives formatting.
+    assert formatter.format(final_user_turn, output_mode="string") == 'def f():\n    """docstring"""\n'
+
+    # And: the default remains strip-on.
+    default_formatter = ConcatFormatter()
+    assert default_formatter.format(final_user_turn, output_mode="string") == 'def f():\n    """docstring"""'
+
+
 @pytest.mark.parametrize(
     "model_name, expected_formatter",
     [


### PR DESCRIPTION


Background: [humaneval-docstring-eos-boundary](https://expert-adventure-7pvov27.pages.github.io/latest/blog/2026/08/14/humaneval-docstring-eos-boundary/).