### PR TITLE
rework base task

### DIFF
--- a/examples/custom_tasks/benchmark_template.py
+++ b/examples/custom_tasks/benchmark_template.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from eval_framework.metrics.completion import AccuracyCompletion  # Import your metrics
 from eval_framework.tasks.base import BaseTask, ResponseType, Sample
-from eval_framework.tasks.registry import Registry
+from eval_framework.tasks.registry import Registry, register_task
 
 
 class YourBenchmarkTask(BaseTask[str]):  # Replace with your class name
@@ -116,4 +116,4 @@ class GeographyQATask(BaseTask[str]):
 
 def register_tasks(registry: Registry) -> None:
     """Entrypoint invoked by the plugin loader to register this module's tasks."""
-    registry.register(GeographyQATask)
+    register_task(GeographyQATask, registry)

--- a/examples/custom_tasks/hellaswag_local.py
+++ b/examples/custom_tasks/hellaswag_local.py
@@ -6,7 +6,7 @@ from typing import Any
 from datasets import load_dataset
 
 from eval_framework.tasks.benchmarks.hellaswag import HELLASWAG
-from eval_framework.tasks.registry import Registry
+from eval_framework.tasks.registry import Registry, register_task
 
 logger = logging.getLogger(__name__)
 
@@ -53,4 +53,4 @@ class HELLASWAG_LOCAL(HELLASWAG):
 
 def register_tasks(registry: Registry) -> None:
     """Entrypoint invoked by the plugin loader to register this module's tasks."""
-    registry.register(HELLASWAG_LOCAL)
+    register_task(HELLASWAG_LOCAL, registry)

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -1,4 +1,3 @@
-import importlib
 import logging
 import os
 import random
@@ -501,71 +500,6 @@ def resolve_overwrite_subjects[SubjectType](
             )
 
     return chosen_subjects
-
-
-class Lazy(EvalFactory):
-    """
-    Create eval from qualified class path; Delays importing modules until
-    eval is constructed.
-    """
-
-    def __init__(self, class_name: str, module: str) -> None:
-        """
-        Args:
-            class_name: The name of the task class to import.
-            module: The module to import the task class from.
-        """
-        self._class_name = class_name
-        self._module = module
-        self._loaded: type[BaseTask] | None = None
-
-    def id(self) -> str:
-        return self._class_name
-
-    def task_class(self) -> type[BaseTask]:
-        if self._loaded is None:
-            module = importlib.import_module(self._module)
-            self._loaded = getattr(module, self._class_name)
-        return self._loaded
-
-    def create(
-        self,
-        num_fewshot: int,
-        custom_subjects: list[str] | None,
-        custom_hf_revision: str | None,
-        user_prompt_suffix: str | None = None,
-        seed: int | None = None,
-    ) -> BaseTask:
-        return self.task_class().with_overwrite(
-            num_fewshot=num_fewshot,
-            custom_subjects=custom_subjects,
-            custom_hf_revision=custom_hf_revision,
-            user_prompt_suffix=user_prompt_suffix,
-            seed=seed,
-        )
-
-    def response_type(self) -> ResponseType:
-        """The eval's response type"""
-        return self.task_class().get_response_type()
-
-    def metrics(self) -> list[type["BaseMetric"]]:
-        """The eval's metrics"""
-        return self.task_class().get_metrics()
-
-    def subjects(self) -> list[Any]:
-        """The eval's subjects"""
-        return self.task_class().SUBJECTS
-
-    def display_name(self) -> str:
-        """The eval's human-readable display name (the task's ``NAME``)."""
-        return self.task_class().NAME
-
-    def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
-        try:
-            task = self.create(num_fewshot=1, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED)
-        except (TypeError, ValueError, AssertionError):
-            task = self.create(num_fewshot=0, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED)
-        return task.markdown_doc(formatters)
 
 
 class Eager(EvalFactory):

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -247,7 +247,6 @@ class BaseTask[SubjectType](Task):
 
         return render_markdown_doc(
             name=self.NAME,
-            module=type(self).__module__,
             dataset_path=dataset_path,
             sample_split=getattr(self, "SAMPLE_SPLIT", None),
             fewshot_split=getattr(self, "FEWSHOT_SPLIT", None),

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 import os
 import random
@@ -13,7 +14,7 @@ from datasets import DatasetDict, DownloadConfig, load_dataset
 from eval_framework.shared.types import BaseMetricContext, Completion, Error, RawCompletion
 from eval_framework.tasks.dataset_revisions import pinned_revision
 from eval_framework.tasks.markdown_doc import markdown_doc as render_markdown_doc
-from eval_framework.tasks.task import ResponseType, Sample, Task
+from eval_framework.tasks.task import EvalFactory, ResponseType, Sample, Task
 from eval_framework.tasks.utils import classproperty, raise_errors
 from template_formatting.formatter import BaseFormatter, Message, Role
 
@@ -501,3 +502,125 @@ def resolve_overwrite_subjects[SubjectType](
             )
 
     return chosen_subjects
+
+
+class Lazy(EvalFactory):
+    """
+    Create eval from qualified class path; Delays importing modules until
+    eval is constructed.
+    """
+
+    def __init__(self, class_name: str, module: str) -> None:
+        """
+        Args:
+            class_name: The name of the task class to import.
+            module: The module to import the task class from.
+        """
+        self._class_name = class_name
+        self._module = module
+        self._loaded: type[BaseTask] | None = None
+
+    @property
+    def source_module(self) -> str:
+        return self._module
+
+    def id(self) -> str:
+        return self._class_name
+
+    def task_class(self) -> type[BaseTask]:
+        if self._loaded is None:
+            module = importlib.import_module(self._module)
+            self._loaded = getattr(module, self._class_name)
+        return self._loaded
+
+    def create(
+        self,
+        num_fewshot: int,
+        custom_subjects: list[str] | None,
+        custom_hf_revision: str | None,
+        user_prompt_suffix: str | None = None,
+        seed: int | None = None,
+    ) -> BaseTask:
+        return self.task_class().with_overwrite(
+            num_fewshot=num_fewshot,
+            custom_subjects=custom_subjects,
+            custom_hf_revision=custom_hf_revision,
+            user_prompt_suffix=user_prompt_suffix,
+            seed=seed,
+        )
+
+    def response_type(self) -> ResponseType:
+        """The eval's response type"""
+        return self.task_class().get_response_type()
+
+    def metrics(self) -> list[type["BaseMetric"]]:
+        """The eval's metrics"""
+        return self.task_class().get_metrics()
+
+    def subjects(self) -> list[Any]:
+        """The eval's subjects"""
+        return self.task_class().SUBJECTS
+
+    def display_name(self) -> str:
+        """The eval's human-readable display name (the task's ``NAME``)."""
+        return self.task_class().NAME
+
+    def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
+        try:
+            task = self.create(num_fewshot=1, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED)
+        except (TypeError, ValueError, AssertionError):
+            task = self.create(num_fewshot=0, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED)
+        return task.markdown_doc(formatters)
+
+
+class Eager(EvalFactory):
+    """Wraps an already-imported task class."""
+
+    def __init__(self, task: type[BaseTask]) -> None:
+        self._task = task
+
+    @property
+    def source_module(self) -> str:
+        return self._task.__module__
+
+    def id(self) -> str:
+        return self._task.__name__
+
+    def create(
+        self,
+        num_fewshot: int,
+        custom_subjects: list[str] | None,
+        custom_hf_revision: str | None,
+        user_prompt_suffix: str | None = None,
+        seed: int | None = None,
+    ) -> BaseTask:
+        return self._task.with_overwrite(
+            num_fewshot=num_fewshot,
+            custom_subjects=custom_subjects,
+            custom_hf_revision=custom_hf_revision,
+            user_prompt_suffix=user_prompt_suffix,
+            seed=seed,
+        )
+
+    def response_type(self) -> ResponseType:
+        """The eval's response type"""
+        return self._task.get_response_type()
+
+    def metrics(self) -> list[type["BaseMetric"]]:
+        """The eval's metrics"""
+        return self._task.get_metrics()
+
+    def subjects(self) -> list[Any]:
+        """The eval's subjects"""
+        return self._task.SUBJECTS
+
+    def display_name(self) -> str:
+        """The eval's human-readable display name (the task's ``NAME``)."""
+        return self._task.NAME
+
+    def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
+        try:
+            task = self.create(num_fewshot=1, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED)
+        except (TypeError, ValueError, AssertionError):
+            task = self.create(num_fewshot=0, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED)
+        return task.markdown_doc(formatters)

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -520,10 +520,6 @@ class Lazy(EvalFactory):
         self._module = module
         self._loaded: type[BaseTask] | None = None
 
-    @property
-    def source_module(self) -> str:
-        return self._module
-
     def id(self) -> str:
         return self._class_name
 
@@ -578,10 +574,6 @@ class Eager(EvalFactory):
 
     def __init__(self, task: type[BaseTask]) -> None:
         self._task = task
-
-    @property
-    def source_module(self) -> str:
-        return self._task.__module__
 
     def id(self) -> str:
         return self._task.__name__

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -2,7 +2,6 @@ import logging
 import os
 import random
 import traceback
-from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from enum import Enum
 from pathlib import Path
@@ -10,11 +9,11 @@ from typing import TYPE_CHECKING, Any, Self, TypeVar
 
 import iso639
 from datasets import DatasetDict, DownloadConfig, load_dataset
-from pydantic import BaseModel, ConfigDict
 
 from eval_framework.shared.types import BaseMetricContext, Completion, Error, RawCompletion
 from eval_framework.tasks.dataset_revisions import pinned_revision
 from eval_framework.tasks.markdown_doc import markdown_doc as render_markdown_doc
+from eval_framework.tasks.task import ResponseType, Sample, Task
 from eval_framework.tasks.utils import classproperty, raise_errors
 from template_formatting.formatter import BaseFormatter, Message, Role
 
@@ -24,11 +23,6 @@ if TYPE_CHECKING:
 
 RANDOM_SEED = 42
 NO_SUBJECT = "no_subject"
-
-
-class ResponseType(Enum):
-    COMPLETION = "completion"
-    LOGLIKELIHOODS = "loglikelihoods"
 
 
 class TaskStyle(Enum):
@@ -71,49 +65,9 @@ for language in iso639.ALL_LANGUAGES:
 Language: type[Enum] = Language.add_members(languages)  # type: ignore[no-redef]
 
 
-class Sample(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-    id: int
-    subject: str
-    messages: list[Message]
-    ground_truth: str | list[str] | None
-    possible_completions: list[str] | None
-    context: BaseMetricContext | list[BaseMetricContext] | None = None
-
-
 SubjectType = TypeVar("SubjectType")
 
 logger = logging.getLogger(__name__)
-
-
-class Task(ABC):
-    """The contract a caller relies on to run an evaluation"""
-
-    @abstractmethod
-    def iterate_samples(self, num_samples: int | None = None) -> Iterable[Sample]: ...
-
-    @abstractmethod
-    def generate_completions(
-        self,
-        llm: "BaseLLM",
-        samples: list[Sample],
-        stop_sequences: list[str] | None = None,
-        max_tokens: int | None = None,
-        fail_on_error: bool = True,
-    ) -> list[Completion]:
-        """Run ``llm`` over ``samples`` and return their completions."""
-
-    @abstractmethod
-    def get_metadata(self) -> dict[str, str | list[str]]:
-        """Descriptive metadata about the eval for result reporting."""
-
-    @abstractmethod
-    def get_response_type(self) -> ResponseType: ...
-
-    @abstractmethod
-    def display_name(self) -> str:
-        """Human-readable display name. Is allowed to have special characters and whitespaces."""
-        ...
 
 
 class BaseTask[SubjectType](Task):

--- a/src/eval_framework/tasks/lazy.py
+++ b/src/eval_framework/tasks/lazy.py
@@ -1,0 +1,56 @@
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any
+
+from eval_framework.tasks.task import EvalFactory, ResponseType, Task
+from template_formatting.formatter import BaseFormatter
+
+if TYPE_CHECKING:
+    from eval_framework.metrics.base import BaseMetric
+
+
+class Lazy(EvalFactory):
+    """An ``EvalFactory`` that defers producing the real factory until first use.
+
+    Holds an ``id`` and a ``load`` thunk returning the wrapped ``EvalFactory``; every
+    other call is delegated to that factory, which is built (and memoized) on first
+    access. This keeps ``Lazy`` independent of any concrete task type — the thunk owns
+    whatever loading (e.g. importing a module) the wrapped factory requires.
+    """
+
+    def __init__(self, id: str, load: Callable[[], EvalFactory]) -> None:
+        self._id = id
+        self._load = load
+        self._factory: EvalFactory | None = None
+
+    def _loaded_factory(self) -> EvalFactory:
+        if self._factory is None:
+            self._factory = self._load()
+        return self._factory
+
+    def id(self) -> str:
+        return self._id
+
+    def create(
+        self,
+        num_fewshot: int,
+        custom_subjects: list[str] | None,
+        custom_hf_revision: str | None,
+        user_prompt_suffix: str | None = None,
+        seed: int | None = None,
+    ) -> Task:
+        return self._loaded_factory().create(num_fewshot, custom_subjects, custom_hf_revision, user_prompt_suffix, seed)
+
+    def response_type(self) -> ResponseType:
+        return self._loaded_factory().response_type()
+
+    def metrics(self) -> list[type["BaseMetric"]]:
+        return self._loaded_factory().metrics()
+
+    def subjects(self) -> list[Any]:
+        return self._loaded_factory().subjects()
+
+    def display_name(self) -> str:
+        return self._loaded_factory().display_name()
+
+    def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
+        return self._loaded_factory().markdown_doc(formatters)

--- a/src/eval_framework/tasks/markdown_doc.py
+++ b/src/eval_framework/tasks/markdown_doc.py
@@ -8,7 +8,6 @@ from template_formatting.formatter import BaseFormatter, Message
 def markdown_doc(
     *,
     name: str,
-    module: str,
     dataset_path: str | None,
     sample_split: str | None,
     fewshot_split: str | None,
@@ -43,8 +42,6 @@ def markdown_doc(
     if language is not None:
         buf.write(f"LANGUAGE = {language!r}".strip() + "\n")
     buf.write("````\n\n")
-
-    buf.write(f"- Module: `{module}`\n\n")
 
     if http_path:
         buf.write(f"- Link to dataset: [{http_path}]({http_path})\n")

--- a/src/eval_framework/tasks/registry.py
+++ b/src/eval_framework/tasks/registry.py
@@ -1,10 +1,12 @@
 import contextlib
+import importlib
 import re
 import warnings
 from collections.abc import Generator, Iterator
 from typing import Any
 
-from eval_framework.tasks.base import BaseTask, Eager, Lazy
+from eval_framework.tasks.base import BaseTask, Eager
+from eval_framework.tasks.lazy import Lazy
 from eval_framework.tasks.task import EvalFactory
 
 __all__ = [
@@ -153,5 +155,10 @@ def register_lazy_task(class_path: str, /, registry: Registry | None = None) -> 
             "`eval_framework.tasks.benchmarks.mmlu.MMLU`): "
         )
     r = registry if registry is not None else _REGISTRY
-    base_module, class_name = class_path.rsplit(".", maxsplit=1)
-    r.add(Lazy(class_name=class_name, module=base_module))
+    module_path, class_name = class_path.rsplit(".", maxsplit=1)
+
+    def load() -> EvalFactory:
+        module = importlib.import_module(module_path)
+        return Eager(getattr(module, class_name))
+
+    r.add(Lazy(id=class_name, load=load))

--- a/src/eval_framework/tasks/registry.py
+++ b/src/eval_framework/tasks/registry.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 
-from eval_framework.tasks.base import RANDOM_SEED, BaseTask, ResponseType
+from eval_framework.tasks.base import RANDOM_SEED, BaseTask, ResponseType, Task
 from template_formatting.formatter import BaseFormatter
 
 if TYPE_CHECKING:
@@ -66,7 +66,7 @@ class EvalFactory(ABC):
         custom_hf_revision: str | None,
         user_prompt_suffix: str | None = None,
         seed: int | None = None,
-    ) -> BaseTask: ...
+    ) -> Task: ...
 
     @abstractmethod
     def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:

--- a/src/eval_framework/tasks/registry.py
+++ b/src/eval_framework/tasks/registry.py
@@ -1,6 +1,7 @@
 import contextlib
 import importlib
 import re
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterator, Sequence
 from typing import TYPE_CHECKING, Any
@@ -16,6 +17,8 @@ __all__ = [
     "register_task",
     "register_lazy_task",
     "EvalFactory",
+    "Eager",
+    "Lazy",
     "Registry",
     "with_registry",
     "is_registered",
@@ -75,7 +78,7 @@ class EvalFactory(ABC):
         ...
 
 
-class _Lazy(EvalFactory):
+class Lazy(EvalFactory):
     """
     Create eval from qualified class path; Delays importing modules until
     eval is constructed.
@@ -144,7 +147,7 @@ class _Lazy(EvalFactory):
         return task.markdown_doc(formatters)
 
 
-class _Eager(EvalFactory):
+class Eager(EvalFactory):
     """Wraps an already-imported task class."""
 
     def __init__(self, task: type[BaseTask]) -> None:
@@ -246,22 +249,30 @@ class Registry:
         self._registry[task_key] = factory
 
     def register(self, task: type[BaseTask]) -> str:
-        """The class name is used as the task name."""
-        if not issubclass(task, BaseTask):
-            raise ValueError(f"Can only register subclasses of BaseTask, got {task}")
-        factory = _Eager(task)
-        self.add(factory)
-        return factory.id()
+        """Register a task class. The class name is used as the task name.
+
+        .. deprecated::
+            Use :func:`register_task` (``register_task(task, registry)``) instead.
+        """
+        warnings.warn(
+            "Registry.register is deprecated; use register_task(task, registry) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return register_task(task, registry=self)
 
     def register_lazy(self, class_path: str, /) -> None:
-        """Register a task by its dotted class path, without importing its module."""
-        if "." not in class_path:
-            raise ValueError(
-                f"Invalid class path `{class_path}`. This needs to be a global path like "
-                "`eval_framework.tasks.benchmarks.mmlu.MMLU`): "
-            )
-        base_module, class_name = class_path.rsplit(".", maxsplit=1)
-        self.add(_Lazy(class_name=class_name, module=base_module))
+        """Register a task by its dotted class path, without importing its module.
+
+        .. deprecated::
+            Use :func:`register_lazy_task` (``register_lazy_task(class_path, registry)``) instead.
+        """
+        warnings.warn(
+            "Registry.register_lazy is deprecated; use register_lazy_task(class_path, registry) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        register_lazy_task(class_path, registry=self)
 
 
 _REGISTRY = Registry()
@@ -300,12 +311,26 @@ def validate_task_name(name: str) -> str:
     return name
 
 
-def register_task(task: type[BaseTask]) -> str:
-    """The class name is used as the task name."""
-    return registry().register(task)
+def register_task(task: type[BaseTask], registry: Registry | None = None) -> str:
+    """Register ``task`` into ``registry`` (the global registry by default).
+
+    The class name is used as the task name.
+    """
+    if not issubclass(task, BaseTask):
+        raise ValueError(f"Can only register subclasses of BaseTask, got {task}")
+    r = registry if registry is not None else _REGISTRY
+    factory = Eager(task)
+    r.add(factory)
+    return factory.id()
 
 
 def register_lazy_task(class_path: str, /, registry: Registry | None = None) -> None:
     """Register a task by its dotted class path, without importing its module."""
+    if "." not in class_path:
+        raise ValueError(
+            f"Invalid class path `{class_path}`. This needs to be a global path like "
+            "`eval_framework.tasks.benchmarks.mmlu.MMLU`): "
+        )
     r = registry if registry is not None else _REGISTRY
-    r.register_lazy(class_path)
+    base_module, class_name = class_path.rsplit(".", maxsplit=1)
+    r.add(Lazy(class_name=class_name, module=base_module))

--- a/src/eval_framework/tasks/registry.py
+++ b/src/eval_framework/tasks/registry.py
@@ -2,12 +2,11 @@ import contextlib
 import importlib
 import re
 import warnings
-from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 
 from eval_framework.tasks.base import RANDOM_SEED, BaseTask
-from eval_framework.tasks.task import ResponseType, Task
+from eval_framework.tasks.task import EvalFactory, ResponseType
 from template_formatting.formatter import BaseFormatter
 
 if TYPE_CHECKING:
@@ -25,57 +24,6 @@ __all__ = [
     "validate_task_name",
     "registered_task_names",
 ]
-
-
-class EvalFactory(ABC):
-    """Produces a registered benchmark's eval.
-
-    The registry stores one factory per eval. This allows the factory to be
-    constructed without constructing all evals. Going via this ABC allows
-    the factory instances to contain state specifically relevant to the
-    eval, as well as supporting different strategies for instantiating it.
-    E.g. eager vs lazy loading of the required dependencies.
-    """
-
-    @abstractmethod
-    def id(self) -> str:
-        "Canonical key used to register this benchmark"
-
-    @property
-    @abstractmethod
-    def source_module(self) -> str:
-        """Module the task class is defined in, resolvable without importing it."""
-
-    @abstractmethod
-    def response_type(self) -> ResponseType:
-        """The eval's response type"""
-
-    @abstractmethod
-    def metrics(self) -> list[type["BaseMetric"]]:
-        """The eval's metrics"""
-
-    @abstractmethod
-    def subjects(self) -> list[Any]:
-        """The eval's subjects"""
-
-    @abstractmethod
-    def display_name(self) -> str:
-        """Human-readable display name. Is allowed to have special characters and whitespaces."""
-
-    @abstractmethod
-    def create(
-        self,
-        num_fewshot: int,
-        custom_subjects: list[str] | None,
-        custom_hf_revision: str | None,
-        user_prompt_suffix: str | None = None,
-        seed: int | None = None,
-    ) -> Task: ...
-
-    @abstractmethod
-    def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
-        """Render the eval's documentation as markdown."""
-        ...
 
 
 class Lazy(EvalFactory):

--- a/src/eval_framework/tasks/registry.py
+++ b/src/eval_framework/tasks/registry.py
@@ -1,16 +1,11 @@
 import contextlib
-import importlib
 import re
 import warnings
-from collections.abc import Generator, Iterator, Sequence
-from typing import TYPE_CHECKING, Any
+from collections.abc import Generator, Iterator
+from typing import Any
 
-from eval_framework.tasks.base import RANDOM_SEED, BaseTask
-from eval_framework.tasks.task import EvalFactory, ResponseType
-from template_formatting.formatter import BaseFormatter
-
-if TYPE_CHECKING:
-    from eval_framework.metrics.base import BaseMetric
+from eval_framework.tasks.base import BaseTask, Eager, Lazy
+from eval_framework.tasks.task import EvalFactory
 
 __all__ = [
     "register_task",
@@ -24,128 +19,6 @@ __all__ = [
     "validate_task_name",
     "registered_task_names",
 ]
-
-
-class Lazy(EvalFactory):
-    """
-    Create eval from qualified class path; Delays importing modules until
-    eval is constructed.
-    """
-
-    def __init__(self, class_name: str, module: str) -> None:
-        """
-        Args:
-            class_name: The name of the task class to import.
-            module: The module to import the task class from.
-        """
-        self._class_name = class_name
-        self._module = module
-        self._loaded: type[BaseTask] | None = None
-
-    @property
-    def source_module(self) -> str:
-        return self._module
-
-    def id(self) -> str:
-        return self._class_name
-
-    def task_class(self) -> type[BaseTask]:
-        if self._loaded is None:
-            module = importlib.import_module(self._module)
-            self._loaded = getattr(module, self._class_name)
-        return self._loaded
-
-    def create(
-        self,
-        num_fewshot: int,
-        custom_subjects: list[str] | None,
-        custom_hf_revision: str | None,
-        user_prompt_suffix: str | None = None,
-        seed: int | None = None,
-    ) -> BaseTask:
-        return self.task_class().with_overwrite(
-            num_fewshot=num_fewshot,
-            custom_subjects=custom_subjects,
-            custom_hf_revision=custom_hf_revision,
-            user_prompt_suffix=user_prompt_suffix,
-            seed=seed,
-        )
-
-    def response_type(self) -> ResponseType:
-        """The eval's response type"""
-        return self.task_class().get_response_type()
-
-    def metrics(self) -> list[type["BaseMetric"]]:
-        """The eval's metrics"""
-        return self.task_class().get_metrics()
-
-    def subjects(self) -> list[Any]:
-        """The eval's subjects"""
-        return self.task_class().SUBJECTS
-
-    def display_name(self) -> str:
-        """The eval's human-readable display name (the task's ``NAME``)."""
-        return self.task_class().NAME
-
-    def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
-        try:
-            task = self.create(num_fewshot=1, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED)
-        except (TypeError, ValueError, AssertionError):
-            task = self.create(num_fewshot=0, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED)
-        return task.markdown_doc(formatters)
-
-
-class Eager(EvalFactory):
-    """Wraps an already-imported task class."""
-
-    def __init__(self, task: type[BaseTask]) -> None:
-        self._task = task
-
-    @property
-    def source_module(self) -> str:
-        return self._task.__module__
-
-    def id(self) -> str:
-        return self._task.__name__
-
-    def create(
-        self,
-        num_fewshot: int,
-        custom_subjects: list[str] | None,
-        custom_hf_revision: str | None,
-        user_prompt_suffix: str | None = None,
-        seed: int | None = None,
-    ) -> BaseTask:
-        return self._task.with_overwrite(
-            num_fewshot=num_fewshot,
-            custom_subjects=custom_subjects,
-            custom_hf_revision=custom_hf_revision,
-            user_prompt_suffix=user_prompt_suffix,
-            seed=seed,
-        )
-
-    def response_type(self) -> ResponseType:
-        """The eval's response type"""
-        return self._task.get_response_type()
-
-    def metrics(self) -> list[type["BaseMetric"]]:
-        """The eval's metrics"""
-        return self._task.get_metrics()
-
-    def subjects(self) -> list[Any]:
-        """The eval's subjects"""
-        return self._task.SUBJECTS
-
-    def display_name(self) -> str:
-        """The eval's human-readable display name (the task's ``NAME``)."""
-        return self._task.NAME
-
-    def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
-        try:
-            task = self.create(num_fewshot=1, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED)
-        except (TypeError, ValueError, AssertionError):
-            task = self.create(num_fewshot=0, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED)
-        return task.markdown_doc(formatters)
 
 
 class Registry:

--- a/src/eval_framework/tasks/registry.py
+++ b/src/eval_framework/tasks/registry.py
@@ -5,7 +5,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 
-from eval_framework.tasks.base import RANDOM_SEED, BaseTask, ResponseType, Task
+from eval_framework.tasks.base import RANDOM_SEED, BaseTask
+from eval_framework.tasks.task import ResponseType, Task
 from template_formatting.formatter import BaseFormatter
 
 if TYPE_CHECKING:

--- a/src/eval_framework/tasks/task.py
+++ b/src/eval_framework/tasks/task.py
@@ -1,15 +1,16 @@
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict
 
 from eval_framework.shared.types import BaseMetricContext, Completion
-from template_formatting.formatter import Message
+from template_formatting.formatter import BaseFormatter, Message
 
 if TYPE_CHECKING:
     from eval_framework.llm.base import BaseLLM
+    from eval_framework.metrics.base import BaseMetric
 
 
 class ResponseType(Enum):
@@ -54,4 +55,55 @@ class Task(ABC):
     @abstractmethod
     def display_name(self) -> str:
         """Human-readable display name. Is allowed to have special characters and whitespaces."""
+        ...
+
+
+class EvalFactory(ABC):
+    """Produces a registered benchmark's eval.
+
+    The registry stores one factory per eval. This allows the factory to be
+    constructed without constructing all evals. Going via this ABC allows
+    the factory instances to contain state specifically relevant to the
+    eval, as well as supporting different strategies for instantiating it.
+    E.g. eager vs lazy loading of the required dependencies.
+    """
+
+    @abstractmethod
+    def id(self) -> str:
+        "Canonical key used to register this benchmark"
+
+    @property
+    @abstractmethod
+    def source_module(self) -> str:
+        """Module the task class is defined in, resolvable without importing it."""
+
+    @abstractmethod
+    def response_type(self) -> ResponseType:
+        """The eval's response type"""
+
+    @abstractmethod
+    def metrics(self) -> list[type["BaseMetric"]]:
+        """The eval's metrics"""
+
+    @abstractmethod
+    def subjects(self) -> list[Any]:
+        """The eval's subjects"""
+
+    @abstractmethod
+    def display_name(self) -> str:
+        """Human-readable display name. Is allowed to have special characters and whitespaces."""
+
+    @abstractmethod
+    def create(
+        self,
+        num_fewshot: int,
+        custom_subjects: list[str] | None,
+        custom_hf_revision: str | None,
+        user_prompt_suffix: str | None = None,
+        seed: int | None = None,
+    ) -> Task: ...
+
+    @abstractmethod
+    def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
+        """Render the eval's documentation as markdown."""
         ...

--- a/src/eval_framework/tasks/task.py
+++ b/src/eval_framework/tasks/task.py
@@ -72,11 +72,6 @@ class EvalFactory(ABC):
     def id(self) -> str:
         "Canonical key used to register this benchmark"
 
-    @property
-    @abstractmethod
-    def source_module(self) -> str:
-        """Module the task class is defined in, resolvable without importing it."""
-
     @abstractmethod
     def response_type(self) -> ResponseType:
         """The eval's response type"""

--- a/src/eval_framework/tasks/task.py
+++ b/src/eval_framework/tasks/task.py
@@ -1,0 +1,57 @@
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict
+
+from eval_framework.shared.types import BaseMetricContext, Completion
+from template_formatting.formatter import Message
+
+if TYPE_CHECKING:
+    from eval_framework.llm.base import BaseLLM
+
+
+class ResponseType(Enum):
+    COMPLETION = "completion"
+    LOGLIKELIHOODS = "loglikelihoods"
+
+
+class Sample(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    id: int
+    subject: str
+    messages: list[Message]
+    ground_truth: str | list[str] | None
+    possible_completions: list[str] | None
+    context: BaseMetricContext | list[BaseMetricContext] | None = None
+
+
+class Task(ABC):
+    """The contract a caller relies on to run an evaluation"""
+
+    @abstractmethod
+    def iterate_samples(self, num_samples: int | None = None) -> Iterable[Sample]: ...
+
+    @abstractmethod
+    def generate_completions(
+        self,
+        llm: "BaseLLM",
+        samples: list[Sample],
+        stop_sequences: list[str] | None = None,
+        max_tokens: int | None = None,
+        fail_on_error: bool = True,
+    ) -> list[Completion]:
+        """Run ``llm`` over ``samples`` and return their completions."""
+
+    @abstractmethod
+    def get_metadata(self) -> dict[str, str | list[str]]:
+        """Descriptive metadata about the eval for result reporting."""
+
+    @abstractmethod
+    def get_response_type(self) -> ResponseType: ...
+
+    @abstractmethod
+    def display_name(self) -> str:
+        """Human-readable display name. Is allowed to have special characters and whitespaces."""
+        ...

--- a/tests/tests_eval_framework/tasks/test_markdown_doc.py
+++ b/tests/tests_eval_framework/tasks/test_markdown_doc.py
@@ -12,7 +12,6 @@ class ExampleFormatter:
 def test_markdown_doc_with_examples() -> None:
     doc = markdown_doc(
         name="MyTask",
-        module="eval_framework.tasks.benchmarks.mytask",
         dataset_path=None,
         sample_split="test",
         fewshot_split="train",
@@ -41,8 +40,6 @@ RESPONSE_TYPE = COMPLETION
 METRICS = [Accuracy, F1]
 SUBJECTS = ['no_subject']
 ````
-
-- Module: `eval_framework.tasks.benchmarks.mytask`
 
 - `test` has 3 samples
 
@@ -73,7 +70,6 @@ SUBJECTS = ['no_subject']
 def test_markdown_doc_with_dataset_link() -> None:
     doc = markdown_doc(
         name="MyTask",
-        module="eval_framework.tasks.benchmarks.mytask",
         dataset_path="datasets/mytask",
         sample_split="test",
         fewshot_split="train",
@@ -103,8 +99,6 @@ RESPONSE_TYPE = COMPLETION
 METRICS = [Accuracy, F1]
 SUBJECTS = ['no_subject']
 ````
-
-- Module: `eval_framework.tasks.benchmarks.mytask`
 
 - Link to dataset: [https://huggingface.co/datasets/datasets/mytask](https://huggingface.co/datasets/datasets/mytask)
 """

--- a/tests/tests_eval_framework/tasks/test_registry.py
+++ b/tests/tests_eval_framework/tasks/test_registry.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 import pytest
 
 from eval_framework.tasks.benchmarks.math_reasoning import MATH, MATHLvl5
-from eval_framework.tasks.registry import Registry, with_registry
+from eval_framework.tasks.registry import Registry, register_lazy_task, register_task, with_registry
 
 
 def temporary_registry[**P, T](fun: Callable[P, T]) -> Callable[P, T]:
@@ -22,7 +22,7 @@ def temporary_registry[**P, T](fun: Callable[P, T]) -> Callable[P, T]:
 def test_case_insensitive_lookup() -> None:
     registry = Registry()
 
-    registry.register(MATH)
+    register_task(MATH, registry)
 
     assert "MATH" in registry
     assert set(registry.task_names()) == {"MATH"}
@@ -30,7 +30,7 @@ def test_case_insensitive_lookup() -> None:
     assert registry["Math"].id() == MATH.__name__
     assert registry["math"].id() == MATH.__name__
 
-    registry.register(MATHLvl5)
+    register_task(MATHLvl5, registry)
     assert set(registry.task_names()) == {"MATH", "MATHLvl5"}
     assert registry["math lvl 5"].id() == MATHLvl5.__name__
     assert registry["MATH LVL 5"].id() == MATHLvl5.__name__
@@ -46,26 +46,38 @@ def test_register_non_task() -> None:
     registry = Registry()
 
     with pytest.raises(ValueError):
-        registry.register(int)  # type: ignore[arg-type]
+        register_task(int, registry=registry)  # type: ignore[arg-type]
 
     class MyTask:
         pass
 
     with pytest.raises(ValueError):
-        registry.register(MyTask)  # type: ignore[arg-type]
+        register_task(MyTask, registry=registry)  # type: ignore[arg-type]
 
 
 def test_lazy_registration() -> None:
     registry = Registry()
-    registry.register_lazy(f"{MATH.__module__}.{MATH.__name__}")
+    register_lazy_task(f"{MATH.__module__}.{MATH.__name__}", registry=registry)
     assert registry["Math"].display_name() == MATH.NAME
 
 
 def test_subjects() -> None:
     registry = Registry()
-    registry.register(MATH)
+    register_task(MATH, registry)
     assert registry["MATH"].subjects() == MATH.SUBJECTS
 
     registry = Registry()
-    registry.register_lazy(f"{MATH.__module__}.{MATH.__name__}")
+    register_lazy_task(f"{MATH.__module__}.{MATH.__name__}", registry=registry)
     assert registry["Math"].subjects() == MATH.SUBJECTS
+
+
+def test_deprecated_register_methods_warn() -> None:
+    registry = Registry()
+    with pytest.warns(DeprecationWarning):
+        registry.register(MATH)
+    assert registry["MATH"].id() == MATH.__name__
+
+    registry = Registry()
+    with pytest.warns(DeprecationWarning):
+        registry.register_lazy(f"{MATHLvl5.__module__}.{MATHLvl5.__name__}")
+    assert registry["MATHLvl5"].subjects() == MATHLvl5.SUBJECTS

--- a/tests/tests_eval_framework/test_user_task_registration.py
+++ b/tests/tests_eval_framework/test_user_task_registration.py
@@ -5,7 +5,7 @@ from eval_framework.tasks.task_loader import load_extra_tasks, load_modules_from
 
 TASK1 = """\
 from eval_framework.tasks.base import BaseTask, Language
-from eval_framework.tasks.registry import Registry
+from eval_framework.tasks.registry import Registry, register_task
 
 class MyCustomTask(BaseTask):
     NAME = "MyCustomTask"
@@ -18,12 +18,12 @@ class MyCustomTask(BaseTask):
     LANGUAGE = Language.ENG
 
 def register_tasks(registry: Registry) -> None:
-    registry.register(MyCustomTask)
+    register_task(MyCustomTask, registry)
 """
 
 TASK2 = """\
 from eval_framework.tasks.base import BaseTask, Language
-from eval_framework.tasks.registry import Registry
+from eval_framework.tasks.registry import Registry, register_task
 
 class MySecondCustomTask(BaseTask):
     NAME = "MySecondCustomTask"
@@ -36,7 +36,7 @@ class MySecondCustomTask(BaseTask):
     LANGUAGE = Language.ENG
 
 def register_tasks(registry: Registry) -> None:
-    registry.register(MySecondCustomTask)
+    register_task(MySecondCustomTask, registry)
 """
 
 


### PR DESCRIPTION
- **refactor: EvalFactory return Task instead of BaseTask**
- **refactor: Task extracted into its own module**
- **chore: registry.register and register_lazy method are deprecated**
- **refactor: EvalFactory now defined in task.py**
- **refactor: lazy and eager both defined in base.py rather than register.py**
- **refactor: source_module removed from EvalFactory**
- **docs: Module name removed from documenation**
- **refactor: Lazy factory now independent of BaseTask**
