### PR TITLE
feat: make unavailable metrics always return nan rather than none

### DIFF
--- a/src/eval_framework/evaluation_generator.py
+++ b/src/eval_framework/evaluation_generator.py
@@ -168,7 +168,7 @@ class EvaluationGenerator:
 
                         group_key_subject_mean = group_error_free.groupby(["key", "subject"]).mean()
                         value = float(group_key_subject_mean[["value"]].mean()["value"])
-                        aggregated_results[f"Average {metric} - {name[0]}"] = value if not math.isnan(value) else None
+                        aggregated_results[f"Average {metric} - {name[0]}"] = value
 
                         if group_error_free_ratio < 1.0:
                             # Treat error samples (with value=None) as 0 for the "including errors" average
@@ -182,9 +182,7 @@ class EvaluationGenerator:
                                 "value"
                             ].mean()
                             value_with_errors = float(group_key_subject_mean_with_errors.mean())
-                            aggregated_results[f"Average {metric} (including Errors) - {name[0]}"] = (
-                                value_with_errors if not math.isnan(value_with_errors) else None
-                            )
+                            aggregated_results[f"Average {metric} (including Errors) - {name[0]}"] = value_with_errors
 
                         if not ("SequencePositions" in metric or "Bytes" in metric):
                             # calculate standard error for selected  metrics
@@ -193,7 +191,7 @@ class EvaluationGenerator:
                             num_samples = len(group_error_free)
 
                             if math.isnan(std) or num_samples == 0:
-                                aggregated_results[f"StdErr {metric} - {name[0]}"] = None
+                                aggregated_results[f"StdErr {metric} - {name[0]}"] = float("nan")
                             else:
                                 aggregated_results[f"StdErr {metric} - {name[0]}"] = std / np.sqrt(num_samples)
                             aggregated_results[f"NumSamples {metric} - {name[0]}"] = num_samples
@@ -210,7 +208,7 @@ class EvaluationGenerator:
                     # where variance_i is the variance of each group and i is the number of groups
                     # (the combined mean is also not weighted by the number of samples)
                     if math.isnan(std) or std_err_mean_total_num_samples == 0:
-                        aggregated_results[f"StdErr {metric}"] = None
+                        aggregated_results[f"StdErr {metric}"] = float("nan")
                     else:
                         aggregated_results[f"StdErr {metric}"] = np.sqrt(
                             std_err_mean_sum_of_squares / std_err_mean_num_subjects
@@ -222,7 +220,7 @@ class EvaluationGenerator:
                     std = float(key_subject_std[["value"]].mean()["value"])
                     num_samples = len(data_subset_error_free)
                     if math.isnan(std) or num_samples == 0:
-                        aggregated_results[f"StdErr {metric}"] = None
+                        aggregated_results[f"StdErr {metric}"] = float("nan")
                     else:
                         aggregated_results[f"StdErr {metric}"] = std / np.sqrt(num_samples)
                     aggregated_results[f"NumSamples {metric}"] = num_samples

--- a/tests/tests_eval_framework/test_evaluation_generator.py
+++ b/tests/tests_eval_framework/test_evaluation_generator.py
@@ -203,58 +203,63 @@ def test_aggregate_results(tmp_path: Path) -> None:
 
     aggregated_results = evaluator._aggregate_results(results)
 
-    assert aggregated_results == {
-        "Average metric1": 2.0,  # mean of all key-subject pairs (3.0, 4.0, 1.0, 0.0)
-        "Average metric1 (including Errors)": 1.8125,  # errors treated as 0: (2.25, 1.0, 4.0, 0.0)
-        "Average metric1 - key1": 3.5,  # mean of means of subjects (3.0 and 4.0)
-        "Average metric1 (including Errors) - key1": 3.125,  # errors as 0: (2.25, 4.0)
-        "Average metric1 - key2": 0.5,
-        "Average metric1 (including Errors) - key2": 0.5,  # errors as 0: (1.0, 0.0)
-        "Average metric1 - subject1": 2.0,  # mean of means of keys (3.0 and 1.0)
-        "Average metric1 (including Errors) - subject1": 1.625,  # errors as 0: (2.25, 1.0)
-        "Average metric1 - subject2": 2.0,
-        "Average metric1 (including Errors) - subject2": 2.0,  # errors as 0: (4.0, 0.0)
-        "Average metric2": 3.0,  # NaNs are skipped in the mean calculation
-        "Average metric2 - subject1": 3.0,
-        "Average metric2 - subject2": None,  # NaN appears
-        # key in metric2 is not output because it's just a single submetric
-        "Average metric3": 19.0,  # key=None case works
-        "Average metric3 - subject1": 20.0,
-        "Average metric3 - subject2": 18.0,
-        "ErrorFreeRatio metric1": 0.8,
-        "ErrorFreeRatio metric1 - key1": 0.8,
-        "ErrorFreeRatio metric1 - key2": 0.8,
-        "ErrorFreeRatio metric1 - subject1": 0.8571428571428571,
-        "ErrorFreeRatio metric1 - subject2": 0.6666666666666666,
-        "ErrorFreeRatio metric2": 1.0,
-        "ErrorFreeRatio metric2 - subject1": 1.0,
-        "ErrorFreeRatio metric2 - subject2": 1.0,
-        "ErrorFreeRatio metric3": 1.0,
-        "ErrorFreeRatio metric3 - subject1": 1.0,
-        "ErrorFreeRatio metric3 - subject2": 1.0,
-        "StdErr metric1 - key1": 0.8660254037844386,
-        "NumSamples metric1 - key1": 4,
-        "StdErr metric1 - key2": 0.3535533905932738,
-        "NumSamples metric1 - key2": 4,
-        "StdErr metric1 - subject1": 0.4978909578906802,
-        "NumSamples metric1 - subject1": 6,
-        "StdErr metric1 - subject2": None,  # NaN appear, cannot compute the std of only one value (division by N-1)
-        "NumSamples metric1 - subject2": 2,
-        "StdErr metric1": None,
-        "NumSamples metric1": 16,
-        "StdErr metric2 - subject1": 0,
-        "NumSamples metric2 - subject1": 2,
-        "StdErr metric2 - subject2": None,
-        "NumSamples metric2 - subject2": 1,
-        "StdErr metric2": None,
-        "NumSamples metric2": 3,
-        "StdErr metric3 - subject1": None,
-        "NumSamples metric3 - subject1": 1,
-        "StdErr metric3 - subject2": None,
-        "NumSamples metric3 - subject2": 1,
-        "StdErr metric3": None,
-        "NumSamples metric3": 2,
-    }
+    assert aggregated_results == pytest.approx(
+        {
+            "Average metric1": 2.0,  # mean of all key-subject pairs (3.0, 4.0, 1.0, 0.0)
+            "Average metric1 (including Errors)": 1.8125,  # errors treated as 0: (2.25, 1.0, 4.0, 0.0)
+            "Average metric1 - key1": 3.5,  # mean of means of subjects (3.0 and 4.0)
+            "Average metric1 (including Errors) - key1": 3.125,  # errors as 0: (2.25, 4.0)
+            "Average metric1 - key2": 0.5,
+            "Average metric1 (including Errors) - key2": 0.5,  # errors as 0: (1.0, 0.0)
+            "Average metric1 - subject1": 2.0,  # mean of means of keys (3.0 and 1.0)
+            "Average metric1 (including Errors) - subject1": 1.625,  # errors as 0: (2.25, 1.0)
+            "Average metric1 - subject2": 2.0,
+            "Average metric1 (including Errors) - subject2": 2.0,  # errors as 0: (4.0, 0.0)
+            "Average metric2": 3.0,  # NaNs are skipped in the mean calculation
+            "Average metric2 - subject1": 3.0,
+            "Average metric2 - subject2": float("nan"),  # NaN appears
+            # key in metric2 is not output because it's just a single submetric
+            "Average metric3": 19.0,  # key=None case works
+            "Average metric3 - subject1": 20.0,
+            "Average metric3 - subject2": 18.0,
+            "ErrorFreeRatio metric1": 0.8,
+            "ErrorFreeRatio metric1 - key1": 0.8,
+            "ErrorFreeRatio metric1 - key2": 0.8,
+            "ErrorFreeRatio metric1 - subject1": 0.8571428571428571,
+            "ErrorFreeRatio metric1 - subject2": 0.6666666666666666,
+            "ErrorFreeRatio metric2": 1.0,
+            "ErrorFreeRatio metric2 - subject1": 1.0,
+            "ErrorFreeRatio metric2 - subject2": 1.0,
+            "ErrorFreeRatio metric3": 1.0,
+            "ErrorFreeRatio metric3 - subject1": 1.0,
+            "ErrorFreeRatio metric3 - subject2": 1.0,
+            "StdErr metric1 - key1": 0.8660254037844386,
+            "NumSamples metric1 - key1": 4,
+            "StdErr metric1 - key2": 0.3535533905932738,
+            "NumSamples metric1 - key2": 4,
+            "StdErr metric1 - subject1": 0.4978909578906802,
+            "NumSamples metric1 - subject1": 6,
+            "StdErr metric1 - subject2": float(
+                "nan"
+            ),  # NaN appear, cannot compute the std of only one value (division by N-1)
+            "NumSamples metric1 - subject2": 2,
+            "StdErr metric1": float("nan"),
+            "NumSamples metric1": 16,
+            "StdErr metric2 - subject1": 0,
+            "NumSamples metric2 - subject1": 2,
+            "StdErr metric2 - subject2": float("nan"),
+            "NumSamples metric2 - subject2": 1,
+            "StdErr metric2": float("nan"),
+            "NumSamples metric2": 3,
+            "StdErr metric3 - subject1": float("nan"),
+            "NumSamples metric3 - subject1": 1,
+            "StdErr metric3 - subject2": float("nan"),
+            "NumSamples metric3 - subject2": 1,
+            "StdErr metric3": float("nan"),
+            "NumSamples metric3": 2,
+        },
+        nan_ok=True,
+    )
 
 
 def test_aggregate_results_with_aggregators(tmp_path: Path) -> None:


### PR DESCRIPTION
make consistent with previous unavailable metrics reporting NaN
