### PR TITLE
Benchmark and Eval

### DIFF
--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -3,7 +3,7 @@ import os
 import random
 import traceback
 import typing
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self, TypeVar
@@ -540,14 +540,49 @@ def resolve_overwrite_subjects[SubjectType](
 class Eager(EvalFactory):
     """Wraps an already-imported task class."""
 
-    def __init__(self, task: type[BaseTask], id: str) -> None:
+    def __init__(
+        self,
+        task: type[BaseTask],
+        *,
+        id: str,
+        display_name: str,
+        subjects: list[Any],
+        metrics: list[type["BaseMetric"]],
+        response_type: ResponseType,
+        generate_markdown_doc: Callable[[Sequence[BaseFormatter]], str],
+    ) -> None:
         self._task = task
         self._id = id
+        self._display_name = display_name
+        self._subjects = subjects
+        self._metrics = metrics
+        self._response_type = response_type
+        self._generate_markdown_doc = generate_markdown_doc
 
     @classmethod
     def from_base_task(cls, task: type[BaseTask]) -> Self:
-        """Build an ``Eager`` from a task class, deriving the id from its class name."""
-        return cls(task, id=task.__name__)
+        """Build an ``Eager`` from a task class, deriving its metadata from the class."""
+
+        def generate_markdown_doc(formatters: Sequence[BaseFormatter]) -> str:
+            try:
+                instance = task.with_overwrite(
+                    num_fewshot=1, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED
+                )
+            except (TypeError, ValueError, AssertionError):
+                instance = task.with_overwrite(
+                    num_fewshot=0, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED
+                )
+            return instance.markdown_doc(formatters)
+
+        return cls(
+            task,
+            id=task.__name__,
+            display_name=task.NAME,
+            subjects=task.SUBJECTS,
+            metrics=task.get_metrics(),
+            response_type=task.get_response_type(),
+            generate_markdown_doc=generate_markdown_doc,
+        )
 
     def id(self) -> str:
         return self._id
@@ -570,23 +605,19 @@ class Eager(EvalFactory):
 
     def response_type(self) -> ResponseType:
         """The eval's response type"""
-        return self._task.get_response_type()
+        return self._response_type
 
     def metrics(self) -> list[type["BaseMetric"]]:
         """The eval's metrics"""
-        return self._task.get_metrics()
+        return self._metrics
 
     def subjects(self) -> list[Any]:
         """The eval's subjects"""
-        return self._task.SUBJECTS
+        return self._subjects
 
     def display_name(self) -> str:
-        """The eval's human-readable display name (the task's ``NAME``)."""
-        return self._task.NAME
+        """The eval's human-readable display name."""
+        return self._display_name
 
     def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
-        try:
-            task = self.create(num_fewshot=1, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED)
-        except (TypeError, ValueError, AssertionError):
-            task = self.create(num_fewshot=0, custom_subjects=None, custom_hf_revision=None, seed=RANDOM_SEED)
-        return task.markdown_doc(formatters)
+        return self._generate_markdown_doc(formatters)

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -21,7 +21,7 @@ from eval_framework.metrics.efficiency.token_counters import TokenCounts
 from eval_framework.shared.types import BaseMetricContext, Completion, Error, RawCompletion
 from eval_framework.tasks.dataset_revisions import pinned_revision
 from eval_framework.tasks.markdown_doc import markdown_doc as render_markdown_doc
-from eval_framework.tasks.task import EvalFactory, ResponseType, Sample, Task
+from eval_framework.tasks.task import Benchmark, ResponseType, Sample, Task
 from eval_framework.tasks.utils import classproperty, raise_errors
 from template_formatting.formatter import BaseFormatter, Message, Role
 
@@ -537,8 +537,8 @@ def resolve_overwrite_subjects[SubjectType](
     return chosen_subjects
 
 
-class Eager(EvalFactory):
-    """An ``EvalFactory`` assembled from precomputed metadata and eval/doc callables."""
+class Eager(Benchmark):
+    """A ``Benchmark`` assembled from precomputed metadata and eval/doc callables."""
 
     def __init__(
         self,

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -538,30 +538,45 @@ def resolve_overwrite_subjects[SubjectType](
 
 
 class Eager(EvalFactory):
-    """Wraps an already-imported task class."""
+    """An ``EvalFactory`` assembled from precomputed metadata and eval/doc callables."""
 
     def __init__(
         self,
-        task: type[BaseTask],
         *,
         id: str,
         display_name: str,
         subjects: list[Any],
         metrics: list[type["BaseMetric"]],
         response_type: ResponseType,
+        make_eval: Callable[..., Task],
         generate_markdown_doc: Callable[[Sequence[BaseFormatter]], str],
     ) -> None:
-        self._task = task
         self._id = id
         self._display_name = display_name
         self._subjects = subjects
         self._metrics = metrics
         self._response_type = response_type
+        self._make_eval = make_eval
         self._generate_markdown_doc = generate_markdown_doc
 
     @classmethod
     def from_base_task(cls, task: type[BaseTask]) -> Self:
         """Build an ``Eager`` from a task class, deriving its metadata from the class."""
+
+        def make_eval(
+            num_fewshot: int,
+            custom_subjects: list[str] | None,
+            custom_hf_revision: str | None,
+            user_prompt_suffix: str | None = None,
+            seed: int | None = None,
+        ) -> Task:
+            return task.with_overwrite(
+                num_fewshot=num_fewshot,
+                custom_subjects=custom_subjects,
+                custom_hf_revision=custom_hf_revision,
+                user_prompt_suffix=user_prompt_suffix,
+                seed=seed,
+            )
 
         def generate_markdown_doc(formatters: Sequence[BaseFormatter]) -> str:
             try:
@@ -575,12 +590,12 @@ class Eager(EvalFactory):
             return instance.markdown_doc(formatters)
 
         return cls(
-            task,
             id=task.__name__,
             display_name=task.NAME,
             subjects=task.SUBJECTS,
             metrics=task.get_metrics(),
             response_type=task.get_response_type(),
+            make_eval=make_eval,
             generate_markdown_doc=generate_markdown_doc,
         )
 
@@ -594,14 +609,8 @@ class Eager(EvalFactory):
         custom_hf_revision: str | None,
         user_prompt_suffix: str | None = None,
         seed: int | None = None,
-    ) -> BaseTask:
-        return self._task.with_overwrite(
-            num_fewshot=num_fewshot,
-            custom_subjects=custom_subjects,
-            custom_hf_revision=custom_hf_revision,
-            user_prompt_suffix=user_prompt_suffix,
-            seed=seed,
-        )
+    ) -> Task:
+        return self._make_eval(num_fewshot, custom_subjects, custom_hf_revision, user_prompt_suffix, seed)
 
     def response_type(self) -> ResponseType:
         """The eval's response type"""

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -540,11 +540,17 @@ def resolve_overwrite_subjects[SubjectType](
 class Eager(EvalFactory):
     """Wraps an already-imported task class."""
 
-    def __init__(self, task: type[BaseTask]) -> None:
+    def __init__(self, task: type[BaseTask], id: str) -> None:
         self._task = task
+        self._id = id
+
+    @classmethod
+    def from_base_task(cls, task: type[BaseTask]) -> Self:
+        """Build an ``Eager`` from a task class, deriving the id from its class name."""
+        return cls(task, id=task.__name__)
 
     def id(self) -> str:
-        return self._task.__name__
+        return self._id
 
     def create(
         self,

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -21,7 +21,7 @@ from eval_framework.metrics.efficiency.token_counters import TokenCounts
 from eval_framework.shared.types import BaseMetricContext, Completion, Error, RawCompletion
 from eval_framework.tasks.dataset_revisions import pinned_revision
 from eval_framework.tasks.markdown_doc import markdown_doc as render_markdown_doc
-from eval_framework.tasks.task import Benchmark, ResponseType, Sample, Task
+from eval_framework.tasks.task import Benchmark, Eval, ResponseType, Sample
 from eval_framework.tasks.utils import classproperty, raise_errors
 from template_formatting.formatter import BaseFormatter, Message, Role
 
@@ -78,7 +78,7 @@ SubjectType = TypeVar("SubjectType")
 logger = logging.getLogger(__name__)
 
 
-class BaseTask[SubjectType](Task):
+class BaseTask[SubjectType](Eval):
     NAME: str
     DATASET_PATH: str
     SAMPLE_SPLIT: str
@@ -548,7 +548,7 @@ class Eager(Benchmark):
         subjects: list[Any],
         metrics: list[type["BaseMetric"]],
         response_type: ResponseType,
-        make_eval: Callable[..., Task],
+        make_eval: Callable[..., Eval],
         generate_markdown_doc: Callable[[Sequence[BaseFormatter]], str],
     ) -> None:
         self._id = id
@@ -569,7 +569,7 @@ class Eager(Benchmark):
             custom_hf_revision: str | None,
             user_prompt_suffix: str | None = None,
             seed: int | None = None,
-        ) -> Task:
+        ) -> Eval:
             return task.with_overwrite(
                 num_fewshot=num_fewshot,
                 custom_subjects=custom_subjects,
@@ -609,7 +609,7 @@ class Eager(Benchmark):
         custom_hf_revision: str | None,
         user_prompt_suffix: str | None = None,
         seed: int | None = None,
-    ) -> Task:
+    ) -> Eval:
         return self._make_eval(num_fewshot, custom_subjects, custom_hf_revision, user_prompt_suffix, seed)
 
     def response_type(self) -> ResponseType:

--- a/src/eval_framework/tasks/lazy.py
+++ b/src/eval_framework/tasks/lazy.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
-from eval_framework.tasks.task import Benchmark, ResponseType, Task
+from eval_framework.tasks.task import Benchmark, Eval, ResponseType
 from template_formatting.formatter import BaseFormatter
 
 if TYPE_CHECKING:
@@ -37,7 +37,7 @@ class Lazy(Benchmark):
         custom_hf_revision: str | None,
         user_prompt_suffix: str | None = None,
         seed: int | None = None,
-    ) -> Task:
+    ) -> Eval:
         return self._loaded_factory().create(num_fewshot, custom_subjects, custom_hf_revision, user_prompt_suffix, seed)
 
     def response_type(self) -> ResponseType:

--- a/src/eval_framework/tasks/lazy.py
+++ b/src/eval_framework/tasks/lazy.py
@@ -1,28 +1,28 @@
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
-from eval_framework.tasks.task import EvalFactory, ResponseType, Task
+from eval_framework.tasks.task import Benchmark, ResponseType, Task
 from template_formatting.formatter import BaseFormatter
 
 if TYPE_CHECKING:
     from eval_framework.metrics.base import BaseMetric
 
 
-class Lazy(EvalFactory):
-    """An ``EvalFactory`` that defers producing the real factory until first use.
+class Lazy(Benchmark):
+    """A ``Benchmark`` that defers producing the real benchmark until first use.
 
-    Holds an ``id`` and a ``load`` thunk returning the wrapped ``EvalFactory``; every
-    other call is delegated to that factory, which is built (and memoized) on first
+    Holds an ``id`` and a ``load`` thunk returning the wrapped ``Benchmark``; every
+    other call is delegated to that benchmark, which is built (and memoized) on first
     access. This keeps ``Lazy`` independent of any concrete task type — the thunk owns
-    whatever loading (e.g. importing a module) the wrapped factory requires.
+    whatever loading (e.g. importing a module) the wrapped benchmark requires.
     """
 
-    def __init__(self, id: str, load: Callable[[], EvalFactory]) -> None:
+    def __init__(self, id: str, load: Callable[[], Benchmark]) -> None:
         self._id = id
         self._load = load
-        self._factory: EvalFactory | None = None
+        self._factory: Benchmark | None = None
 
-    def _loaded_factory(self) -> EvalFactory:
+    def _loaded_factory(self) -> Benchmark:
         if self._factory is None:
             self._factory = self._load()
         return self._factory

--- a/src/eval_framework/tasks/registry.py
+++ b/src/eval_framework/tasks/registry.py
@@ -7,11 +7,12 @@ from typing import Any
 
 from eval_framework.tasks.base import BaseTask, Eager
 from eval_framework.tasks.lazy import Lazy
-from eval_framework.tasks.task import EvalFactory
+from eval_framework.tasks.task import Benchmark
 
 __all__ = [
     "register_task",
     "register_lazy_task",
+    "Benchmark",
     "EvalFactory",
     "Eager",
     "Lazy",
@@ -22,12 +23,16 @@ __all__ = [
     "registered_task_names",
 ]
 
+# Transitional alias for the former name. Remove once downstream consumers (e.g. the
+# companion) have migrated their imports to ``Benchmark``.
+EvalFactory = Benchmark
+
 
 class Registry:
-    """A registry for Tasks"""
+    """A registry for Benchmarks"""
 
     def __init__(self) -> None:
-        self._registry: dict[str, EvalFactory] = dict()
+        self._registry: dict[str, Benchmark] = dict()
 
     def __iter__(self) -> Iterator[str]:
         """Iterate over all task names in the registry."""
@@ -38,8 +43,8 @@ class Registry:
         """The names of all registered tasks."""
         return list(self)
 
-    def items(self) -> Iterator[tuple[str, EvalFactory]]:
-        """Iterate over `(task name, EvalFactory)` pairs in the registry."""
+    def items(self) -> Iterator[tuple[str, Benchmark]]:
+        """Iterate over `(task name, Benchmark)` pairs in the registry."""
         for factory in self._registry.values():
             yield factory.id(), factory
 
@@ -56,14 +61,14 @@ class Registry:
         task_key = self._task_key(name)
         return task_key in self._registry
 
-    def __getitem__(self, name: str, /) -> EvalFactory:
+    def __getitem__(self, name: str, /) -> Benchmark:
         task_key = self._task_key(name)
         try:
             return self._registry[task_key]
         except KeyError:
             raise KeyError(f"Task not found: {name=} with task_key {task_key=}")
 
-    def add(self, factory: EvalFactory) -> None:
+    def add(self, factory: Benchmark) -> None:
         """Register a factory under the key derived from its ``id()``."""
         task_key = self._task_key(factory.id())
         if task_key in self._registry:
@@ -157,7 +162,7 @@ def register_lazy_task(class_path: str, /, registry: Registry | None = None) -> 
     r = registry if registry is not None else _REGISTRY
     module_path, class_name = class_path.rsplit(".", maxsplit=1)
 
-    def load() -> EvalFactory:
+    def load() -> Benchmark:
         module = importlib.import_module(module_path)
         return Eager.from_base_task(getattr(module, class_name))
 

--- a/src/eval_framework/tasks/registry.py
+++ b/src/eval_framework/tasks/registry.py
@@ -142,7 +142,7 @@ def register_task(task: type[BaseTask], registry: Registry | None = None) -> str
     if not issubclass(task, BaseTask):
         raise ValueError(f"Can only register subclasses of BaseTask, got {task}")
     r = registry if registry is not None else _REGISTRY
-    factory = Eager(task)
+    factory = Eager.from_base_task(task)
     r.add(factory)
     return factory.id()
 
@@ -159,6 +159,6 @@ def register_lazy_task(class_path: str, /, registry: Registry | None = None) -> 
 
     def load() -> EvalFactory:
         module = importlib.import_module(module_path)
-        return Eager(getattr(module, class_name))
+        return Eager.from_base_task(getattr(module, class_name))
 
     r.add(Lazy(id=class_name, load=load))

--- a/src/eval_framework/tasks/task.py
+++ b/src/eval_framework/tasks/task.py
@@ -58,31 +58,27 @@ class Task(ABC):
         ...
 
 
-class EvalFactory(ABC):
-    """Produces a registered benchmark's eval.
+class Benchmark(ABC):
+    """A benchmark is used to provide means of measuring model performance in a domain.
 
-    The registry stores one factory per eval. This allows the factory to be
-    constructed without constructing all evals. Going via this ABC allows
-    the factory instances to contain state specifically relevant to the
-    eval, as well as supporting different strategies for instantiating it.
-    E.g. eager vs lazy loading of the required dependencies.
+    A benchmark is used to instantiate concrete evaluations.
     """
 
     @abstractmethod
     def id(self) -> str:
-        "Canonical key used to register this benchmark"
+        "Uniquely identifies the benchmark"
 
     @abstractmethod
     def response_type(self) -> ResponseType:
-        """The eval's response type"""
+        """The benchmark's response type"""
 
     @abstractmethod
     def metrics(self) -> list[type["BaseMetric"]]:
-        """The eval's metrics"""
+        """The benchmark's metrics"""
 
     @abstractmethod
     def subjects(self) -> list[Any]:
-        """The eval's subjects"""
+        """Subjects of the benchmark"""
 
     @abstractmethod
     def display_name(self) -> str:
@@ -100,5 +96,5 @@ class EvalFactory(ABC):
 
     @abstractmethod
     def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
-        """Render the eval's documentation as markdown."""
+        """Render the benchmarks's documentation as markdown."""
         ...

--- a/src/eval_framework/tasks/task.py
+++ b/src/eval_framework/tasks/task.py
@@ -28,7 +28,7 @@ class Sample(BaseModel):
     context: BaseMetricContext | list[BaseMetricContext] | None = None
 
 
-class Task(ABC):
+class Eval(ABC):
     """The contract a caller relies on to run an evaluation"""
 
     @abstractmethod
@@ -92,7 +92,7 @@ class Benchmark(ABC):
         custom_hf_revision: str | None,
         user_prompt_suffix: str | None = None,
         seed: int | None = None,
-    ) -> Task: ...
+    ) -> Eval: ...
 
     @abstractmethod
     def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:

--- a/tests/tests_eval_framework/test_user_task_registration.py
+++ b/tests/tests_eval_framework/test_user_task_registration.py
@@ -4,7 +4,7 @@ from eval_framework.tasks.registry import Registry
 from eval_framework.tasks.task_loader import load_extra_tasks, load_modules_from_directory
 
 TASK1 = """\
-from eval_framework.tasks.base import BaseTask, Language
+from eval_framework.tasks.base import BaseTask, Language, ResponseType
 from eval_framework.tasks.registry import Registry, register_task
 
 class MyCustomTask(BaseTask):
@@ -12,7 +12,7 @@ class MyCustomTask(BaseTask):
     DATASET_PATH = "dummy"
     SAMPLE_SPLIT = "test"
     FEWSHOT_SPLIT = "test"
-    RESPONSE_TYPE = None
+    RESPONSE_TYPE = ResponseType.COMPLETION
     METRICS = []
     SUBJECTS = []
     LANGUAGE = Language.ENG
@@ -22,7 +22,7 @@ def register_tasks(registry: Registry) -> None:
 """
 
 TASK2 = """\
-from eval_framework.tasks.base import BaseTask, Language
+from eval_framework.tasks.base import BaseTask, Language, ResponseType
 from eval_framework.tasks.registry import Registry, register_task
 
 class MySecondCustomTask(BaseTask):
@@ -30,7 +30,7 @@ class MySecondCustomTask(BaseTask):
     DATASET_PATH = "dummy"
     SAMPLE_SPLIT = "test"
     FEWSHOT_SPLIT = "test"
-    RESPONSE_TYPE = None
+    RESPONSE_TYPE = ResponseType.COMPLETION
     METRICS = []
     SUBJECTS = []
     LANGUAGE = Language.ENG

--- a/tests/tests_eval_framework/test_user_task_registration.py
+++ b/tests/tests_eval_framework/test_user_task_registration.py
@@ -4,39 +4,67 @@ from eval_framework.tasks.registry import Registry
 from eval_framework.tasks.task_loader import load_extra_tasks, load_modules_from_directory
 
 TASK1 = """\
-from eval_framework.tasks.base import BaseTask, Language, ResponseType
-from eval_framework.tasks.registry import Registry, register_task
+from eval_framework.tasks.registry import Registry
+from eval_framework.tasks.task import Benchmark
 
-class MyCustomTask(BaseTask):
-    NAME = "MyCustomTask"
-    DATASET_PATH = "dummy"
-    SAMPLE_SPLIT = "test"
-    FEWSHOT_SPLIT = "test"
-    RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = []
-    SUBJECTS = []
-    LANGUAGE = Language.ENG
+
+class DummyBenchmark(Benchmark):
+    def id(self):
+        return "MyCustomTask"
+
+    def display_name(self):
+        return "MyCustomTask"
+
+    def response_type(self):
+        raise NotImplementedError
+
+    def metrics(self):
+        raise NotImplementedError
+
+    def subjects(self):
+        raise NotImplementedError
+
+    def create(self, num_fewshot, custom_subjects, custom_hf_revision, user_prompt_suffix=None, seed=None):
+        raise NotImplementedError
+
+    def markdown_doc(self, formatters):
+        raise NotImplementedError
+
 
 def register_tasks(registry: Registry) -> None:
-    register_task(MyCustomTask, registry)
+    registry.add(DummyBenchmark())
 """
 
 TASK2 = """\
-from eval_framework.tasks.base import BaseTask, Language, ResponseType
-from eval_framework.tasks.registry import Registry, register_task
+from eval_framework.tasks.registry import Registry
+from eval_framework.tasks.task import Benchmark
 
-class MySecondCustomTask(BaseTask):
-    NAME = "MySecondCustomTask"
-    DATASET_PATH = "dummy"
-    SAMPLE_SPLIT = "test"
-    FEWSHOT_SPLIT = "test"
-    RESPONSE_TYPE = ResponseType.COMPLETION
-    METRICS = []
-    SUBJECTS = []
-    LANGUAGE = Language.ENG
+
+class DummyBenchmark(Benchmark):
+    def id(self):
+        return "MySecondCustomTask"
+
+    def display_name(self):
+        return "MySecondCustomTask"
+
+    def response_type(self):
+        raise NotImplementedError
+
+    def metrics(self):
+        raise NotImplementedError
+
+    def subjects(self):
+        raise NotImplementedError
+
+    def create(self, num_fewshot, custom_subjects, custom_hf_revision, user_prompt_suffix=None, seed=None):
+        raise NotImplementedError
+
+    def markdown_doc(self, formatters):
+        raise NotImplementedError
+
 
 def register_tasks(registry: Registry) -> None:
-    register_task(MySecondCustomTask, registry)
+    registry.add(DummyBenchmark())
 """
 
 


### PR DESCRIPTION
- **refactor: Eager factory stores id in dedicated member**
- **refactor: Eager factory holds metadata for all the getters**
- **refactor: Eval is now not strictly dependent on BaseTask**
- **refactor: EvalFactory is now Benchmark**
- **refactor: Task is now Eval**
