### PR TITLE
composed benchmarks

### DIFF
--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -80,15 +80,9 @@ class ComposedEval[SubjectType](Eval):
         sample_split: str,
         fewshot_split: str,
         subjects: list[SubjectType],
-        language: LanguageSpec = None,
-        user_prompt_suffix: str | None = None,
-        seed: int | None = RANDOM_SEED,
+        language: LanguageSpec,
+        rnd: random.Random,
     ) -> None:
-        # No completion path yet, so any suffix is rejected. This deliberately trips even for a
-        # completion response type, flagging that suffix handling must be implemented once that lands.
-        if user_prompt_suffix is not None:
-            raise ValueError("user_prompt_suffix is only supported for completion tasks.")
-
         self.num_fewshot = num_fewshot
         self.reader = reader
         self.loader = loader
@@ -96,7 +90,7 @@ class ComposedEval[SubjectType](Eval):
         self.fewshot_split = fewshot_split
         self.subjects = subjects
         self.language = language
-        self.rnd = random.Random(seed)
+        self.rnd = rnd
 
     def _shuffle_splits(self, hf_dataset: DatasetDict) -> dict[str, Any]:
         dataset = {}
@@ -367,7 +361,7 @@ class ComposedBenchmark(Benchmark):
         sample_split: str,
         fewshot_split: str,
         dataset_policy: DatasetPolicy,
-        language: LanguageSpec = None,
+        language: LanguageSpec,
         task: type[ComposedEval],
     ) -> None:
         self._id = id
@@ -391,7 +385,7 @@ class ComposedBenchmark(Benchmark):
         fewshot_split: str,
         subjects: list[Any],
         dataset_policy: DatasetPolicy,
-        language: LanguageSpec = None,
+        language: LanguageSpec,
     ) -> Self:
         """Build an ``ComposedBenchmark`` from a task class and its construction inputs.
 
@@ -422,6 +416,9 @@ class ComposedBenchmark(Benchmark):
         user_prompt_suffix: str | None = None,
         seed: int | None = None,
     ) -> Eval:
+        # Composed evals have no completion path yet, so a completion-only user prompt suffix is rejected.
+        if user_prompt_suffix is not None:
+            raise ValueError("user_prompt_suffix is only supported for completion tasks.")
         subjects = self._subjects
         if custom_subjects:
             subjects = resolve_overwrite_subjects(
@@ -436,8 +433,7 @@ class ComposedBenchmark(Benchmark):
             subjects=subjects,
             language=self.language,
             loader=self.dataset_policy.loader(custom_hf_revision),
-            user_prompt_suffix=user_prompt_suffix,
-            seed=seed,
+            rnd=random.Random(seed),
         )
 
     def response_type(self) -> ResponseType:
@@ -466,7 +462,7 @@ class ComposedBenchmark(Benchmark):
             subjects=self._subjects,
             language=self.language,
             loader=self.dataset_policy.loader(None),
-            seed=RANDOM_SEED,
+            rnd=random.Random(RANDOM_SEED),
         )
         sample = next(iter(instance.iterate_samples(1)))
         return render_markdown_doc(

--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -4,7 +4,7 @@ import random
 import traceback
 import typing
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
@@ -410,7 +410,7 @@ class ComposedEval[SubjectType](Eval):
 
 
 class ComposedBenchmark(Benchmark):
-    """A ``Benchmark`` assembled from precomputed metadata and eval/doc callables."""
+    """A ``Benchmark`` that constructs one ``ComposedEval`` type from precomputed metadata + inputs."""
 
     def __init__(
         self,
@@ -424,8 +424,7 @@ class ComposedBenchmark(Benchmark):
         dataset_path: str,
         sample_split: str,
         fewshot_split: str,
-        make_eval: Callable[..., Eval],
-        generate_markdown_doc: Callable[..., str],
+        task: type[ComposedEval],
     ) -> None:
         self._id = id
         self._display_name = display_name
@@ -436,8 +435,7 @@ class ComposedBenchmark(Benchmark):
         self.dataset_path = dataset_path
         self.sample_split = sample_split
         self.fewshot_split = fewshot_split
-        self._make_eval = make_eval
-        self._generate_markdown_doc = generate_markdown_doc
+        self._task = task
 
     @classmethod
     def from_base(
@@ -453,51 +451,6 @@ class ComposedBenchmark(Benchmark):
 
         Metadata (name, metrics, response type) is derived from the class.
         """
-
-        def make_eval(
-            num_fewshot: int,
-            subjects: list[Any],
-            custom_hf_revision: str | None,
-            user_prompt_suffix: str | None = None,
-            seed: int | None = None,
-            *,
-            reader: ChoiceReader,
-            dataset_path: str,
-            sample_split: str,
-            fewshot_split: str,
-        ) -> Eval:
-            return task(
-                num_fewshot=num_fewshot,
-                reader=reader,
-                dataset_path=dataset_path,
-                sample_split=sample_split,
-                fewshot_split=fewshot_split,
-                subjects=subjects,
-                custom_hf_revision=custom_hf_revision,
-                user_prompt_suffix=user_prompt_suffix,
-                seed=seed,
-            )
-
-        def generate_markdown_doc(
-            formatters: Sequence[BaseFormatter],
-            reader: ChoiceReader,
-            dataset_path: str,
-            sample_split: str,
-            fewshot_split: str,
-            subjects: list[Any],
-        ) -> str:
-            instance = task(
-                num_fewshot=1,
-                reader=reader,
-                dataset_path=dataset_path,
-                sample_split=sample_split,
-                fewshot_split=fewshot_split,
-                subjects=subjects,
-                custom_hf_revision=None,
-                seed=RANDOM_SEED,
-            )
-            return instance.markdown_doc(formatters)
-
         return cls(
             id=task.__name__,
             display_name=task.NAME,
@@ -508,8 +461,7 @@ class ComposedBenchmark(Benchmark):
             dataset_path=dataset_path,
             sample_split=sample_split,
             fewshot_split=fewshot_split,
-            make_eval=make_eval,
-            generate_markdown_doc=generate_markdown_doc,
+            task=task,
         )
 
     def id(self) -> str:
@@ -529,16 +481,16 @@ class ComposedBenchmark(Benchmark):
                 custom_subjects=custom_subjects, accepted_subjects=self._subjects, task_name=self._display_name
             )
             logger.info(f"Restricting subjects to `{subjects}` for the task {self._display_name}")
-        return self._make_eval(
-            num_fewshot,
-            subjects,
-            custom_hf_revision,
-            user_prompt_suffix,
-            seed,
+        return self._task(
+            num_fewshot=num_fewshot,
             reader=self.reader,
             dataset_path=self.dataset_path,
             sample_split=self.sample_split,
             fewshot_split=self.fewshot_split,
+            subjects=subjects,
+            custom_hf_revision=custom_hf_revision,
+            user_prompt_suffix=user_prompt_suffix,
+            seed=seed,
         )
 
     def response_type(self) -> ResponseType:
@@ -558,6 +510,14 @@ class ComposedBenchmark(Benchmark):
         return self._display_name
 
     def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
-        return self._generate_markdown_doc(
-            formatters, self.reader, self.dataset_path, self.sample_split, self.fewshot_split, self._subjects
+        instance = self._task(
+            num_fewshot=1,
+            reader=self.reader,
+            dataset_path=self.dataset_path,
+            sample_split=self.sample_split,
+            fewshot_split=self.fewshot_split,
+            subjects=self._subjects,
+            custom_hf_revision=None,
+            seed=RANDOM_SEED,
         )
+        return instance.markdown_doc(formatters)

--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -480,6 +480,7 @@ class ComposedBenchmark(Benchmark):
         return render_markdown_doc(
             name=self._display_name,
             dataset_path=self.dataset_path,
+            dataset_doc=self.dataset_policy.documentation(),
             sample_split=self.sample_split,
             fewshot_split=self.fewshot_split,
             response_type=self._response_type.name,

--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -364,7 +364,6 @@ class ComposedBenchmark(Benchmark):
         metrics: list[type["BaseMetric"]],
         response_type: ResponseType,
         reader: ChoiceReader,
-        dataset_path: str,
         sample_split: str,
         fewshot_split: str,
         dataset_policy: DatasetPolicy,
@@ -377,7 +376,6 @@ class ComposedBenchmark(Benchmark):
         self._metrics = metrics
         self._response_type = response_type
         self.reader = reader
-        self.dataset_path = dataset_path
         self.sample_split = sample_split
         self.fewshot_split = fewshot_split
         self.language = language
@@ -389,7 +387,6 @@ class ComposedBenchmark(Benchmark):
         cls,
         task: type[ComposedEval],
         reader: ChoiceReader,
-        dataset_path: str,
         sample_split: str,
         fewshot_split: str,
         subjects: list[Any],
@@ -407,7 +404,6 @@ class ComposedBenchmark(Benchmark):
             metrics=task.get_metrics(),
             response_type=task.get_response_type(),
             reader=reader,
-            dataset_path=dataset_path,
             sample_split=sample_split,
             fewshot_split=fewshot_split,
             language=language,
@@ -475,7 +471,6 @@ class ComposedBenchmark(Benchmark):
         sample = next(iter(instance.iterate_samples(1)))
         return render_markdown_doc(
             name=self._display_name,
-            dataset_path=self.dataset_path,
             dataset_doc=self.dataset_policy.documentation(),
             sample_split=self.sample_split,
             fewshot_split=self.fewshot_split,

--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import random
 import traceback
 import typing
@@ -9,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 
-from datasets import DatasetDict, DownloadConfig, load_dataset
+from datasets import DatasetDict
 
 from eval_framework.contract import Benchmark, Eval, ResponseType, Sample
 from eval_framework.metrics.efficiency.bytes_per_sequence_position import (
@@ -27,6 +26,7 @@ from eval_framework.tasks.base import (
     Language,
     resolve_overwrite_subjects,
 )
+from eval_framework.tasks.dataset_loading import DatasetLoader, HfDatasetLoader
 from eval_framework.tasks.dataset_revisions import pinned_revision
 from eval_framework.tasks.markdown_doc import markdown_doc as render_markdown_doc
 from template_formatting.formatter import BaseFormatter, Message, Role
@@ -78,13 +78,12 @@ class ComposedEval[SubjectType](Eval):
         num_fewshot: int = 0,
         *,
         reader: ChoiceReader,
+        loader: DatasetLoader,
         dataset_path: str,
         sample_split: str,
         fewshot_split: str,
         subjects: list[SubjectType],
-        revision_lockfile: Path | None,
         language: LanguageSpec = None,
-        custom_hf_revision: str | None = None,
         user_prompt_suffix: str | None = None,
         seed: int | None = RANDOM_SEED,
     ) -> None:
@@ -95,35 +94,13 @@ class ComposedEval[SubjectType](Eval):
 
         self.num_fewshot = num_fewshot
         self.reader = reader
+        self.loader = loader
         self.dataset_path = dataset_path
         self.sample_split = sample_split
         self.fewshot_split = fewshot_split
         self.subjects = subjects
         self.language = language
-        self.revision_lockfile = revision_lockfile
         self.rnd = random.Random(seed)
-        self.hf_revision: str | None = self._apply_hf_revision(custom_hf_revision)
-
-    def _apply_hf_revision(self, custom_hf_revision: str | None = None) -> str | None:
-        # Precedence: CLI/config override > revision_lockfile pin.
-        # Tasks without a Hugging Face dataset get revision_lockfile=None and are not pinned.
-        if custom_hf_revision:
-            hf_revision = custom_hf_revision
-        elif self.revision_lockfile is not None:
-            hf_revision = pinned_revision(self.revision_lockfile, self.dataset_path)
-        else:
-            hf_revision = None
-        return hf_revision
-
-    def _load_hf_dataset(self, **kwargs: Any) -> Any:
-        cache_dir: str = os.environ.get("HF_DATASET_CACHE_DIR", f"{Path.home()}/.cache/huggingface/datasets")
-        download_config = DownloadConfig(cache_dir=cache_dir, max_retries=5)
-        return load_dataset(
-            **kwargs,
-            revision=self.hf_revision,
-            cache_dir=cache_dir,
-            download_config=download_config,
-        )
 
     def _shuffle_splits(self, hf_dataset: DatasetDict) -> dict[str, Any]:
         dataset = {}
@@ -142,8 +119,9 @@ class ComposedEval[SubjectType](Eval):
         return dataset
 
     def _load_dataset(self, subject: SubjectType) -> None:
-        name = subject if subject != NO_SUBJECT else None
-        hf_dataset = self._load_hf_dataset(path=self.dataset_path, name=name)
+        # HF addresses configs by string name; NO_SUBJECT marks a dataset with no configs.
+        name = None if subject == NO_SUBJECT else str(subject)
+        hf_dataset = self.loader.load(name)
         self.dataset = self._shuffle_splits(hf_dataset=hf_dataset)
 
     def post_process_generated_completion(self, completion_text: str, sample: Sample | None = None) -> str:
@@ -421,7 +399,7 @@ class ComposedBenchmark(Benchmark):
         dataset_path: str,
         sample_split: str,
         fewshot_split: str,
-        revision_lockfile: Path | None,
+        revision_lockfile: Path,
         language: LanguageSpec = None,
         task: type[ComposedEval],
     ) -> None:
@@ -447,7 +425,7 @@ class ComposedBenchmark(Benchmark):
         sample_split: str,
         fewshot_split: str,
         subjects: list[Any],
-        revision_lockfile: Path | None,
+        revision_lockfile: Path,
         language: LanguageSpec = None,
     ) -> Self:
         """Build an ``ComposedBenchmark`` from a task class and its construction inputs.
@@ -494,8 +472,10 @@ class ComposedBenchmark(Benchmark):
             fewshot_split=self.fewshot_split,
             subjects=subjects,
             language=self.language,
-            revision_lockfile=self.revision_lockfile,
-            custom_hf_revision=custom_hf_revision,
+            loader=HfDatasetLoader(
+                self.dataset_path,
+                custom_hf_revision or pinned_revision(self.revision_lockfile, self.dataset_path),
+            ),
             user_prompt_suffix=user_prompt_suffix,
             seed=seed,
         )
@@ -525,8 +505,7 @@ class ComposedBenchmark(Benchmark):
             fewshot_split=self.fewshot_split,
             subjects=self._subjects,
             language=self.language,
-            revision_lockfile=self.revision_lockfile,
-            custom_hf_revision=None,
+            loader=HfDatasetLoader(self.dataset_path, pinned_revision(self.revision_lockfile, self.dataset_path)),
             seed=RANDOM_SEED,
         )
         return instance.markdown_doc(formatters)

--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -73,12 +73,6 @@ class ComposedEval[SubjectType](Eval):
     # Composed evals are styler-only (choice-based); there is no completion styling path.
     TASK_STYLER: "TaskStyler"
 
-    # The lock file this task resolves its pinned dataset revision from, keyed by ``dataset_path``.
-    # Each task sets this explicitly: point it at a lock file (e.g. ``HF_REVISIONS_LOCKFILE`` or a
-    # frozen one), or ``None`` to opt out of pinning. Deliberately not defaulted so it is never
-    # inherited implicitly (a subclass in another package would otherwise resolve the wrong file).
-    REVISION_LOCKFILE: Path | None
-
     def __init__(
         self,
         num_fewshot: int = 0,
@@ -88,6 +82,7 @@ class ComposedEval[SubjectType](Eval):
         sample_split: str,
         fewshot_split: str,
         subjects: list[SubjectType],
+        revision_lockfile: Path | None,
         language: LanguageSpec = None,
         custom_hf_revision: str | None = None,
         user_prompt_suffix: str | None = None,
@@ -105,16 +100,17 @@ class ComposedEval[SubjectType](Eval):
         self.fewshot_split = fewshot_split
         self.subjects = subjects
         self.language = language
+        self.revision_lockfile = revision_lockfile
         self.rnd = random.Random(seed)
         self.hf_revision: str | None = self._apply_hf_revision(custom_hf_revision)
 
     def _apply_hf_revision(self, custom_hf_revision: str | None = None) -> str | None:
-        # Precedence: CLI/config override > REVISION_LOCKFILE pin.
-        # Tasks without a Hugging Face dataset set REVISION_LOCKFILE to None and are not pinned.
+        # Precedence: CLI/config override > revision_lockfile pin.
+        # Tasks without a Hugging Face dataset get revision_lockfile=None and are not pinned.
         if custom_hf_revision:
             hf_revision = custom_hf_revision
-        elif self.REVISION_LOCKFILE is not None:
-            hf_revision = pinned_revision(self.REVISION_LOCKFILE, self.dataset_path)
+        elif self.revision_lockfile is not None:
+            hf_revision = pinned_revision(self.revision_lockfile, self.dataset_path)
         else:
             hf_revision = None
         return hf_revision
@@ -425,6 +421,7 @@ class ComposedBenchmark(Benchmark):
         dataset_path: str,
         sample_split: str,
         fewshot_split: str,
+        revision_lockfile: Path | None,
         language: LanguageSpec = None,
         task: type[ComposedEval],
     ) -> None:
@@ -438,6 +435,7 @@ class ComposedBenchmark(Benchmark):
         self.sample_split = sample_split
         self.fewshot_split = fewshot_split
         self.language = language
+        self.revision_lockfile = revision_lockfile
         self._task = task
 
     @classmethod
@@ -449,6 +447,7 @@ class ComposedBenchmark(Benchmark):
         sample_split: str,
         fewshot_split: str,
         subjects: list[Any],
+        revision_lockfile: Path | None,
         language: LanguageSpec = None,
     ) -> Self:
         """Build an ``ComposedBenchmark`` from a task class and its construction inputs.
@@ -466,6 +465,7 @@ class ComposedBenchmark(Benchmark):
             sample_split=sample_split,
             fewshot_split=fewshot_split,
             language=language,
+            revision_lockfile=revision_lockfile,
             task=task,
         )
 
@@ -494,6 +494,7 @@ class ComposedBenchmark(Benchmark):
             fewshot_split=self.fewshot_split,
             subjects=subjects,
             language=self.language,
+            revision_lockfile=self.revision_lockfile,
             custom_hf_revision=custom_hf_revision,
             user_prompt_suffix=user_prompt_suffix,
             seed=seed,
@@ -524,6 +525,7 @@ class ComposedBenchmark(Benchmark):
             fewshot_split=self.fewshot_split,
             subjects=self._subjects,
             language=self.language,
+            revision_lockfile=self.revision_lockfile,
             custom_hf_revision=None,
             seed=RANDOM_SEED,
         )

--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -66,9 +66,6 @@ class ChoiceReader(ABC):
 
 
 class ComposedEval[SubjectType](Eval):
-    # Composed evals are styler-only (choice-based); there is no completion styling path.
-    TASK_STYLER: "TaskStyler"
-
     def __init__(
         self,
         num_fewshot: int = 0,
@@ -77,6 +74,7 @@ class ComposedEval[SubjectType](Eval):
         display_name: str,
         reader: ChoiceReader,
         loader: DatasetLoader,
+        styler: "TaskStyler",
         sample_split: str,
         fewshot_split: str,
         subjects: list[SubjectType],
@@ -88,6 +86,7 @@ class ComposedEval[SubjectType](Eval):
         self.num_fewshot = num_fewshot
         self.reader = reader
         self.loader = loader
+        self.styler = styler
         self.sample_split = sample_split
         self.fewshot_split = fewshot_split
         self.subjects = subjects
@@ -187,22 +186,22 @@ class ComposedEval[SubjectType](Eval):
 
     def _get_instruction_text(self, item: dict[str, Any]) -> str:
         fields = self.reader.read(item)
-        return self.TASK_STYLER.get_instruction_text(fields.raw_question, fields.choices)
+        return self.styler.get_instruction_text(fields.raw_question, fields.choices)
 
     def _get_fewshot_target_text(self, item: dict[str, Any]) -> str:
         fields = self.reader.read(item)
-        return self.TASK_STYLER.get_fewshot_target_text(fields.choices, fields.correct_index)
+        return self.styler.get_fewshot_target_text(fields.choices, fields.correct_index)
 
     def _get_ground_truth(self, item: dict[str, Any]) -> str | None | list[str]:
         fields = self.reader.read(item)
-        return self.TASK_STYLER.get_ground_truth(fields.choices, fields.correct_index)
+        return self.styler.get_ground_truth(fields.choices, fields.correct_index)
 
     def _get_cue_text(self, item: dict[str, Any]) -> str:
-        return self.TASK_STYLER.get_cue_text()
+        return self.styler.get_cue_text()
 
     def _get_possible_completions(self, item: dict[str, Any]) -> list[str] | None:
         fields = self.reader.read(item)
-        return self.TASK_STYLER.get_possible_completions(fields.choices, fields.correct_index)
+        return self.styler.get_possible_completions(fields.choices, fields.correct_index)
 
     def _sample_fewshot_examples(self, item: dict[str, Any]) -> list[dict]:
         if self.fewshot_split == self.sample_split:
@@ -225,11 +224,11 @@ class ComposedEval[SubjectType](Eval):
             "sample_split": self.sample_split,
             "fewshot_split": self.fewshot_split,
             "response_type": self.get_response_type().value,
-            "metrics": [m.NAME for m in self._get_task_specific_metrics()],
+            "metrics": [m.NAME for m in self.styler.metrics],
             "subjects": [str(s) for s in self.subjects],
         }
         meta.update(self.loader.metadata())
-        meta.update(self.TASK_STYLER.get_extra_metadata())
+        meta.update(self.styler.get_extra_metadata())
         return meta
 
     def generate_completions(
@@ -312,37 +311,8 @@ class ComposedEval[SubjectType](Eval):
             )
         return completion_list
 
-    @classmethod
-    def get_response_type(cls) -> ResponseType:
-        return cls.TASK_STYLER.response_type
-
-    @classmethod
-    def _get_task_specific_metrics(cls) -> list[type["BaseMetric"]]:
-        return cls.TASK_STYLER.metrics
-
-    @classmethod
-    def _get_response_type_specific_metrics(cls) -> list[type["BaseMetric"]]:
-        metrics: list[type[BaseMetric]]
-        match cls.get_response_type():
-            case ResponseType.COMPLETION:
-                metrics = [
-                    BytesCompletion,
-                    SequencePositionsCompletion,
-                    TokenCounts,
-                ]
-            case ResponseType.LOGLIKELIHOODS:
-                metrics = [BytesLoglikelihood, SequencePositionsLoglikelihood]
-            case _:
-                typing.assert_never(cls.get_response_type())
-
-        return metrics
-
-    @classmethod
-    def get_metrics(cls) -> list[type["BaseMetric"]]:
-        task_metrics = cls._get_task_specific_metrics()
-        response_type_metrics = cls._get_response_type_specific_metrics()
-
-        return task_metrics + response_type_metrics
+    def get_response_type(self) -> ResponseType:
+        return self.styler.response_type
 
     def id(self) -> str:
         return self._id
@@ -351,8 +321,21 @@ class ComposedEval[SubjectType](Eval):
         return self._display_name
 
 
+def _metrics_for(styler: "TaskStyler") -> list[type["BaseMetric"]]:
+    """The metrics a styler implies: its own plus those its response type requires."""
+    response_type_metrics: list[type[BaseMetric]]
+    match styler.response_type:
+        case ResponseType.COMPLETION:
+            response_type_metrics = [BytesCompletion, SequencePositionsCompletion, TokenCounts]
+        case ResponseType.LOGLIKELIHOODS:
+            response_type_metrics = [BytesLoglikelihood, SequencePositionsLoglikelihood]
+        case _:
+            typing.assert_never(styler.response_type)
+    return styler.metrics + response_type_metrics
+
+
 class ComposedBenchmark(Benchmark):
-    """A ``Benchmark`` that constructs one ``ComposedEval`` type from precomputed metadata + inputs."""
+    """A ``Benchmark`` that builds a ``ComposedEval`` from an injected styler and dataset inputs."""
 
     def __init__(
         self,
@@ -360,33 +343,29 @@ class ComposedBenchmark(Benchmark):
         id: str,
         display_name: str,
         subjects: list[Any],
-        metrics: list[type["BaseMetric"]],
-        response_type: ResponseType,
+        styler: "TaskStyler",
         reader: ChoiceReader,
         sample_split: str,
         fewshot_split: str,
         dataset_policy: DatasetPolicy,
         language: LanguageSpec,
-        task: type[ComposedEval],
     ) -> None:
         self._id = id
         self._display_name = display_name
         self._subjects = subjects
-        self._metrics = metrics
-        self._response_type = response_type
+        self._styler = styler
         self.reader = reader
         self.sample_split = sample_split
         self.fewshot_split = fewshot_split
         self.language = language
         self.dataset_policy = dataset_policy
-        self._task = task
 
     @classmethod
-    def from_base(
+    def compose(
         cls,
-        task: type[ComposedEval],
         *,
         id: str,
+        styler: "TaskStyler",
         reader: ChoiceReader,
         sample_split: str,
         fewshot_split: str,
@@ -395,22 +374,17 @@ class ComposedBenchmark(Benchmark):
         language: LanguageSpec,
         display_name: str | None = None,
     ) -> Self:
-        """Build an ``ComposedBenchmark`` from a task class and its construction inputs.
-
-        Metrics and response type are derived from the class; ``display_name`` defaults to ``id``.
-        """
+        """Build a ``ComposedBenchmark`` from its inputs; ``display_name`` defaults to ``id``."""
         return cls(
             id=id,
             display_name=display_name if display_name is not None else id,
             subjects=subjects,
-            metrics=task.get_metrics(),
-            response_type=task.get_response_type(),
+            styler=styler,
             reader=reader,
             sample_split=sample_split,
             fewshot_split=fewshot_split,
             language=language,
             dataset_policy=dataset_policy,
-            task=task,
         )
 
     def id(self) -> str:
@@ -433,11 +407,12 @@ class ComposedBenchmark(Benchmark):
                 custom_subjects=custom_subjects, accepted_subjects=self._subjects, task_name=self._display_name
             )
             logger.info(f"Restricting subjects to `{subjects}` for the task {self._display_name}")
-        return self._task(
+        return ComposedEval(
             num_fewshot=num_fewshot,
             id=self._id,
             display_name=self._display_name,
             reader=self.reader,
+            styler=self._styler,
             sample_split=self.sample_split,
             fewshot_split=self.fewshot_split,
             subjects=subjects,
@@ -448,11 +423,11 @@ class ComposedBenchmark(Benchmark):
 
     def response_type(self) -> ResponseType:
         """The eval's response type"""
-        return self._response_type
+        return self._styler.response_type
 
     def metrics(self) -> list[type["BaseMetric"]]:
         """The eval's metrics"""
-        return self._metrics
+        return _metrics_for(self._styler)
 
     def subjects(self) -> list[Any]:
         """The eval's subjects"""
@@ -464,11 +439,12 @@ class ComposedBenchmark(Benchmark):
 
     def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
         num_fewshot = 1
-        instance = self._task(
+        instance = ComposedEval(
             num_fewshot=num_fewshot,
             id=self._id,
             display_name=self._display_name,
             reader=self.reader,
+            styler=self._styler,
             sample_split=self.sample_split,
             fewshot_split=self.fewshot_split,
             subjects=self._subjects,
@@ -482,8 +458,8 @@ class ComposedBenchmark(Benchmark):
             dataset_doc=self.dataset_policy.documentation(),
             sample_split=self.sample_split,
             fewshot_split=self.fewshot_split,
-            response_type=self._response_type.name,
-            metrics=[m.__name__ for m in self._metrics],
+            response_type=self.response_type().name,
+            metrics=[m.__name__ for m in self.metrics()],
             subjects=self._subjects,
             language=self.language,
             num_fewshot=num_fewshot,

--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -77,7 +77,6 @@ class ComposedEval[SubjectType](Eval):
         *,
         reader: ChoiceReader,
         loader: DatasetLoader,
-        dataset_path: str,
         sample_split: str,
         fewshot_split: str,
         subjects: list[SubjectType],
@@ -93,7 +92,6 @@ class ComposedEval[SubjectType](Eval):
         self.num_fewshot = num_fewshot
         self.reader = reader
         self.loader = loader
-        self.dataset_path = dataset_path
         self.sample_split = sample_split
         self.fewshot_split = fewshot_split
         self.subjects = subjects
@@ -228,13 +226,13 @@ class ComposedEval[SubjectType](Eval):
 
     def get_metadata(self) -> dict[str, str | list[str]]:
         meta: dict[str, str | list[str]] = {
-            "dataset_path": self.dataset_path,
             "sample_split": self.sample_split,
             "fewshot_split": self.fewshot_split,
             "response_type": self.get_response_type().value,
             "metrics": [m.NAME for m in self._get_task_specific_metrics()],
             "subjects": [str(s) for s in self.subjects],
         }
+        meta.update(self.loader.metadata())
         meta.update(self.TASK_STYLER.get_extra_metadata())
         return meta
 
@@ -437,7 +435,6 @@ class ComposedBenchmark(Benchmark):
         return self._task(
             num_fewshot=num_fewshot,
             reader=self.reader,
-            dataset_path=self.dataset_path,
             sample_split=self.sample_split,
             fewshot_split=self.fewshot_split,
             subjects=subjects,
@@ -468,7 +465,6 @@ class ComposedBenchmark(Benchmark):
         instance = self._task(
             num_fewshot=num_fewshot,
             reader=self.reader,
-            dataset_path=self.dataset_path,
             sample_split=self.sample_split,
             fewshot_split=self.fewshot_split,
             subjects=self._subjects,

--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -66,7 +66,6 @@ class ChoiceReader(ABC):
 
 class ComposedEval[SubjectType](Eval):
     NAME: str
-    SUBJECTS: list[SubjectType]
 
     # Composed evals are styler-only (choice-based); there is no completion styling path.
     TASK_STYLER: "TaskStyler"
@@ -89,7 +88,7 @@ class ComposedEval[SubjectType](Eval):
         dataset_path: str,
         sample_split: str,
         fewshot_split: str,
-        custom_subjects: list[str] | None = None,
+        subjects: list[SubjectType],
         custom_hf_revision: str | None = None,
         user_prompt_suffix: str | None = None,
         seed: int | None = RANDOM_SEED,
@@ -104,18 +103,8 @@ class ComposedEval[SubjectType](Eval):
         self.dataset_path = dataset_path
         self.sample_split = sample_split
         self.fewshot_split = fewshot_split
+        self.subjects = subjects
         self.rnd = random.Random(seed)
-
-        # Custom subjects, when provided, take precedence over the class-level SUBJECTS.
-        if custom_subjects:
-            filtered_subjects = resolve_overwrite_subjects(
-                custom_subjects=custom_subjects,
-                accepted_subjects=self.SUBJECTS,
-                task_name=self.display_name(),
-            )
-            logger.info(f"Setting SUBJECTS to `{filtered_subjects}` for the task {self.display_name()}")
-            self.SUBJECTS = filtered_subjects
-
         self.hf_revision: str | None = self._apply_hf_revision(custom_hf_revision)
 
     def _apply_hf_revision(self, custom_hf_revision: str | None = None) -> str | None:
@@ -194,7 +183,7 @@ class ComposedEval[SubjectType](Eval):
         return [Message(role=Role.USER, content=self._get_instruction_text(item))]
 
     def iterate_samples(self, num_samples: int | None = None) -> Iterable[Sample]:
-        for subject in self.SUBJECTS:
+        for subject in self.subjects:
             self._load_dataset(subject)
             assert len(self.dataset[self.sample_split]) > 0
             done = False
@@ -228,7 +217,7 @@ class ComposedEval[SubjectType](Eval):
             fewshot_split=self.fewshot_split,
             response_type=self.get_response_type().name,
             metrics=[m.__name__ for m in self.get_metrics()],
-            subjects=getattr(self, "SUBJECTS", None),
+            subjects=self.subjects,
             language=getattr(self, "LANGUAGE", None),
             num_fewshot=self.num_fewshot,
             formatters=formatters,
@@ -299,7 +288,7 @@ class ComposedEval[SubjectType](Eval):
             "fewshot_split": self.fewshot_split,
             "response_type": self.get_response_type().value,
             "metrics": [m.NAME for m in self._get_task_specific_metrics()],
-            "subjects": [str(s) for s in self.SUBJECTS],
+            "subjects": [str(s) for s in self.subjects],
         }
         meta.update(self.TASK_STYLER.get_extra_metadata())
         return meta
@@ -458,15 +447,16 @@ class ComposedBenchmark(Benchmark):
         dataset_path: str,
         sample_split: str,
         fewshot_split: str,
+        subjects: list[Any],
     ) -> Self:
         """Build an ``ComposedBenchmark`` from a task class and its construction inputs.
 
-        Metadata (name, subjects, metrics, response type) is derived from the class.
+        Metadata (name, metrics, response type) is derived from the class.
         """
 
         def make_eval(
             num_fewshot: int,
-            custom_subjects: list[str] | None,
+            subjects: list[Any],
             custom_hf_revision: str | None,
             user_prompt_suffix: str | None = None,
             seed: int | None = None,
@@ -482,7 +472,7 @@ class ComposedBenchmark(Benchmark):
                 dataset_path=dataset_path,
                 sample_split=sample_split,
                 fewshot_split=fewshot_split,
-                custom_subjects=custom_subjects,
+                subjects=subjects,
                 custom_hf_revision=custom_hf_revision,
                 user_prompt_suffix=user_prompt_suffix,
                 seed=seed,
@@ -494,6 +484,7 @@ class ComposedBenchmark(Benchmark):
             dataset_path: str,
             sample_split: str,
             fewshot_split: str,
+            subjects: list[Any],
         ) -> str:
             instance = task(
                 num_fewshot=1,
@@ -501,7 +492,7 @@ class ComposedBenchmark(Benchmark):
                 dataset_path=dataset_path,
                 sample_split=sample_split,
                 fewshot_split=fewshot_split,
-                custom_subjects=None,
+                subjects=subjects,
                 custom_hf_revision=None,
                 seed=RANDOM_SEED,
             )
@@ -510,7 +501,7 @@ class ComposedBenchmark(Benchmark):
         return cls(
             id=task.__name__,
             display_name=task.NAME,
-            subjects=task.SUBJECTS,
+            subjects=subjects,
             metrics=task.get_metrics(),
             response_type=task.get_response_type(),
             reader=reader,
@@ -532,9 +523,15 @@ class ComposedBenchmark(Benchmark):
         user_prompt_suffix: str | None = None,
         seed: int | None = None,
     ) -> Eval:
+        subjects = self._subjects
+        if custom_subjects:
+            subjects = resolve_overwrite_subjects(
+                custom_subjects=custom_subjects, accepted_subjects=self._subjects, task_name=self._display_name
+            )
+            logger.info(f"Restricting subjects to `{subjects}` for the task {self._display_name}")
         return self._make_eval(
             num_fewshot,
-            custom_subjects,
+            subjects,
             custom_hf_revision,
             user_prompt_suffix,
             seed,
@@ -562,5 +559,5 @@ class ComposedBenchmark(Benchmark):
 
     def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
         return self._generate_markdown_doc(
-            formatters, self.reader, self.dataset_path, self.sample_split, self.fewshot_split
+            formatters, self.reader, self.dataset_path, self.sample_split, self.fewshot_split, self._subjects
         )

--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -172,34 +172,6 @@ class ComposedEval[SubjectType](Eval):
                         done = True
                         break
 
-    def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
-        """Render this task's documentation as markdown."""
-        dataset_path = self.dataset_path
-        example_messages = split_sizes = possible_completions = ground_truth = None
-        if dataset_path is None:
-            sample = next(iter(self.iterate_samples(1)))
-            example_messages = sample.messages
-            split_sizes = {split: len(self.dataset[split]) for split in self.dataset}
-            possible_completions = sample.possible_completions
-            ground_truth = sample.ground_truth
-
-        return render_markdown_doc(
-            name=self.NAME,
-            dataset_path=dataset_path,
-            sample_split=self.sample_split,
-            fewshot_split=self.fewshot_split,
-            response_type=self.get_response_type().name,
-            metrics=[m.__name__ for m in self.get_metrics()],
-            subjects=self.subjects,
-            language=self.language,
-            num_fewshot=self.num_fewshot,
-            formatters=formatters,
-            example_messages=example_messages,
-            split_sizes=split_sizes,
-            possible_completions=possible_completions,
-            ground_truth=ground_truth,
-        )
-
     def _create_samples(self, item: dict[str, Any], index: int, subject: str) -> list[Sample]:
         """Creates one or more samples from a single dataset item. Default implementation returns single sample."""
         return [
@@ -492,8 +464,9 @@ class ComposedBenchmark(Benchmark):
         return self._display_name
 
     def markdown_doc(self, formatters: Sequence[BaseFormatter]) -> str:
+        num_fewshot = 1
         instance = self._task(
-            num_fewshot=1,
+            num_fewshot=num_fewshot,
             reader=self.reader,
             dataset_path=self.dataset_path,
             sample_split=self.sample_split,
@@ -503,4 +476,20 @@ class ComposedBenchmark(Benchmark):
             loader=self.dataset_policy.loader(None),
             seed=RANDOM_SEED,
         )
-        return instance.markdown_doc(formatters)
+        sample = next(iter(instance.iterate_samples(1)))
+        return render_markdown_doc(
+            name=self._display_name,
+            dataset_path=self.dataset_path,
+            sample_split=self.sample_split,
+            fewshot_split=self.fewshot_split,
+            response_type=self._response_type.name,
+            metrics=[m.__name__ for m in self._metrics],
+            subjects=self._subjects,
+            language=self.language,
+            num_fewshot=num_fewshot,
+            formatters=formatters,
+            example_messages=sample.messages,
+            split_sizes={split: len(instance.dataset[split]) for split in instance.dataset},
+            possible_completions=sample.possible_completions,
+            ground_truth=sample.ground_truth,
+        )

--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -66,8 +66,6 @@ class ChoiceReader(ABC):
 
 
 class ComposedEval[SubjectType](Eval):
-    NAME: str
-
     # Composed evals are styler-only (choice-based); there is no completion styling path.
     TASK_STYLER: "TaskStyler"
 
@@ -75,6 +73,8 @@ class ComposedEval[SubjectType](Eval):
         self,
         num_fewshot: int = 0,
         *,
+        id: str,
+        display_name: str,
         reader: ChoiceReader,
         loader: DatasetLoader,
         sample_split: str,
@@ -83,6 +83,8 @@ class ComposedEval[SubjectType](Eval):
         language: LanguageSpec,
         rnd: random.Random,
     ) -> None:
+        self._id = id
+        self._display_name = display_name
         self.num_fewshot = num_fewshot
         self.reader = reader
         self.loader = loader
@@ -342,8 +344,11 @@ class ComposedEval[SubjectType](Eval):
 
         return task_metrics + response_type_metrics
 
+    def id(self) -> str:
+        return self._id
+
     def display_name(self) -> str:
-        return self.NAME
+        return self._display_name
 
 
 class ComposedBenchmark(Benchmark):
@@ -380,20 +385,23 @@ class ComposedBenchmark(Benchmark):
     def from_base(
         cls,
         task: type[ComposedEval],
+        *,
+        id: str,
         reader: ChoiceReader,
         sample_split: str,
         fewshot_split: str,
         subjects: list[Any],
         dataset_policy: DatasetPolicy,
         language: LanguageSpec,
+        display_name: str | None = None,
     ) -> Self:
         """Build an ``ComposedBenchmark`` from a task class and its construction inputs.
 
-        Metadata (name, metrics, response type) is derived from the class.
+        Metrics and response type are derived from the class; ``display_name`` defaults to ``id``.
         """
         return cls(
-            id=task.__name__,
-            display_name=task.NAME,
+            id=id,
+            display_name=display_name if display_name is not None else id,
             subjects=subjects,
             metrics=task.get_metrics(),
             response_type=task.get_response_type(),
@@ -427,6 +435,8 @@ class ComposedBenchmark(Benchmark):
             logger.info(f"Restricting subjects to `{subjects}` for the task {self._display_name}")
         return self._task(
             num_fewshot=num_fewshot,
+            id=self._id,
+            display_name=self._display_name,
             reader=self.reader,
             sample_split=self.sample_split,
             fewshot_split=self.fewshot_split,
@@ -456,6 +466,8 @@ class ComposedBenchmark(Benchmark):
         num_fewshot = 1
         instance = self._task(
             num_fewshot=num_fewshot,
+            id=self._id,
+            display_name=self._display_name,
             reader=self.reader,
             sample_split=self.sample_split,
             fewshot_split=self.fewshot_split,

--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# The language(s) a benchmark tests: a single language, a per-subtopic mapping, or None (not language-specific).
+LanguageSpec = Language | dict[str, Language] | dict[str, tuple[Language, Language]] | None
+
 
 @dataclass(frozen=True)
 class ChoiceFields:
@@ -76,10 +79,6 @@ class ComposedEval[SubjectType](Eval):
     # inherited implicitly (a subclass in another package would otherwise resolve the wrong file).
     REVISION_LOCKFILE: Path | None
 
-    # The language (or languages) tested by the benchmark. Accepts a single string, a dictionary specifying
-    # language by subtopic, or `None` (for tasks not specific to a single language).
-    LANGUAGE: Language | dict[str, Language] | dict[str, tuple[Language, Language]] | None
-
     def __init__(
         self,
         num_fewshot: int = 0,
@@ -89,6 +88,7 @@ class ComposedEval[SubjectType](Eval):
         sample_split: str,
         fewshot_split: str,
         subjects: list[SubjectType],
+        language: LanguageSpec = None,
         custom_hf_revision: str | None = None,
         user_prompt_suffix: str | None = None,
         seed: int | None = RANDOM_SEED,
@@ -104,6 +104,7 @@ class ComposedEval[SubjectType](Eval):
         self.sample_split = sample_split
         self.fewshot_split = fewshot_split
         self.subjects = subjects
+        self.language = language
         self.rnd = random.Random(seed)
         self.hf_revision: str | None = self._apply_hf_revision(custom_hf_revision)
 
@@ -218,7 +219,7 @@ class ComposedEval[SubjectType](Eval):
             response_type=self.get_response_type().name,
             metrics=[m.__name__ for m in self.get_metrics()],
             subjects=self.subjects,
-            language=getattr(self, "LANGUAGE", None),
+            language=self.language,
             num_fewshot=self.num_fewshot,
             formatters=formatters,
             example_messages=example_messages,
@@ -424,6 +425,7 @@ class ComposedBenchmark(Benchmark):
         dataset_path: str,
         sample_split: str,
         fewshot_split: str,
+        language: LanguageSpec = None,
         task: type[ComposedEval],
     ) -> None:
         self._id = id
@@ -435,6 +437,7 @@ class ComposedBenchmark(Benchmark):
         self.dataset_path = dataset_path
         self.sample_split = sample_split
         self.fewshot_split = fewshot_split
+        self.language = language
         self._task = task
 
     @classmethod
@@ -446,6 +449,7 @@ class ComposedBenchmark(Benchmark):
         sample_split: str,
         fewshot_split: str,
         subjects: list[Any],
+        language: LanguageSpec = None,
     ) -> Self:
         """Build an ``ComposedBenchmark`` from a task class and its construction inputs.
 
@@ -461,6 +465,7 @@ class ComposedBenchmark(Benchmark):
             dataset_path=dataset_path,
             sample_split=sample_split,
             fewshot_split=fewshot_split,
+            language=language,
             task=task,
         )
 
@@ -488,6 +493,7 @@ class ComposedBenchmark(Benchmark):
             sample_split=self.sample_split,
             fewshot_split=self.fewshot_split,
             subjects=subjects,
+            language=self.language,
             custom_hf_revision=custom_hf_revision,
             user_prompt_suffix=user_prompt_suffix,
             seed=seed,
@@ -517,6 +523,7 @@ class ComposedBenchmark(Benchmark):
             sample_split=self.sample_split,
             fewshot_split=self.fewshot_split,
             subjects=self._subjects,
+            language=self.language,
             custom_hf_revision=None,
             seed=RANDOM_SEED,
         )

--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -5,7 +5,6 @@ import typing
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 
 from datasets import DatasetDict
@@ -26,8 +25,7 @@ from eval_framework.tasks.base import (
     Language,
     resolve_overwrite_subjects,
 )
-from eval_framework.tasks.dataset_loading import DatasetLoader, HfDatasetLoader
-from eval_framework.tasks.dataset_revisions import pinned_revision
+from eval_framework.tasks.dataset_loading import DatasetLoader, DatasetPolicy
 from eval_framework.tasks.markdown_doc import markdown_doc as render_markdown_doc
 from template_formatting.formatter import BaseFormatter, Message, Role
 
@@ -399,7 +397,7 @@ class ComposedBenchmark(Benchmark):
         dataset_path: str,
         sample_split: str,
         fewshot_split: str,
-        revision_lockfile: Path,
+        dataset_policy: DatasetPolicy,
         language: LanguageSpec = None,
         task: type[ComposedEval],
     ) -> None:
@@ -413,7 +411,7 @@ class ComposedBenchmark(Benchmark):
         self.sample_split = sample_split
         self.fewshot_split = fewshot_split
         self.language = language
-        self.revision_lockfile = revision_lockfile
+        self.dataset_policy = dataset_policy
         self._task = task
 
     @classmethod
@@ -425,7 +423,7 @@ class ComposedBenchmark(Benchmark):
         sample_split: str,
         fewshot_split: str,
         subjects: list[Any],
-        revision_lockfile: Path,
+        dataset_policy: DatasetPolicy,
         language: LanguageSpec = None,
     ) -> Self:
         """Build an ``ComposedBenchmark`` from a task class and its construction inputs.
@@ -443,7 +441,7 @@ class ComposedBenchmark(Benchmark):
             sample_split=sample_split,
             fewshot_split=fewshot_split,
             language=language,
-            revision_lockfile=revision_lockfile,
+            dataset_policy=dataset_policy,
             task=task,
         )
 
@@ -472,10 +470,7 @@ class ComposedBenchmark(Benchmark):
             fewshot_split=self.fewshot_split,
             subjects=subjects,
             language=self.language,
-            loader=HfDatasetLoader(
-                self.dataset_path,
-                custom_hf_revision or pinned_revision(self.revision_lockfile, self.dataset_path),
-            ),
+            loader=self.dataset_policy.loader(custom_hf_revision),
             user_prompt_suffix=user_prompt_suffix,
             seed=seed,
         )
@@ -505,7 +500,7 @@ class ComposedBenchmark(Benchmark):
             fewshot_split=self.fewshot_split,
             subjects=self._subjects,
             language=self.language,
-            loader=HfDatasetLoader(self.dataset_path, pinned_revision(self.revision_lockfile, self.dataset_path)),
+            loader=self.dataset_policy.loader(None),
             seed=RANDOM_SEED,
         )
         return instance.markdown_doc(formatters)

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -261,7 +261,6 @@ class BaseTask[SubjectType](Eval):
 
         return render_markdown_doc(
             name=self.NAME,
-            dataset_path=dataset_path,
             dataset_doc=hf_dataset_link(dataset_path) if dataset_path else "No information about dataset",
             sample_split=getattr(self, "SAMPLE_SPLIT", None),
             fewshot_split=getattr(self, "FEWSHOT_SPLIT", None),

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -79,6 +79,12 @@ SubjectType = TypeVar("SubjectType")
 logger = logging.getLogger(__name__)
 
 
+def hf_dataset_link(dataset_path: str) -> str:
+    """Markdown bullet linking to a Hugging Face dataset."""
+    url = f"https://huggingface.co/datasets/{dataset_path}"
+    return f"- Link to dataset: [{url}]({url})"
+
+
 class BaseTask[SubjectType](Eval):
     NAME: str
     DATASET_PATH: str
@@ -256,6 +262,7 @@ class BaseTask[SubjectType](Eval):
         return render_markdown_doc(
             name=self.NAME,
             dataset_path=dataset_path,
+            dataset_doc=hf_dataset_link(dataset_path) if dataset_path else "No information about dataset",
             sample_split=getattr(self, "SAMPLE_SPLIT", None),
             fewshot_split=getattr(self, "FEWSHOT_SPLIT", None),
             response_type=self.get_response_type().name,

--- a/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
+++ b/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 from eval_framework.composed import ChoiceFields, ChoiceReader, ComposedBenchmark, ComposedEval
 from eval_framework.contract import Benchmark
 from eval_framework.tasks.base import Language
-from eval_framework.tasks.dataset_revisions import HF_REVISIONS_LOCKFILE
+from eval_framework.tasks.dataset_revisions import pinned_by_framework
 from eval_framework.tasks.task_style import BPBStyle, ClozeStyle, MCStyle, shuffle_correct_with_distractors
 
 
@@ -82,14 +82,15 @@ class PIQA_ELLAMIND_BPB_DE(ComposedEval[str]):
 
 def _piqa_ellamind_benchmark(task: type[ComposedEval[str]], distractor_level: Literal["easy", "hard"]) -> Benchmark:
     """Dataset: https://huggingface.co/datasets/ellamind/piqa-multilingual"""
+    dataset_path = "ellamind/piqa-multilingual"
     return ComposedBenchmark.from_base(
         task,
         PiqaReader(distractor_level),
-        dataset_path="ellamind/piqa-multilingual",
+        dataset_path=dataset_path,
         sample_split="validation",
         fewshot_split="validation",
         subjects=["deu"],
-        revision_lockfile=HF_REVISIONS_LOCKFILE,
+        dataset_policy=pinned_by_framework(dataset_path),
         language=Language.DEU,
     )
 

--- a/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
+++ b/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
@@ -48,44 +48,42 @@ PIQA_ELLAMIND_BPB_STYLER = BPBStyle(question_prefix=_QUESTION_PREFIX, cue_text=_
 class PIQA_ELLAMIND_CLOZE_EASY_DE(ComposedEval[str]):
     """German PIQA - Cloze format with easy distractor."""
 
-    NAME = "PIQA_ELLAMIND_CLOZE_EASY_DE"
     TASK_STYLER = PIQA_ELLAMIND_CLOZE_STYLER
 
 
 class PIQA_ELLAMIND_CLOZE_HARD_DE(ComposedEval[str]):
     """German PIQA - Cloze format with hard distractor."""
 
-    NAME = "PIQA_ELLAMIND_CLOZE_HARD_DE"
     TASK_STYLER = PIQA_ELLAMIND_CLOZE_STYLER
 
 
 class PIQA_ELLAMIND_MC_EASY_DE(ComposedEval[str]):
     """German PIQA - MC format with easy distractor."""
 
-    NAME = "PIQA_ELLAMIND_MC_EASY_DE"
     TASK_STYLER = PIQA_ELLAMIND_MC_STYLER
 
 
 class PIQA_ELLAMIND_MC_HARD_DE(ComposedEval[str]):
     """German PIQA - MC format with hard distractor."""
 
-    NAME = "PIQA_ELLAMIND_MC_HARD_DE"
     TASK_STYLER = PIQA_ELLAMIND_MC_STYLER
 
 
 class PIQA_ELLAMIND_BPB_DE(ComposedEval[str]):
     """German PIQA - BPB format (distractor set is irrelevant for BPB)."""
 
-    NAME = "PIQA_ELLAMIND_BPB_DE"
     TASK_STYLER = PIQA_ELLAMIND_BPB_STYLER
 
 
-def _piqa_ellamind_benchmark(task: type[ComposedEval[str]], distractor_level: Literal["easy", "hard"]) -> Benchmark:
+def _piqa_ellamind_benchmark(
+    task: type[ComposedEval[str]], name: str, distractor_level: Literal["easy", "hard"]
+) -> Benchmark:
     """Dataset: https://huggingface.co/datasets/ellamind/piqa-multilingual"""
     dataset_path = "ellamind/piqa-multilingual"
     return ComposedBenchmark.from_base(
         task,
-        PiqaReader(distractor_level),
+        id=name,
+        reader=PiqaReader(distractor_level),
         sample_split="validation",
         fewshot_split="validation",
         subjects=["deu"],
@@ -96,9 +94,9 @@ def _piqa_ellamind_benchmark(task: type[ComposedEval[str]], distractor_level: Li
 
 def piqa_ellamind_benchmarks() -> list[Benchmark]:
     return [
-        _piqa_ellamind_benchmark(PIQA_ELLAMIND_CLOZE_EASY_DE, "easy"),
-        _piqa_ellamind_benchmark(PIQA_ELLAMIND_CLOZE_HARD_DE, "hard"),
-        _piqa_ellamind_benchmark(PIQA_ELLAMIND_MC_EASY_DE, "easy"),
-        _piqa_ellamind_benchmark(PIQA_ELLAMIND_MC_HARD_DE, "hard"),
-        _piqa_ellamind_benchmark(PIQA_ELLAMIND_BPB_DE, "easy"),
+        _piqa_ellamind_benchmark(PIQA_ELLAMIND_CLOZE_EASY_DE, "PIQA_ELLAMIND_CLOZE_EASY_DE", "easy"),
+        _piqa_ellamind_benchmark(PIQA_ELLAMIND_CLOZE_HARD_DE, "PIQA_ELLAMIND_CLOZE_HARD_DE", "hard"),
+        _piqa_ellamind_benchmark(PIQA_ELLAMIND_MC_EASY_DE, "PIQA_ELLAMIND_MC_EASY_DE", "easy"),
+        _piqa_ellamind_benchmark(PIQA_ELLAMIND_MC_HARD_DE, "PIQA_ELLAMIND_MC_HARD_DE", "hard"),
+        _piqa_ellamind_benchmark(PIQA_ELLAMIND_BPB_DE, "PIQA_ELLAMIND_BPB_DE", "easy"),
     ]

--- a/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
+++ b/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
@@ -86,7 +86,6 @@ def _piqa_ellamind_benchmark(task: type[ComposedEval[str]], distractor_level: Li
     return ComposedBenchmark.from_base(
         task,
         PiqaReader(distractor_level),
-        dataset_path=dataset_path,
         sample_split="validation",
         fewshot_split="validation",
         subjects=["deu"],

--- a/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
+++ b/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
@@ -35,15 +35,6 @@ class PiqaReader(ChoiceReader):
         return ChoiceFields(raw_question=item["goal"], choices=choices, correct_index=correct_index)
 
 
-class _PIQA_ELLAMIND_DE_Base(ComposedEval[str]):
-    """Non-registered base for German PIQA (EllaMind) variants.
-
-    Dataset: https://huggingface.co/datasets/ellamind/piqa-multilingual
-    """
-
-    LANGUAGE = Language.DEU
-
-
 _QUESTION_PREFIX = "Ziel: "
 _CUE_TEXT = "Antwort:"
 
@@ -54,7 +45,7 @@ PIQA_ELLAMIND_MC_STYLER = MCStyle(question_prefix=_QUESTION_PREFIX, cue_text=_CU
 PIQA_ELLAMIND_BPB_STYLER = BPBStyle(question_prefix=_QUESTION_PREFIX, cue_text=_CUE_TEXT)
 
 
-class PIQA_ELLAMIND_CLOZE_EASY_DE(_PIQA_ELLAMIND_DE_Base):
+class PIQA_ELLAMIND_CLOZE_EASY_DE(ComposedEval[str]):
     """German PIQA - Cloze format with easy distractor."""
 
     REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
@@ -63,7 +54,7 @@ class PIQA_ELLAMIND_CLOZE_EASY_DE(_PIQA_ELLAMIND_DE_Base):
     TASK_STYLER = PIQA_ELLAMIND_CLOZE_STYLER
 
 
-class PIQA_ELLAMIND_CLOZE_HARD_DE(_PIQA_ELLAMIND_DE_Base):
+class PIQA_ELLAMIND_CLOZE_HARD_DE(ComposedEval[str]):
     """German PIQA - Cloze format with hard distractor."""
 
     REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
@@ -72,7 +63,7 @@ class PIQA_ELLAMIND_CLOZE_HARD_DE(_PIQA_ELLAMIND_DE_Base):
     TASK_STYLER = PIQA_ELLAMIND_CLOZE_STYLER
 
 
-class PIQA_ELLAMIND_MC_EASY_DE(_PIQA_ELLAMIND_DE_Base):
+class PIQA_ELLAMIND_MC_EASY_DE(ComposedEval[str]):
     """German PIQA - MC format with easy distractor."""
 
     REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
@@ -81,7 +72,7 @@ class PIQA_ELLAMIND_MC_EASY_DE(_PIQA_ELLAMIND_DE_Base):
     TASK_STYLER = PIQA_ELLAMIND_MC_STYLER
 
 
-class PIQA_ELLAMIND_MC_HARD_DE(_PIQA_ELLAMIND_DE_Base):
+class PIQA_ELLAMIND_MC_HARD_DE(ComposedEval[str]):
     """German PIQA - MC format with hard distractor."""
 
     REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
@@ -90,7 +81,7 @@ class PIQA_ELLAMIND_MC_HARD_DE(_PIQA_ELLAMIND_DE_Base):
     TASK_STYLER = PIQA_ELLAMIND_MC_STYLER
 
 
-class PIQA_ELLAMIND_BPB_DE(_PIQA_ELLAMIND_DE_Base):
+class PIQA_ELLAMIND_BPB_DE(ComposedEval[str]):
     """German PIQA - BPB format (distractor set is irrelevant for BPB)."""
 
     REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
@@ -99,9 +90,7 @@ class PIQA_ELLAMIND_BPB_DE(_PIQA_ELLAMIND_DE_Base):
     TASK_STYLER = PIQA_ELLAMIND_BPB_STYLER
 
 
-def _piqa_ellamind_benchmark(
-    task: type[_PIQA_ELLAMIND_DE_Base], distractor_level: Literal["easy", "hard"]
-) -> Benchmark:
+def _piqa_ellamind_benchmark(task: type[ComposedEval[str]], distractor_level: Literal["easy", "hard"]) -> Benchmark:
     """Dataset: https://huggingface.co/datasets/ellamind/piqa-multilingual"""
     return ComposedBenchmark.from_base(
         task,
@@ -110,6 +99,7 @@ def _piqa_ellamind_benchmark(
         sample_split="validation",
         fewshot_split="validation",
         subjects=["deu"],
+        language=Language.DEU,
     )
 
 

--- a/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
+++ b/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
@@ -8,11 +8,11 @@ concern, carried by the ``PiqaReader`` handed to each benchmark rather than by t
 
 from typing import Any, Literal
 
-from eval_framework.composed import ChoiceFields, ChoiceReader, ComposedBenchmark, ComposedEval
+from eval_framework.composed import ChoiceFields, ChoiceReader, ComposedBenchmark
 from eval_framework.contract import Benchmark
 from eval_framework.tasks.base import Language
 from eval_framework.tasks.dataset_revisions import pinned_by_framework
-from eval_framework.tasks.task_style import BPBStyle, ClozeStyle, MCStyle, shuffle_correct_with_distractors
+from eval_framework.tasks.task_style import BPBStyle, ClozeStyle, MCStyle, TaskStyler, shuffle_correct_with_distractors
 
 
 class PiqaReader(ChoiceReader):
@@ -45,44 +45,12 @@ PIQA_ELLAMIND_MC_STYLER = MCStyle(question_prefix=_QUESTION_PREFIX, cue_text=_CU
 PIQA_ELLAMIND_BPB_STYLER = BPBStyle(question_prefix=_QUESTION_PREFIX, cue_text=_CUE_TEXT)
 
 
-class PIQA_ELLAMIND_CLOZE_EASY_DE(ComposedEval[str]):
-    """German PIQA - Cloze format with easy distractor."""
-
-    TASK_STYLER = PIQA_ELLAMIND_CLOZE_STYLER
-
-
-class PIQA_ELLAMIND_CLOZE_HARD_DE(ComposedEval[str]):
-    """German PIQA - Cloze format with hard distractor."""
-
-    TASK_STYLER = PIQA_ELLAMIND_CLOZE_STYLER
-
-
-class PIQA_ELLAMIND_MC_EASY_DE(ComposedEval[str]):
-    """German PIQA - MC format with easy distractor."""
-
-    TASK_STYLER = PIQA_ELLAMIND_MC_STYLER
-
-
-class PIQA_ELLAMIND_MC_HARD_DE(ComposedEval[str]):
-    """German PIQA - MC format with hard distractor."""
-
-    TASK_STYLER = PIQA_ELLAMIND_MC_STYLER
-
-
-class PIQA_ELLAMIND_BPB_DE(ComposedEval[str]):
-    """German PIQA - BPB format (distractor set is irrelevant for BPB)."""
-
-    TASK_STYLER = PIQA_ELLAMIND_BPB_STYLER
-
-
-def _piqa_ellamind_benchmark(
-    task: type[ComposedEval[str]], name: str, distractor_level: Literal["easy", "hard"]
-) -> Benchmark:
+def _piqa_ellamind_benchmark(id: str, styler: TaskStyler, distractor_level: Literal["easy", "hard"]) -> Benchmark:
     """Dataset: https://huggingface.co/datasets/ellamind/piqa-multilingual"""
     dataset_path = "ellamind/piqa-multilingual"
-    return ComposedBenchmark.from_base(
-        task,
-        id=name,
+    return ComposedBenchmark.compose(
+        id=id,
+        styler=styler,
         reader=PiqaReader(distractor_level),
         sample_split="validation",
         fewshot_split="validation",
@@ -94,9 +62,9 @@ def _piqa_ellamind_benchmark(
 
 def piqa_ellamind_benchmarks() -> list[Benchmark]:
     return [
-        _piqa_ellamind_benchmark(PIQA_ELLAMIND_CLOZE_EASY_DE, "PIQA_ELLAMIND_CLOZE_EASY_DE", "easy"),
-        _piqa_ellamind_benchmark(PIQA_ELLAMIND_CLOZE_HARD_DE, "PIQA_ELLAMIND_CLOZE_HARD_DE", "hard"),
-        _piqa_ellamind_benchmark(PIQA_ELLAMIND_MC_EASY_DE, "PIQA_ELLAMIND_MC_EASY_DE", "easy"),
-        _piqa_ellamind_benchmark(PIQA_ELLAMIND_MC_HARD_DE, "PIQA_ELLAMIND_MC_HARD_DE", "hard"),
-        _piqa_ellamind_benchmark(PIQA_ELLAMIND_BPB_DE, "PIQA_ELLAMIND_BPB_DE", "easy"),
+        _piqa_ellamind_benchmark("PIQA_ELLAMIND_CLOZE_EASY_DE", PIQA_ELLAMIND_CLOZE_STYLER, "easy"),
+        _piqa_ellamind_benchmark("PIQA_ELLAMIND_CLOZE_HARD_DE", PIQA_ELLAMIND_CLOZE_STYLER, "hard"),
+        _piqa_ellamind_benchmark("PIQA_ELLAMIND_MC_EASY_DE", PIQA_ELLAMIND_MC_STYLER, "easy"),
+        _piqa_ellamind_benchmark("PIQA_ELLAMIND_MC_HARD_DE", PIQA_ELLAMIND_MC_STYLER, "hard"),
+        _piqa_ellamind_benchmark("PIQA_ELLAMIND_BPB_DE", PIQA_ELLAMIND_BPB_STYLER, "easy"),
     ]

--- a/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
+++ b/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
@@ -41,7 +41,6 @@ class _PIQA_ELLAMIND_DE_Base(ComposedEval[str]):
     Dataset: https://huggingface.co/datasets/ellamind/piqa-multilingual
     """
 
-    SUBJECTS = ["deu"]
     LANGUAGE = Language.DEU
 
 
@@ -110,6 +109,7 @@ def _piqa_ellamind_benchmark(
         dataset_path="ellamind/piqa-multilingual",
         sample_split="validation",
         fewshot_split="validation",
+        subjects=["deu"],
     )
 
 

--- a/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
+++ b/src/eval_framework/tasks/benchmarks/piqa_ellamind.py
@@ -48,16 +48,12 @@ PIQA_ELLAMIND_BPB_STYLER = BPBStyle(question_prefix=_QUESTION_PREFIX, cue_text=_
 class PIQA_ELLAMIND_CLOZE_EASY_DE(ComposedEval[str]):
     """German PIQA - Cloze format with easy distractor."""
 
-    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
-
     NAME = "PIQA_ELLAMIND_CLOZE_EASY_DE"
     TASK_STYLER = PIQA_ELLAMIND_CLOZE_STYLER
 
 
 class PIQA_ELLAMIND_CLOZE_HARD_DE(ComposedEval[str]):
     """German PIQA - Cloze format with hard distractor."""
-
-    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "PIQA_ELLAMIND_CLOZE_HARD_DE"
     TASK_STYLER = PIQA_ELLAMIND_CLOZE_STYLER
@@ -66,8 +62,6 @@ class PIQA_ELLAMIND_CLOZE_HARD_DE(ComposedEval[str]):
 class PIQA_ELLAMIND_MC_EASY_DE(ComposedEval[str]):
     """German PIQA - MC format with easy distractor."""
 
-    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
-
     NAME = "PIQA_ELLAMIND_MC_EASY_DE"
     TASK_STYLER = PIQA_ELLAMIND_MC_STYLER
 
@@ -75,16 +69,12 @@ class PIQA_ELLAMIND_MC_EASY_DE(ComposedEval[str]):
 class PIQA_ELLAMIND_MC_HARD_DE(ComposedEval[str]):
     """German PIQA - MC format with hard distractor."""
 
-    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
-
     NAME = "PIQA_ELLAMIND_MC_HARD_DE"
     TASK_STYLER = PIQA_ELLAMIND_MC_STYLER
 
 
 class PIQA_ELLAMIND_BPB_DE(ComposedEval[str]):
     """German PIQA - BPB format (distractor set is irrelevant for BPB)."""
-
-    REVISION_LOCKFILE = HF_REVISIONS_LOCKFILE
 
     NAME = "PIQA_ELLAMIND_BPB_DE"
     TASK_STYLER = PIQA_ELLAMIND_BPB_STYLER
@@ -99,6 +89,7 @@ def _piqa_ellamind_benchmark(task: type[ComposedEval[str]], distractor_level: Li
         sample_split="validation",
         fewshot_split="validation",
         subjects=["deu"],
+        revision_lockfile=HF_REVISIONS_LOCKFILE,
         language=Language.DEU,
     )
 

--- a/src/eval_framework/tasks/dataset_loading.py
+++ b/src/eval_framework/tasks/dataset_loading.py
@@ -1,0 +1,36 @@
+"""Fetching a benchmark's dataset, kept out of the composed classes so they stay free of Hugging Face
+mechanics (revisions, cache directories, download config)."""
+
+import os
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import cast
+
+from datasets import DatasetDict, DownloadConfig, load_dataset
+
+
+class DatasetLoader(ABC):
+    """Loads a benchmark's dataset splits, selecting the subject config via ``name``."""
+
+    @abstractmethod
+    def load(self, name: str | None) -> DatasetDict: ...
+
+
+class HfDatasetLoader(DatasetLoader):
+    """Loads one Hugging Face dataset, pinned to ``revision``."""
+
+    def __init__(self, dataset_path: str, revision: str | None) -> None:
+        self._dataset_path = dataset_path
+        self.revision = revision
+
+    def load(self, name: str | None) -> DatasetDict:
+        cache_dir = os.environ.get("HF_DATASET_CACHE_DIR", f"{Path.home()}/.cache/huggingface/datasets")
+        download_config = DownloadConfig(cache_dir=cache_dir, max_retries=5)
+        dataset = load_dataset(
+            path=self._dataset_path,
+            name=name,
+            revision=self.revision,
+            cache_dir=cache_dir,
+            download_config=download_config,
+        )
+        return cast(DatasetDict, dataset)

--- a/src/eval_framework/tasks/dataset_loading.py
+++ b/src/eval_framework/tasks/dataset_loading.py
@@ -37,7 +37,12 @@ class HfDatasetLoader(DatasetLoader):
 
 
 class DatasetPolicy(ABC):
-    """Produces the loader for a benchmark's dataset, given a run's optional revision override."""
+    """Produces the loader for a benchmark's dataset, and documents where that dataset comes from."""
 
     @abstractmethod
     def loader(self, custom_hf_revision: str | None) -> DatasetLoader: ...
+
+    @abstractmethod
+    def documentation(self) -> str:
+        """Markdown for the task's ``## Dataset`` doc section, describing where the dataset comes from."""
+        ...

--- a/src/eval_framework/tasks/dataset_loading.py
+++ b/src/eval_framework/tasks/dataset_loading.py
@@ -34,3 +34,10 @@ class HfDatasetLoader(DatasetLoader):
             download_config=download_config,
         )
         return cast(DatasetDict, dataset)
+
+
+class DatasetPolicy(ABC):
+    """Produces the loader for a benchmark's dataset, given a run's optional revision override."""
+
+    @abstractmethod
+    def loader(self, custom_hf_revision: str | None) -> DatasetLoader: ...

--- a/src/eval_framework/tasks/dataset_loading.py
+++ b/src/eval_framework/tasks/dataset_loading.py
@@ -15,6 +15,11 @@ class DatasetLoader(ABC):
     @abstractmethod
     def load(self, name: str | None) -> DatasetDict: ...
 
+    @abstractmethod
+    def metadata(self) -> dict[str, str]:
+        """Dataset-identifying metadata merged into the eval's ``get_metadata`` (e.g. the dataset path)."""
+        ...
+
 
 class HfDatasetLoader(DatasetLoader):
     """Loads one Hugging Face dataset, pinned to ``revision``."""
@@ -22,6 +27,9 @@ class HfDatasetLoader(DatasetLoader):
     def __init__(self, dataset_path: str, revision: str | None) -> None:
         self._dataset_path = dataset_path
         self.revision = revision
+
+    def metadata(self) -> dict[str, str]:
+        return {"dataset_path": self._dataset_path}
 
     def load(self, name: str | None) -> DatasetDict:
         cache_dir = os.environ.get("HF_DATASET_CACHE_DIR", f"{Path.home()}/.cache/huggingface/datasets")

--- a/src/eval_framework/tasks/dataset_revisions.py
+++ b/src/eval_framework/tasks/dataset_revisions.py
@@ -97,6 +97,11 @@ class Pinned(DatasetPolicy):
         revision = custom_hf_revision or pinned_revision(self._lockfile, self._dataset_path)
         return HfDatasetLoader(self._dataset_path, revision)
 
+    def documentation(self) -> str:
+        url = f"https://huggingface.co/datasets/{self._dataset_path}"
+        revision = pinned_revision(self._lockfile, self._dataset_path)
+        return f"- Link to dataset: [{url}]({url})\n- Revision: {revision}"
+
 
 def pinned_by_framework(dataset_path: str) -> Pinned:
     """A ``Pinned`` policy binding ``dataset_path`` to the framework's bundled lock file."""

--- a/src/eval_framework/tasks/dataset_revisions.py
+++ b/src/eval_framework/tasks/dataset_revisions.py
@@ -1,8 +1,8 @@
 """Pinned Hugging Face dataset revisions.
 
-A lock file maps dataset paths to pinned commit SHAs. Tasks declare the lock file that
-governs them via their ``REVISION_LOCKFILE`` attribute and resolve their pin from it at
-construction time.
+A lock file maps dataset paths to pinned commit SHAs, so an eval runs against a reproducible
+dataset revision. ``BaseTask`` resolves its pin from the lock file named by ``REVISION_LOCKFILE``;
+composed benchmarks take a ``Pinned`` policy instead (usually via ``pinned_by_framework``).
 """
 
 import json
@@ -11,6 +11,8 @@ from functools import lru_cache
 from pathlib import Path
 
 from huggingface_hub import HfApi
+
+from eval_framework.tasks.dataset_loading import DatasetLoader, DatasetPolicy, HfDatasetLoader
 
 logger = logging.getLogger(__name__)
 
@@ -82,3 +84,20 @@ def pinned_revision(lockfile: Path, dataset_path: str) -> str:
         return _revisions_from_file(lockfile).revision_for(dataset_path)
     except KeyError:
         raise KeyError(f"Dataset '{dataset_path}' is not pinned in {lockfile}") from None
+
+
+class Pinned(DatasetPolicy):
+    """Pins ``dataset_path`` to the revision recorded for it in ``lockfile``; a run's override still wins."""
+
+    def __init__(self, lockfile: Path, dataset_path: str) -> None:
+        self._lockfile = lockfile
+        self._dataset_path = dataset_path
+
+    def loader(self, custom_hf_revision: str | None) -> DatasetLoader:
+        revision = custom_hf_revision or pinned_revision(self._lockfile, self._dataset_path)
+        return HfDatasetLoader(self._dataset_path, revision)
+
+
+def pinned_by_framework(dataset_path: str) -> Pinned:
+    """A ``Pinned`` policy binding ``dataset_path`` to the framework's bundled lock file."""
+    return Pinned(HF_REVISIONS_LOCKFILE, dataset_path)

--- a/src/eval_framework/tasks/markdown_doc.py
+++ b/src/eval_framework/tasks/markdown_doc.py
@@ -45,8 +45,8 @@ def markdown_doc(
 
     if http_path:
         buf.write(f"- Link to dataset: [{http_path}]({http_path})\n")
-    else:
-        assert example_messages is not None, "a task without a dataset link must supply an example sample"
+
+    if example_messages is not None:
         for split, size in (split_sizes or {}).items():
             buf.write(f"- `{split}` has {size} samples\n\n")
 

--- a/src/eval_framework/tasks/markdown_doc.py
+++ b/src/eval_framework/tasks/markdown_doc.py
@@ -8,7 +8,6 @@ from template_formatting.formatter import BaseFormatter, Message
 def markdown_doc(
     *,
     name: str,
-    dataset_path: str | None,
     dataset_doc: str,
     sample_split: str | None,
     fewshot_split: str | None,
@@ -27,10 +26,10 @@ def markdown_doc(
     buf = StringIO()
     buf.write(f"# {name}\n\n")
 
+    buf.write(f"## Dataset\n\n{dataset_doc}\n\n")
+
     buf.write("````\n")  # fence with 4 thicks because some prompts have code blocks with 3 thicks
     buf.write(f"NAME = {name}".strip() + "\n")
-    if dataset_path is not None:
-        buf.write(f"DATASET_PATH = {dataset_path}".strip() + "\n")
     if sample_split is not None:
         buf.write(f"SAMPLE_SPLIT = {sample_split}".strip() + "\n")
     if fewshot_split is not None:
@@ -42,8 +41,6 @@ def markdown_doc(
     if language is not None:
         buf.write(f"LANGUAGE = {language!r}".strip() + "\n")
     buf.write("````\n\n")
-
-    buf.write(f"## Dataset\n\n{dataset_doc}\n\n")
 
     if example_messages is not None:
         for split, size in (split_sizes or {}).items():

--- a/src/eval_framework/tasks/markdown_doc.py
+++ b/src/eval_framework/tasks/markdown_doc.py
@@ -9,6 +9,7 @@ def markdown_doc(
     *,
     name: str,
     dataset_path: str | None,
+    dataset_doc: str,
     sample_split: str | None,
     fewshot_split: str | None,
     response_type: str,
@@ -25,7 +26,6 @@ def markdown_doc(
     """Render a task's documentation as markdown"""
     buf = StringIO()
     buf.write(f"# {name}\n\n")
-    http_path = f"https://huggingface.co/datasets/{dataset_path}" if dataset_path else None
 
     buf.write("````\n")  # fence with 4 thicks because some prompts have code blocks with 3 thicks
     buf.write(f"NAME = {name}".strip() + "\n")
@@ -43,8 +43,7 @@ def markdown_doc(
         buf.write(f"LANGUAGE = {language!r}".strip() + "\n")
     buf.write("````\n\n")
 
-    if http_path:
-        buf.write(f"- Link to dataset: [{http_path}]({http_path})\n")
+    buf.write(f"## Dataset\n\n{dataset_doc}\n\n")
 
     if example_messages is not None:
         for split, size in (split_sizes or {}).items():

--- a/tests/tests_eval_framework/tasks/test_dataset_revisions.py
+++ b/tests/tests_eval_framework/tasks/test_dataset_revisions.py
@@ -122,3 +122,18 @@ def test_pinned_by_framework_binds_the_bundled_lockfile() -> None:
 
     # Then the loader carries the framework-pinned revision
     assert loader.revision == sha
+
+
+def test_pinned_documentation_links_dataset_and_records_revision(tmp_path: Path) -> None:
+    # Given a lock file that pins the dataset
+    lockfile = tmp_path / "hf-dataset-revisions.json"
+    dr.HfDatasetRevisions({"my/dataset": "pinned-sha"}).to_file(lockfile)
+
+    # When documenting the policy
+    doc = dr.Pinned(lockfile, "my/dataset").documentation()
+
+    # Then it links the dataset and records the pinned revision
+    assert doc == (
+        "- Link to dataset: [https://huggingface.co/datasets/my/dataset]"
+        "(https://huggingface.co/datasets/my/dataset)\n- Revision: pinned-sha"
+    )

--- a/tests/tests_eval_framework/tasks/test_dataset_revisions.py
+++ b/tests/tests_eval_framework/tasks/test_dataset_revisions.py
@@ -76,3 +76,49 @@ def test_hf_dataset_revisions_file_is_sorted_by_dataset_path(tmp_path: Path) -> 
     dr.HfDatasetRevisions({"org/b": "sha-b", "org/a": "sha-a"}).to_file(lockfile)
 
     assert lockfile.read_text(encoding="utf-8").index('"org/a"') < lockfile.read_text(encoding="utf-8").index('"org/b"')
+
+
+def test_pinned_policy_loads_recorded_revision(tmp_path: Path) -> None:
+    # Given a lock file that pins the dataset
+    lockfile = tmp_path / "hf-dataset-revisions.json"
+    dr.HfDatasetRevisions({"my/dataset": "pinned-sha"}).to_file(lockfile)
+
+    # When building a loader without an override
+    loader = dr.Pinned(lockfile, "my/dataset").loader(None)
+
+    # Then the loader carries that dataset's pinned revision
+    assert loader.revision == "pinned-sha"
+
+
+def test_pinned_policy_override_beats_pin(tmp_path: Path) -> None:
+    # Given a lock file that pins the dataset
+    lockfile = tmp_path / "hf-dataset-revisions.json"
+    dr.HfDatasetRevisions({"my/dataset": "pinned-sha"}).to_file(lockfile)
+
+    # When building a loader with an explicit override
+    loader = dr.Pinned(lockfile, "my/dataset").loader("custom-sha")
+
+    # Then the override wins
+    assert loader.revision == "custom-sha"
+
+
+def test_pinned_policy_missing_pin_raises(tmp_path: Path) -> None:
+    # Given a lock file with no entry for the dataset
+    lockfile = tmp_path / "hf-dataset-revisions.json"
+    dr.HfDatasetRevisions({}).to_file(lockfile)
+
+    # Then building a loader fails
+    with pytest.raises(KeyError, match="not pinned"):
+        dr.Pinned(lockfile, "my/dataset").loader(None)
+
+
+def test_pinned_by_framework_binds_the_bundled_lockfile() -> None:
+    # Given a dataset the framework already pins
+    pins = dr.HfDatasetRevisions.from_file(dr.HF_REVISIONS_LOCKFILE).to_dict()
+    dataset_path, sha = next(iter(pins.items()))
+
+    # When building its loader with no override
+    loader = dr.pinned_by_framework(dataset_path).loader(None)
+
+    # Then the loader carries the framework-pinned revision
+    assert loader.revision == sha

--- a/tests/tests_eval_framework/tasks/test_markdown_doc.py
+++ b/tests/tests_eval_framework/tasks/test_markdown_doc.py
@@ -12,7 +12,6 @@ class ExampleFormatter:
 def test_markdown_doc_with_examples() -> None:
     doc = markdown_doc(
         name="MyTask",
-        dataset_path=None,
         dataset_doc="No information about dataset",
         sample_split="test",
         fewshot_split="train",
@@ -33,6 +32,10 @@ def test_markdown_doc_with_examples() -> None:
         == """\
 # MyTask
 
+## Dataset
+
+No information about dataset
+
 ````
 NAME = MyTask
 SAMPLE_SPLIT = test
@@ -41,10 +44,6 @@ RESPONSE_TYPE = COMPLETION
 METRICS = [Accuracy, F1]
 SUBJECTS = ['no_subject']
 ````
-
-## Dataset
-
-No information about dataset
 
 - `test` has 3 samples
 
@@ -73,10 +72,8 @@ No information about dataset
 
 
 def test_markdown_doc_inserts_dataset_section_verbatim() -> None:
-    # render is agnostic to what the dataset section says; it just places the supplied doc under a heading.
     doc = markdown_doc(
         name="MyTask",
-        dataset_path="datasets/mytask",
         dataset_doc="- line one\n- line two",
         sample_split="test",
         fewshot_split="train",
@@ -97,20 +94,19 @@ def test_markdown_doc_inserts_dataset_section_verbatim() -> None:
         == """\
 # MyTask
 
+## Dataset
+
+- line one
+- line two
+
 ````
 NAME = MyTask
-DATASET_PATH = datasets/mytask
 SAMPLE_SPLIT = test
 FEWSHOT_SPLIT = train
 RESPONSE_TYPE = COMPLETION
 METRICS = [Accuracy, F1]
 SUBJECTS = ['no_subject']
 ````
-
-## Dataset
-
-- line one
-- line two
 
 """
     )

--- a/tests/tests_eval_framework/tasks/test_markdown_doc.py
+++ b/tests/tests_eval_framework/tasks/test_markdown_doc.py
@@ -67,7 +67,45 @@ SUBJECTS = ['no_subject']
     )
 
 
-def test_markdown_doc_with_dataset_link() -> None:
+def test_markdown_doc_with_dataset_link_only() -> None:
+    doc = markdown_doc(
+        name="MyTask",
+        dataset_path="datasets/mytask",
+        sample_split="test",
+        fewshot_split="train",
+        response_type="COMPLETION",
+        metrics=["Accuracy", "F1"],
+        subjects=["no_subject"],
+        language=None,
+        num_fewshot=1,
+        formatters=[ExampleFormatter()],
+        example_messages=None,
+        split_sizes=None,
+        possible_completions=None,
+        ground_truth=None,
+    )
+
+    assert (
+        doc
+        == """\
+# MyTask
+
+````
+NAME = MyTask
+DATASET_PATH = datasets/mytask
+SAMPLE_SPLIT = test
+FEWSHOT_SPLIT = train
+RESPONSE_TYPE = COMPLETION
+METRICS = [Accuracy, F1]
+SUBJECTS = ['no_subject']
+````
+
+- Link to dataset: [https://huggingface.co/datasets/datasets/mytask](https://huggingface.co/datasets/datasets/mytask)
+"""
+    )
+
+
+def test_markdown_doc_with_dataset_link_and_example() -> None:
     doc = markdown_doc(
         name="MyTask",
         dataset_path="datasets/mytask",
@@ -101,5 +139,27 @@ SUBJECTS = ['no_subject']
 ````
 
 - Link to dataset: [https://huggingface.co/datasets/datasets/mytask](https://huggingface.co/datasets/datasets/mytask)
+- `test` has 3 samples
+
+- `train` has 5 samples
+
+## Example prompt with ExampleFormatter (1-shot)
+
+````
+"USER: Q"
+````
+
+## Possible completions:
+
+````
+- "A"
+- "B"
+````
+
+## Ground truth:
+
+````
+- "A"
+````
 """
     )

--- a/tests/tests_eval_framework/tasks/test_markdown_doc.py
+++ b/tests/tests_eval_framework/tasks/test_markdown_doc.py
@@ -13,6 +13,7 @@ def test_markdown_doc_with_examples() -> None:
     doc = markdown_doc(
         name="MyTask",
         dataset_path=None,
+        dataset_doc="No information about dataset",
         sample_split="test",
         fewshot_split="train",
         response_type="COMPLETION",
@@ -41,6 +42,10 @@ METRICS = [Accuracy, F1]
 SUBJECTS = ['no_subject']
 ````
 
+## Dataset
+
+No information about dataset
+
 - `test` has 3 samples
 
 - `train` has 5 samples
@@ -67,10 +72,12 @@ SUBJECTS = ['no_subject']
     )
 
 
-def test_markdown_doc_with_dataset_link_only() -> None:
+def test_markdown_doc_inserts_dataset_section_verbatim() -> None:
+    # render is agnostic to what the dataset section says; it just places the supplied doc under a heading.
     doc = markdown_doc(
         name="MyTask",
         dataset_path="datasets/mytask",
+        dataset_doc="- line one\n- line two",
         sample_split="test",
         fewshot_split="train",
         response_type="COMPLETION",
@@ -100,66 +107,10 @@ METRICS = [Accuracy, F1]
 SUBJECTS = ['no_subject']
 ````
 
-- Link to dataset: [https://huggingface.co/datasets/datasets/mytask](https://huggingface.co/datasets/datasets/mytask)
-"""
-    )
+## Dataset
 
+- line one
+- line two
 
-def test_markdown_doc_with_dataset_link_and_example() -> None:
-    doc = markdown_doc(
-        name="MyTask",
-        dataset_path="datasets/mytask",
-        sample_split="test",
-        fewshot_split="train",
-        response_type="COMPLETION",
-        metrics=["Accuracy", "F1"],
-        subjects=["no_subject"],
-        language=None,
-        num_fewshot=1,
-        formatters=[ExampleFormatter()],
-        example_messages=[Message(role=Role.USER, content="Q")],
-        split_sizes={"test": 3, "train": 5},
-        possible_completions=["A", "B"],
-        ground_truth="A",
-    )
-
-    assert (
-        doc
-        == """\
-# MyTask
-
-````
-NAME = MyTask
-DATASET_PATH = datasets/mytask
-SAMPLE_SPLIT = test
-FEWSHOT_SPLIT = train
-RESPONSE_TYPE = COMPLETION
-METRICS = [Accuracy, F1]
-SUBJECTS = ['no_subject']
-````
-
-- Link to dataset: [https://huggingface.co/datasets/datasets/mytask](https://huggingface.co/datasets/datasets/mytask)
-- `test` has 3 samples
-
-- `train` has 5 samples
-
-## Example prompt with ExampleFormatter (1-shot)
-
-````
-"USER: Q"
-````
-
-## Possible completions:
-
-````
-- "A"
-- "B"
-````
-
-## Ground truth:
-
-````
-- "A"
-````
 """
     )

--- a/tests/tests_eval_framework/test_base_task.py
+++ b/tests/tests_eval_framework/test_base_task.py
@@ -9,7 +9,7 @@ from eval_framework.metrics.efficiency.bytes_per_sequence_position import BytesC
 from eval_framework.metrics.efficiency.token_counters import TokenCounts
 from eval_framework.run import parse_args
 from eval_framework.tasks import dataset_revisions as dr
-from eval_framework.tasks.base import BaseTask, ResponseType
+from eval_framework.tasks.base import BaseTask, ResponseType, hf_dataset_link
 from template_formatting.formatter import Message, Role
 
 
@@ -264,3 +264,9 @@ def test_completion_metrics_returns_all_completion_metrics() -> None:
         SequencePositionsCompletion,
         TokenCounts,
     }
+
+
+def test_hf_dataset_link_formats_markdown_link() -> None:
+    assert hf_dataset_link("org/data") == (
+        "- Link to dataset: [https://huggingface.co/datasets/org/data](https://huggingface.co/datasets/org/data)"
+    )

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from eval_framework.composed import ChoiceFields, ChoiceReader, ComposedEval
+from eval_framework.composed import ChoiceFields, ChoiceReader, ComposedBenchmark, ComposedEval
 from eval_framework.contract import ResponseType
 from eval_framework.metrics.base import BaseMetric
 from eval_framework.metrics.efficiency.bytes_per_sequence_position import (
@@ -28,6 +28,7 @@ class _DummyReader(ChoiceReader):
 _DUMMY_READER = _DummyReader()
 _DUMMY_DATASET_PATH = "dummy/dataset"
 _DUMMY_SPLIT = "test"
+_DUMMY_SUBJECTS = ["subject"]
 
 
 class _DummyStyler(TaskStyler):
@@ -150,38 +151,24 @@ def test_task_custom_subjects(
 ) -> None:
     class MyTask(ComposedEval):
         REVISION_LOCKFILE = None
-        SUBJECTS = subjects
         NAME = "MyTask"
+        TASK_STYLER = _DummyStyler()
 
-        def _get_instruction_text(self, item: dict[str, Any]) -> str:
-            return ""
-
-        def _get_ground_truth(self, item: dict[str, Any]) -> list[str]:
-            return []
-
+    benchmark = ComposedBenchmark.from_base(
+        MyTask,
+        reader=_DUMMY_READER,
+        dataset_path=_DUMMY_DATASET_PATH,
+        sample_split=_DUMMY_SPLIT,
+        fewshot_split=_DUMMY_SPLIT,
+        subjects=subjects,
+    )
+    # Filtering by custom subjects happens in create(), so exercise it there.
     if expected_value == "ValueError":
         with pytest.raises(ValueError):
-            task = MyTask(
-                num_fewshot=0,
-                reader=_DUMMY_READER,
-                dataset_path=_DUMMY_DATASET_PATH,
-                sample_split=_DUMMY_SPLIT,
-                fewshot_split=_DUMMY_SPLIT,
-                custom_subjects=custom_subjects,
-                custom_hf_revision=None,
-            )
+            benchmark.create(0, custom_subjects, None)
     else:
-        task = MyTask(
-            num_fewshot=0,
-            reader=_DUMMY_READER,
-            dataset_path=_DUMMY_DATASET_PATH,
-            sample_split=_DUMMY_SPLIT,
-            fewshot_split=_DUMMY_SPLIT,
-            custom_subjects=custom_subjects,
-            custom_hf_revision=None,
-        )
-        result = task.SUBJECTS
-        assert result == expected_value
+        task = benchmark.create(0, custom_subjects, None)
+        assert task.subjects == expected_value
 
 
 def test_base_task() -> None:
@@ -206,7 +193,11 @@ def test_base_task() -> None:
             return []
 
     task1 = MyTask1(
-        reader=_DUMMY_READER, dataset_path=_DUMMY_DATASET_PATH, sample_split=_DUMMY_SPLIT, fewshot_split=_DUMMY_SPLIT
+        reader=_DUMMY_READER,
+        dataset_path=_DUMMY_DATASET_PATH,
+        sample_split=_DUMMY_SPLIT,
+        fewshot_split=_DUMMY_SPLIT,
+        subjects=_DUMMY_SUBJECTS,
     )
     assert task1.NAME == "MyTask1"
 
@@ -216,7 +207,7 @@ def test_base_task() -> None:
         dataset_path=_DUMMY_DATASET_PATH,
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
-        custom_subjects=None,
+        subjects=_DUMMY_SUBJECTS,
         custom_hf_revision=None,
     )
     assert task2.NAME == "MyTask2"
@@ -236,7 +227,7 @@ def test_user_prompt_suffix_rejected() -> None:
             dataset_path=_DUMMY_DATASET_PATH,
             sample_split=_DUMMY_SPLIT,
             fewshot_split=_DUMMY_SPLIT,
-            custom_subjects=None,
+            subjects=_DUMMY_SUBJECTS,
             custom_hf_revision=None,
             user_prompt_suffix="/think_short",
         )
@@ -277,7 +268,7 @@ def test_pinned_hf_revision_applied_when_unset(tmp_path: Path) -> None:
         dataset_path="my/dataset",
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
-        custom_subjects=None,
+        subjects=_DUMMY_SUBJECTS,
         custom_hf_revision=None,
     )
 
@@ -293,7 +284,7 @@ def test_task_without_lockfile_is_not_pinned() -> None:
         dataset_path="my/dataset",
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
-        custom_subjects=None,
+        subjects=_DUMMY_SUBJECTS,
         custom_hf_revision=None,
     )
 
@@ -314,7 +305,7 @@ def test_missing_pin_in_declared_lockfile_raises(tmp_path: Path) -> None:
             dataset_path="my/dataset",
             sample_split=_DUMMY_SPLIT,
             fewshot_split=_DUMMY_SPLIT,
-            custom_subjects=None,
+            subjects=_DUMMY_SUBJECTS,
             custom_hf_revision=None,
         )
 
@@ -331,7 +322,7 @@ def test_custom_hf_revision_overrides_pinned(tmp_path: Path) -> None:
         dataset_path="my/dataset",
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
-        custom_subjects=None,
+        subjects=_DUMMY_SUBJECTS,
         custom_hf_revision="custom-sha",
     )
 
@@ -348,7 +339,11 @@ def test_get_metrics_combines_styler_and_response_type_metrics() -> None:
 
     # Then its metrics are the styler's metrics plus the loglikelihood response-type metrics
     task = MyTask(
-        reader=_DUMMY_READER, dataset_path=_DUMMY_DATASET_PATH, sample_split=_DUMMY_SPLIT, fewshot_split=_DUMMY_SPLIT
+        reader=_DUMMY_READER,
+        dataset_path=_DUMMY_DATASET_PATH,
+        sample_split=_DUMMY_SPLIT,
+        fewshot_split=_DUMMY_SPLIT,
+        subjects=_DUMMY_SUBJECTS,
     )
     assert set(task.get_metrics()) == {_FakeMetric, BytesLoglikelihood, SequencePositionsLoglikelihood}
 
@@ -372,7 +367,11 @@ def test_get_messages_assembles_instruction_and_cue() -> None:
         TASK_STYLER = _Styler()
 
     task = MyTask(
-        reader=_Reader(), dataset_path=_DUMMY_DATASET_PATH, sample_split=_DUMMY_SPLIT, fewshot_split=_DUMMY_SPLIT
+        reader=_Reader(),
+        dataset_path=_DUMMY_DATASET_PATH,
+        sample_split=_DUMMY_SPLIT,
+        fewshot_split=_DUMMY_SPLIT,
+        subjects=_DUMMY_SUBJECTS,
     )
 
     # Then the instruction becomes the evaluated USER turn and the cue an ASSISTANT turn

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -31,6 +31,9 @@ class _DummyDatasetLoader(DatasetLoader):
     def load(self, name: str | None) -> DatasetDict:
         return DatasetDict()
 
+    def metadata(self) -> dict[str, str]:
+        return {}
+
 
 class _DummyDatasetPolicy(DatasetPolicy):
     """A no-op policy for benchmark doubles that never load a dataset."""
@@ -229,6 +232,9 @@ def test_markdown_doc_renders_policy_dataset_section_and_example() -> None:
         def load(self, name: str | None) -> DatasetDict:
             return DatasetDict({_DUMMY_SPLIT: Dataset.from_list([{"x": 1}, {"x": 2}])})
 
+        def metadata(self) -> dict[str, str]:
+            return {}
+
     class _FixturePolicy(DatasetPolicy):
         def loader(self, custom_hf_revision: str | None) -> DatasetLoader:
             return _FixtureLoader()
@@ -266,7 +272,6 @@ def test_base_task() -> None:
     task1 = MyTask1(
         reader=_DUMMY_READER,
         loader=_DUMMY_LOADER,
-        dataset_path=_DUMMY_DATASET_PATH,
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
@@ -277,7 +282,6 @@ def test_base_task() -> None:
         0,
         reader=_DUMMY_READER,
         loader=_DUMMY_LOADER,
-        dataset_path=_DUMMY_DATASET_PATH,
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
@@ -296,7 +300,6 @@ def test_user_prompt_suffix_rejected() -> None:
             0,
             reader=_DUMMY_READER,
             loader=_DUMMY_LOADER,
-            dataset_path=_DUMMY_DATASET_PATH,
             sample_split=_DUMMY_SPLIT,
             fewshot_split=_DUMMY_SPLIT,
             subjects=_DUMMY_SUBJECTS,
@@ -321,12 +324,36 @@ def test_get_metrics_combines_styler_and_response_type_metrics() -> None:
     task = MyTask(
         reader=_DUMMY_READER,
         loader=_DUMMY_LOADER,
-        dataset_path=_DUMMY_DATASET_PATH,
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
     )
     assert set(task.get_metrics()) == {_FakeMetric, BytesLoglikelihood, SequencePositionsLoglikelihood}
+
+
+def test_get_metadata_reports_dataset_path_from_loader() -> None:
+    # Given an eval whose loader reports a dataset path
+    class _LoaderStub(DatasetLoader):
+        def load(self, name: str | None) -> DatasetDict:
+            return DatasetDict()
+
+        def metadata(self) -> dict[str, str]:
+            return {"dataset_path": "some/dataset"}
+
+    class MyTask(ComposedEval):
+        NAME = "MyTask"
+        TASK_STYLER = _DummyStyler()
+
+    task = MyTask(
+        reader=_DUMMY_READER,
+        loader=_LoaderStub(),
+        sample_split=_DUMMY_SPLIT,
+        fewshot_split=_DUMMY_SPLIT,
+        subjects=_DUMMY_SUBJECTS,
+    )
+
+    # Then get_metadata reports that dataset path
+    assert task.get_metadata()["dataset_path"] == "some/dataset"
 
 
 def test_get_messages_assembles_instruction_and_cue() -> None:
@@ -349,7 +376,6 @@ def test_get_messages_assembles_instruction_and_cue() -> None:
     task = MyTask(
         reader=_Reader(),
         loader=_DUMMY_LOADER,
-        dataset_path=_DUMMY_DATASET_PATH,
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -2,7 +2,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-from datasets import DatasetDict
+from datasets import Dataset, DatasetDict
 
 from eval_framework.composed import ChoiceFields, ChoiceReader, ComposedBenchmark, ComposedEval
 from eval_framework.contract import ResponseType
@@ -14,7 +14,7 @@ from eval_framework.metrics.efficiency.bytes_per_sequence_position import (
 from eval_framework.run import parse_args
 from eval_framework.tasks.dataset_loading import DatasetLoader, DatasetPolicy
 from eval_framework.tasks.task_style import TaskStyle, TaskStyler
-from template_formatting.formatter import Message, Role
+from template_formatting.formatter import ConcatFormatter, Message, Role
 
 
 class _DummyReader(ChoiceReader):
@@ -215,6 +215,24 @@ def test_create_resolves_loader_through_policy_with_revision_override() -> None:
 
     # Then create forwards the override to the policy
     assert policy.calls == ["custom-sha"]
+
+
+def test_markdown_doc_renders_link_and_example_for_composed_benchmark() -> None:
+    # Given a policy whose loader serves a fixture dataset (no network)
+    class _FixtureLoader(DatasetLoader):
+        def load(self, name: str | None) -> DatasetDict:
+            return DatasetDict({_DUMMY_SPLIT: Dataset.from_list([{"x": 1}, {"x": 2}])})
+
+    class _FixturePolicy(DatasetPolicy):
+        def loader(self, custom_hf_revision: str | None) -> DatasetLoader:
+            return _FixtureLoader()
+
+    # When rendering the benchmark's documentation
+    doc = _benchmark_with_subjects(_DUMMY_SUBJECTS, _FixturePolicy()).markdown_doc([ConcatFormatter()])
+
+    # Then it shows both the dataset link and an example prompt
+    assert "Link to dataset" in doc
+    assert "## Example prompt" in doc
 
 
 def test_base_task() -> None:

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -48,7 +48,6 @@ class _DummyDatasetPolicy(DatasetPolicy):
 _DUMMY_READER = _DummyReader()
 _DUMMY_LOADER = _DummyDatasetLoader()
 _DUMMY_POLICY = _DummyDatasetPolicy()
-_DUMMY_DATASET_PATH = "dummy/dataset"
 _DUMMY_SPLIT = "test"
 _DUMMY_SUBJECTS = ["subject"]
 
@@ -108,7 +107,6 @@ def _benchmark_with_subjects(subjects: list[Any], dataset_policy: DatasetPolicy)
     return ComposedBenchmark.from_base(
         MyTask,
         reader=_DUMMY_READER,
-        dataset_path=_DUMMY_DATASET_PATH,
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=subjects,

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -48,7 +48,6 @@ class _DummyDatasetPolicy(DatasetPolicy):
 
 _DUMMY_READER = _DummyReader()
 _DUMMY_LOADER = _DummyDatasetLoader()
-_DUMMY_POLICY = _DummyDatasetPolicy()
 _DUMMY_RNG = random.Random(0)
 _DUMMY_SPLIT = "test"
 _DUMMY_SUBJECTS = ["subject"]
@@ -101,36 +100,40 @@ class _StubTaskStyler(TaskStyler):
         return ""
 
 
-def _benchmark_with_subjects(
-    subjects: list[Any],
-    dataset_policy: DatasetPolicy,
+def _make_benchmark(
+    *,
     id: str = "dummy-benchmark",
     display_name: str | None = None,
+    styler: TaskStyler | None = None,
+    reader: ChoiceReader = _DUMMY_READER,
+    sample_split: str = _DUMMY_SPLIT,
+    fewshot_split: str = _DUMMY_SPLIT,
+    subjects: list[Any] = _DUMMY_SUBJECTS,
+    dataset_policy: DatasetPolicy | None = None,
+    language: LanguageSpec = None,
 ) -> ComposedBenchmark:
-    class MyTask(ComposedEval):
-        TASK_STYLER = _DummyStyler()
-
-    return ComposedBenchmark.from_base(
-        MyTask,
+    """Build a ``ComposedBenchmark`` for tests, defaulting to dummies for every argument the test does not provide."""
+    return ComposedBenchmark.compose(
         id=id,
         display_name=display_name,
-        reader=_DUMMY_READER,
-        sample_split=_DUMMY_SPLIT,
-        fewshot_split=_DUMMY_SPLIT,
+        styler=styler or _DummyStyler(),
+        reader=reader,
+        sample_split=sample_split,
+        fewshot_split=fewshot_split,
         subjects=subjects,
-        dataset_policy=dataset_policy,
-        language=None,
+        dataset_policy=dataset_policy or _DummyDatasetPolicy(),
+        language=language,
     )
 
 
 def _make_eval(
-    task_cls: type[ComposedEval],
     *,
     id: str = "dummy-eval",
     display_name: str = "dummy-eval",
     num_fewshot: int = 0,
     reader: ChoiceReader = _DUMMY_READER,
     loader: DatasetLoader = _DUMMY_LOADER,
+    styler: TaskStyler | None = None,
     sample_split: str = _DUMMY_SPLIT,
     fewshot_split: str = _DUMMY_SPLIT,
     subjects: list[Any] = _DUMMY_SUBJECTS,
@@ -138,12 +141,13 @@ def _make_eval(
     rnd: random.Random = _DUMMY_RNG,
 ) -> ComposedEval:
     """Build a ``ComposedEval`` for tests, defaulting to dummies for every argument the test does not provide."""
-    return task_cls(
+    return ComposedEval(
         num_fewshot,
         id=id,
         display_name=display_name,
         reader=reader,
         loader=loader,
+        styler=styler or _DummyStyler(),
         sample_split=sample_split,
         fewshot_split=fewshot_split,
         subjects=subjects,
@@ -220,7 +224,7 @@ def test_task_custom_subjects(
     expected: list[str] | list[tuple],
 ) -> None:
     # Filtering by custom subjects happens in create().
-    task = _benchmark_with_subjects(subjects, _DUMMY_POLICY).create(0, custom_subjects, None)
+    task = _make_benchmark(subjects=subjects).create(0, custom_subjects, None)
     assert task.subjects == expected
 
 
@@ -237,7 +241,7 @@ def test_task_custom_subjects(
 )
 def test_task_custom_subjects_rejects_unknown(subjects: list[str] | list[tuple], custom_subjects: list[str]) -> None:
     with pytest.raises(ValueError):
-        _benchmark_with_subjects(subjects, _DUMMY_POLICY).create(0, custom_subjects, None)
+        _make_benchmark(subjects=subjects).create(0, custom_subjects, None)
 
 
 def test_create_resolves_loader_through_policy_with_revision_override() -> None:
@@ -256,7 +260,7 @@ def test_create_resolves_loader_through_policy_with_revision_override() -> None:
     policy = _SpyPolicy()
 
     # When creating an eval with a revision override
-    _benchmark_with_subjects(_DUMMY_SUBJECTS, policy).create(0, None, "custom-sha")
+    _make_benchmark(dataset_policy=policy).create(0, None, "custom-sha")
 
     # Then create forwards the override to the policy
     assert policy.calls == ["custom-sha"]
@@ -279,7 +283,7 @@ def test_markdown_doc_renders_policy_dataset_section_and_example() -> None:
             return "FIXTURE DATASET DOC"
 
     # When rendering the benchmark's documentation
-    doc = _benchmark_with_subjects(_DUMMY_SUBJECTS, _FixturePolicy()).markdown_doc([ConcatFormatter()])
+    doc = _make_benchmark(dataset_policy=_FixturePolicy()).markdown_doc([ConcatFormatter()])
 
     # Then the policy's dataset section and an example prompt both appear
     assert "## Dataset\n\nFIXTURE DATASET DOC" in doc
@@ -287,12 +291,12 @@ def test_markdown_doc_renders_policy_dataset_section_and_example() -> None:
 
 
 def test_display_name_defaults_to_id() -> None:
-    benchmark = _benchmark_with_subjects(_DUMMY_SUBJECTS, _DUMMY_POLICY, id="the-id")
+    benchmark = _make_benchmark(id="the-id")
     assert benchmark.display_name() == "the-id"
 
 
 def test_id_and_display_name_reach_the_eval() -> None:
-    benchmark = _benchmark_with_subjects(_DUMMY_SUBJECTS, _DUMMY_POLICY, id="the-id", display_name="Nice Name")
+    benchmark = _make_benchmark(id="the-id", display_name="Nice Name")
     assert (benchmark.id(), benchmark.display_name()) == ("the-id", "Nice Name")
 
     task = benchmark.create(0, None, None)
@@ -302,9 +306,7 @@ def test_id_and_display_name_reach_the_eval() -> None:
 def test_user_prompt_suffix_rejected() -> None:
     # Composed evals have no completion path, so create rejects a user prompt suffix
     with pytest.raises(ValueError, match="only supported for completion tasks"):
-        _benchmark_with_subjects(_DUMMY_SUBJECTS, _DUMMY_POLICY).create(
-            0, None, None, user_prompt_suffix="/think_short"
-        )
+        _make_benchmark().create(0, None, None, user_prompt_suffix="/think_short")
 
 
 def test_cli_user_prompt_suffix_parsing() -> None:
@@ -314,14 +316,10 @@ def test_cli_user_prompt_suffix_parsing() -> None:
     assert args.user_prompt_suffix == "/think_short"
 
 
-def test_get_metrics_combines_styler_and_response_type_metrics() -> None:
-    # Given a composed eval whose styler declares its own metrics
-    class MyTask(ComposedEval):
-        TASK_STYLER = _StubTaskStyler()
-
-    # Then its metrics are the styler's metrics plus the loglikelihood response-type metrics
-    task = _make_eval(MyTask)
-    assert set(task.get_metrics()) == {_FakeMetric, BytesLoglikelihood, SequencePositionsLoglikelihood}
+def test_metrics_combine_styler_and_response_type_metrics() -> None:
+    # A benchmark's metrics are its styler's own metrics plus the ones its response type requires.
+    benchmark = _make_benchmark(styler=_StubTaskStyler())
+    assert set(benchmark.metrics()) == {_FakeMetric, BytesLoglikelihood, SequencePositionsLoglikelihood}
 
 
 def test_get_metadata_reports_dataset_path_from_loader() -> None:
@@ -333,10 +331,7 @@ def test_get_metadata_reports_dataset_path_from_loader() -> None:
         def metadata(self) -> dict[str, str]:
             return {"dataset_path": "some/dataset"}
 
-    class MyTask(ComposedEval):
-        TASK_STYLER = _DummyStyler()
-
-    task = _make_eval(MyTask, loader=_LoaderStub())
+    task = _make_eval(loader=_LoaderStub())
 
     # Then get_metadata reports that dataset path
     assert task.get_metadata()["dataset_path"] == "some/dataset"
@@ -355,10 +350,7 @@ def test_get_messages_assembles_instruction_and_cue() -> None:
         def get_cue_text(self) -> str:
             return "the cue"
 
-    class MyTask(ComposedEval):
-        TASK_STYLER = _Styler()
-
-    task = _make_eval(MyTask, reader=_Reader())
+    task = _make_eval(reader=_Reader(), styler=_Styler())
 
     # Then the instruction becomes the evaluated USER turn and the cue an ASSISTANT turn
     assert task._get_messages({"question": "the goal"}) == [

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -38,6 +38,9 @@ class _DummyDatasetPolicy(DatasetPolicy):
     def loader(self, custom_hf_revision: str | None) -> DatasetLoader:
         return _DUMMY_LOADER
 
+    def documentation(self) -> str:
+        return ""
+
 
 _DUMMY_READER = _DummyReader()
 _DUMMY_LOADER = _DummyDatasetLoader()
@@ -208,6 +211,9 @@ def test_create_resolves_loader_through_policy_with_revision_override() -> None:
             self.calls.append(custom_hf_revision)
             return _DUMMY_LOADER
 
+        def documentation(self) -> str:
+            return ""
+
     policy = _SpyPolicy()
 
     # When creating an eval with a revision override
@@ -217,8 +223,8 @@ def test_create_resolves_loader_through_policy_with_revision_override() -> None:
     assert policy.calls == ["custom-sha"]
 
 
-def test_markdown_doc_renders_link_and_example_for_composed_benchmark() -> None:
-    # Given a policy whose loader serves a fixture dataset (no network)
+def test_markdown_doc_renders_policy_dataset_section_and_example() -> None:
+    # Given a policy whose loader serves a fixture dataset (no network) and documents itself
     class _FixtureLoader(DatasetLoader):
         def load(self, name: str | None) -> DatasetDict:
             return DatasetDict({_DUMMY_SPLIT: Dataset.from_list([{"x": 1}, {"x": 2}])})
@@ -227,11 +233,14 @@ def test_markdown_doc_renders_link_and_example_for_composed_benchmark() -> None:
         def loader(self, custom_hf_revision: str | None) -> DatasetLoader:
             return _FixtureLoader()
 
+        def documentation(self) -> str:
+            return "FIXTURE DATASET DOC"
+
     # When rendering the benchmark's documentation
     doc = _benchmark_with_subjects(_DUMMY_SUBJECTS, _FixturePolicy()).markdown_doc([ConcatFormatter()])
 
-    # Then it shows both the dataset link and an example prompt
-    assert "Link to dataset" in doc
+    # Then the policy's dataset section and an example prompt both appear
+    assert "## Dataset\n\nFIXTURE DATASET DOC" in doc
     assert "## Example prompt" in doc
 
 

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -3,6 +3,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from datasets import DatasetDict
 
 from eval_framework.composed import ChoiceFields, ChoiceReader, ComposedBenchmark, ComposedEval
 from eval_framework.contract import ResponseType
@@ -13,6 +14,7 @@ from eval_framework.metrics.efficiency.bytes_per_sequence_position import (
 )
 from eval_framework.run import parse_args
 from eval_framework.tasks import dataset_revisions as dr
+from eval_framework.tasks.dataset_loading import DatasetLoader
 from eval_framework.tasks.task_style import TaskStyle, TaskStyler
 from template_formatting.formatter import Message, Role
 
@@ -25,7 +27,15 @@ class _DummyReader(ChoiceReader):
         return ChoiceFields(raw_question="", choices=[], correct_index=0)
 
 
+class _DummyDatasetLoader(DatasetLoader):
+    """A no-op loader for doubles that never load a dataset."""
+
+    def load(self, name: str | None) -> DatasetDict:
+        return DatasetDict()
+
+
 _DUMMY_READER = _DummyReader()
+_DUMMY_LOADER = _DummyDatasetLoader()
 _DUMMY_DATASET_PATH = "dummy/dataset"
 _DUMMY_SPLIT = "test"
 _DUMMY_SUBJECTS = ["subject"]
@@ -78,7 +88,7 @@ class _StubTaskStyler(TaskStyler):
         return ""
 
 
-def _benchmark_with_subjects(subjects: list[Any]) -> ComposedBenchmark:
+def _benchmark_with_subjects(subjects: list[Any], revision_lockfile: Path) -> ComposedBenchmark:
     class MyTask(ComposedEval):
         NAME = "MyTask"
         TASK_STYLER = _DummyStyler()
@@ -90,8 +100,16 @@ def _benchmark_with_subjects(subjects: list[Any]) -> ComposedBenchmark:
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=subjects,
-        revision_lockfile=None,
+        revision_lockfile=revision_lockfile,
     )
+
+
+@pytest.fixture
+def dummy_lockfile(tmp_path: Path) -> Path:
+    """Pins the dummy dataset so a composed benchmark (always pinned) can be built."""
+    lockfile = tmp_path / "hf-dataset-revisions.json"
+    dr.HfDatasetRevisions({_DUMMY_DATASET_PATH: "dummy-sha"}).to_file(lockfile)
+    return lockfile
 
 
 @pytest.mark.parametrize(
@@ -157,10 +175,13 @@ def _benchmark_with_subjects(subjects: list[Any]) -> ComposedBenchmark:
     ],
 )
 def test_task_custom_subjects(
-    subjects: list[str] | list[tuple], custom_subjects: list[str] | None, expected: list[str] | list[tuple]
+    dummy_lockfile: Path,
+    subjects: list[str] | list[tuple],
+    custom_subjects: list[str] | None,
+    expected: list[str] | list[tuple],
 ) -> None:
     # Filtering by custom subjects happens in create().
-    task = _benchmark_with_subjects(subjects).create(0, custom_subjects, None)
+    task = _benchmark_with_subjects(subjects, dummy_lockfile).create(0, custom_subjects, None)
     assert task.subjects == expected
 
 
@@ -175,9 +196,11 @@ def test_task_custom_subjects(
         ([("ctx1", 4096, "single"), ("ctx1", 8192, "multi")], ["ctx1,abc,single"]),
     ],
 )
-def test_task_custom_subjects_rejects_unknown(subjects: list[str] | list[tuple], custom_subjects: list[str]) -> None:
+def test_task_custom_subjects_rejects_unknown(
+    dummy_lockfile: Path, subjects: list[str] | list[tuple], custom_subjects: list[str]
+) -> None:
     with pytest.raises(ValueError):
-        _benchmark_with_subjects(subjects).create(0, custom_subjects, None)
+        _benchmark_with_subjects(subjects, dummy_lockfile).create(0, custom_subjects, None)
 
 
 def test_base_task() -> None:
@@ -201,23 +224,22 @@ def test_base_task() -> None:
 
     task1 = MyTask1(
         reader=_DUMMY_READER,
+        loader=_DUMMY_LOADER,
         dataset_path=_DUMMY_DATASET_PATH,
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
-        revision_lockfile=None,
     )
     assert task1.NAME == "MyTask1"
 
     task2 = MyTask2(
         0,
         reader=_DUMMY_READER,
+        loader=_DUMMY_LOADER,
         dataset_path=_DUMMY_DATASET_PATH,
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
-        revision_lockfile=None,
-        custom_hf_revision=None,
     )
     assert task2.NAME == "MyTask2"
 
@@ -232,12 +254,11 @@ def test_user_prompt_suffix_rejected() -> None:
         MyTask(
             0,
             reader=_DUMMY_READER,
+            loader=_DUMMY_LOADER,
             dataset_path=_DUMMY_DATASET_PATH,
             sample_split=_DUMMY_SPLIT,
             fewshot_split=_DUMMY_SPLIT,
             subjects=_DUMMY_SUBJECTS,
-            revision_lockfile=None,
-            custom_hf_revision=None,
             user_prompt_suffix="/think_short",
         )
 
@@ -249,94 +270,38 @@ def test_cli_user_prompt_suffix_parsing() -> None:
     assert args.user_prompt_suffix == "/think_short"
 
 
-class _PinnedTask(ComposedEval):
-    """Test double for revision pinning; its lock file is supplied at construction, as a benchmark would."""
-
-    NAME = "PinnedTask"
-
-    def _get_instruction_text(self, item: dict[str, Any]) -> str:
-        return ""
-
-    def _get_ground_truth(self, item: dict[str, Any]) -> list[str]:
-        return []
-
-
 def test_pinned_hf_revision_applied_when_unset(tmp_path: Path) -> None:
-    # Given a task whose lock file pins its dataset
+    # Given a benchmark whose lock file pins its dataset
     lockfile = tmp_path / "hf-dataset-revisions.json"
-    dr.HfDatasetRevisions({"my/dataset": "pinned-sha"}).to_file(lockfile)
+    dr.HfDatasetRevisions({_DUMMY_DATASET_PATH: "pinned-sha"}).to_file(lockfile)
 
-    # When constructing the task without a revision override
-    task = _PinnedTask(
-        0,
-        reader=_DUMMY_READER,
-        dataset_path="my/dataset",
-        sample_split=_DUMMY_SPLIT,
-        fewshot_split=_DUMMY_SPLIT,
-        subjects=_DUMMY_SUBJECTS,
-        revision_lockfile=lockfile,
-        custom_hf_revision=None,
-    )
+    # When creating an eval without a revision override
+    task = _benchmark_with_subjects(_DUMMY_SUBJECTS, lockfile).create(0, None, None)
 
     # Then the pinned revision is applied
-    assert task.hf_revision == "pinned-sha"
-
-
-def test_task_without_lockfile_is_not_pinned() -> None:
-    # Given a task that opted out of pinning, when constructing it
-    task = _PinnedTask(
-        0,
-        reader=_DUMMY_READER,
-        dataset_path="my/dataset",
-        sample_split=_DUMMY_SPLIT,
-        fewshot_split=_DUMMY_SPLIT,
-        subjects=_DUMMY_SUBJECTS,
-        revision_lockfile=None,
-        custom_hf_revision=None,
-    )
-
-    # Then no revision is pinned
-    assert task.hf_revision is None
+    assert task.loader.revision == "pinned-sha"
 
 
 def test_missing_pin_in_declared_lockfile_raises(tmp_path: Path) -> None:
-    # Given a task whose lock file has no pin for its dataset
+    # Given a benchmark whose lock file has no pin for its dataset
     lockfile = tmp_path / "hf-dataset-revisions.json"
     dr.HfDatasetRevisions({}).to_file(lockfile)
 
-    # Then constructing the task fails
+    # Then creating an eval fails
     with pytest.raises(KeyError, match="not pinned"):
-        _PinnedTask(
-            0,
-            reader=_DUMMY_READER,
-            dataset_path="my/dataset",
-            sample_split=_DUMMY_SPLIT,
-            fewshot_split=_DUMMY_SPLIT,
-            subjects=_DUMMY_SUBJECTS,
-            revision_lockfile=lockfile,
-            custom_hf_revision=None,
-        )
+        _benchmark_with_subjects(_DUMMY_SUBJECTS, lockfile).create(0, None, None)
 
 
 def test_custom_hf_revision_overrides_pinned(tmp_path: Path) -> None:
-    # Given a task whose lock file pins its dataset
+    # Given a benchmark whose lock file pins its dataset
     lockfile = tmp_path / "hf-dataset-revisions.json"
-    dr.HfDatasetRevisions({"my/dataset": "pinned-sha"}).to_file(lockfile)
+    dr.HfDatasetRevisions({_DUMMY_DATASET_PATH: "pinned-sha"}).to_file(lockfile)
 
-    # When constructing the task with a revision override
-    task = _PinnedTask(
-        0,
-        reader=_DUMMY_READER,
-        dataset_path="my/dataset",
-        sample_split=_DUMMY_SPLIT,
-        fewshot_split=_DUMMY_SPLIT,
-        subjects=_DUMMY_SUBJECTS,
-        revision_lockfile=lockfile,
-        custom_hf_revision="custom-sha",
-    )
+    # When creating an eval with a revision override
+    task = _benchmark_with_subjects(_DUMMY_SUBJECTS, lockfile).create(0, None, "custom-sha")
 
     # Then the override beats the pin
-    assert task.hf_revision == "custom-sha"
+    assert task.loader.revision == "custom-sha"
 
 
 def test_get_metrics_combines_styler_and_response_type_metrics() -> None:
@@ -348,11 +313,11 @@ def test_get_metrics_combines_styler_and_response_type_metrics() -> None:
     # Then its metrics are the styler's metrics plus the loglikelihood response-type metrics
     task = MyTask(
         reader=_DUMMY_READER,
+        loader=_DUMMY_LOADER,
         dataset_path=_DUMMY_DATASET_PATH,
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
-        revision_lockfile=None,
     )
     assert set(task.get_metrics()) == {_FakeMetric, BytesLoglikelihood, SequencePositionsLoglikelihood}
 
@@ -376,11 +341,11 @@ def test_get_messages_assembles_instruction_and_cue() -> None:
 
     task = MyTask(
         reader=_Reader(),
+        loader=_DUMMY_LOADER,
         dataset_path=_DUMMY_DATASET_PATH,
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
-        revision_lockfile=None,
     )
 
     # Then the instruction becomes the evaluated USER turn and the cue an ASSISTANT turn

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -80,7 +80,6 @@ class _StubTaskStyler(TaskStyler):
 
 def _benchmark_with_subjects(subjects: list[Any]) -> ComposedBenchmark:
     class MyTask(ComposedEval):
-        REVISION_LOCKFILE = None
         NAME = "MyTask"
         TASK_STYLER = _DummyStyler()
 
@@ -91,6 +90,7 @@ def _benchmark_with_subjects(subjects: list[Any]) -> ComposedBenchmark:
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=subjects,
+        revision_lockfile=None,
     )
 
 
@@ -182,7 +182,6 @@ def test_task_custom_subjects_rejects_unknown(subjects: list[str] | list[tuple],
 
 def test_base_task() -> None:
     class MyTask1(ComposedEval):
-        REVISION_LOCKFILE = None
         NAME = "MyTask1"
 
         def _get_instruction_text(self, item: dict[str, Any]) -> str:
@@ -192,7 +191,6 @@ def test_base_task() -> None:
             return []
 
     class MyTask2(ComposedEval):
-        REVISION_LOCKFILE = None
         NAME = "MyTask2"
 
         def _get_instruction_text(self, item: dict[str, Any]) -> str:
@@ -207,6 +205,7 @@ def test_base_task() -> None:
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
+        revision_lockfile=None,
     )
     assert task1.NAME == "MyTask1"
 
@@ -217,6 +216,7 @@ def test_base_task() -> None:
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
+        revision_lockfile=None,
         custom_hf_revision=None,
     )
     assert task2.NAME == "MyTask2"
@@ -225,7 +225,6 @@ def test_base_task() -> None:
 def test_user_prompt_suffix_rejected() -> None:
     # Given a composed eval (composed evals have no completion path, so a suffix is never valid)
     class MyTask(ComposedEval):
-        REVISION_LOCKFILE = None
         TASK_STYLER = _DummyStyler()
 
     # When constructing it with a user prompt suffix, then it is rejected
@@ -237,6 +236,7 @@ def test_user_prompt_suffix_rejected() -> None:
             sample_split=_DUMMY_SPLIT,
             fewshot_split=_DUMMY_SPLIT,
             subjects=_DUMMY_SUBJECTS,
+            revision_lockfile=None,
             custom_hf_revision=None,
             user_prompt_suffix="/think_short",
         )
@@ -249,20 +249,16 @@ def test_cli_user_prompt_suffix_parsing() -> None:
     assert args.user_prompt_suffix == "/think_short"
 
 
-def _pinned_task(lockfile: Path | None) -> type[ComposedEval]:
-    """Test double declaring its own revision lock file, like any real task would."""
+class _PinnedTask(ComposedEval):
+    """Test double for revision pinning; its lock file is supplied at construction, as a benchmark would."""
 
-    class PinnedTask(ComposedEval):
-        NAME = "PinnedTask"
-        REVISION_LOCKFILE = lockfile
+    NAME = "PinnedTask"
 
-        def _get_instruction_text(self, item: dict[str, Any]) -> str:
-            return ""
+    def _get_instruction_text(self, item: dict[str, Any]) -> str:
+        return ""
 
-        def _get_ground_truth(self, item: dict[str, Any]) -> list[str]:
-            return []
-
-    return PinnedTask
+    def _get_ground_truth(self, item: dict[str, Any]) -> list[str]:
+        return []
 
 
 def test_pinned_hf_revision_applied_when_unset(tmp_path: Path) -> None:
@@ -271,13 +267,14 @@ def test_pinned_hf_revision_applied_when_unset(tmp_path: Path) -> None:
     dr.HfDatasetRevisions({"my/dataset": "pinned-sha"}).to_file(lockfile)
 
     # When constructing the task without a revision override
-    task = _pinned_task(lockfile)(
+    task = _PinnedTask(
         0,
         reader=_DUMMY_READER,
         dataset_path="my/dataset",
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
+        revision_lockfile=lockfile,
         custom_hf_revision=None,
     )
 
@@ -287,13 +284,14 @@ def test_pinned_hf_revision_applied_when_unset(tmp_path: Path) -> None:
 
 def test_task_without_lockfile_is_not_pinned() -> None:
     # Given a task that opted out of pinning, when constructing it
-    task = _pinned_task(None)(
+    task = _PinnedTask(
         0,
         reader=_DUMMY_READER,
         dataset_path="my/dataset",
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
+        revision_lockfile=None,
         custom_hf_revision=None,
     )
 
@@ -308,13 +306,14 @@ def test_missing_pin_in_declared_lockfile_raises(tmp_path: Path) -> None:
 
     # Then constructing the task fails
     with pytest.raises(KeyError, match="not pinned"):
-        _pinned_task(lockfile)(
+        _PinnedTask(
             0,
             reader=_DUMMY_READER,
             dataset_path="my/dataset",
             sample_split=_DUMMY_SPLIT,
             fewshot_split=_DUMMY_SPLIT,
             subjects=_DUMMY_SUBJECTS,
+            revision_lockfile=lockfile,
             custom_hf_revision=None,
         )
 
@@ -325,13 +324,14 @@ def test_custom_hf_revision_overrides_pinned(tmp_path: Path) -> None:
     dr.HfDatasetRevisions({"my/dataset": "pinned-sha"}).to_file(lockfile)
 
     # When constructing the task with a revision override
-    task = _pinned_task(lockfile)(
+    task = _PinnedTask(
         0,
         reader=_DUMMY_READER,
         dataset_path="my/dataset",
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
+        revision_lockfile=lockfile,
         custom_hf_revision="custom-sha",
     )
 
@@ -342,7 +342,6 @@ def test_custom_hf_revision_overrides_pinned(tmp_path: Path) -> None:
 def test_get_metrics_combines_styler_and_response_type_metrics() -> None:
     # Given a composed eval whose styler declares its own metrics
     class MyTask(ComposedEval):
-        REVISION_LOCKFILE = None
         NAME = "MyTask"
         TASK_STYLER = _StubTaskStyler()
 
@@ -353,6 +352,7 @@ def test_get_metrics_combines_styler_and_response_type_metrics() -> None:
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
+        revision_lockfile=None,
     )
     assert set(task.get_metrics()) == {_FakeMetric, BytesLoglikelihood, SequencePositionsLoglikelihood}
 
@@ -371,7 +371,6 @@ def test_get_messages_assembles_instruction_and_cue() -> None:
             return "the cue"
 
     class MyTask(ComposedEval):
-        REVISION_LOCKFILE = None
         NAME = "MyTask"
         TASK_STYLER = _Styler()
 
@@ -381,6 +380,7 @@ def test_get_messages_assembles_instruction_and_cue() -> None:
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=_DUMMY_SUBJECTS,
+        revision_lockfile=None,
     )
 
     # Then the instruction becomes the evaluated USER turn and the cue an ASSISTANT turn

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -1,10 +1,11 @@
+import random
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 from datasets import Dataset, DatasetDict
 
-from eval_framework.composed import ChoiceFields, ChoiceReader, ComposedBenchmark, ComposedEval
+from eval_framework.composed import ChoiceFields, ChoiceReader, ComposedBenchmark, ComposedEval, LanguageSpec
 from eval_framework.contract import ResponseType
 from eval_framework.metrics.base import BaseMetric
 from eval_framework.metrics.efficiency.bytes_per_sequence_position import (
@@ -48,6 +49,7 @@ class _DummyDatasetPolicy(DatasetPolicy):
 _DUMMY_READER = _DummyReader()
 _DUMMY_LOADER = _DummyDatasetLoader()
 _DUMMY_POLICY = _DummyDatasetPolicy()
+_DUMMY_RNG = random.Random(0)
 _DUMMY_SPLIT = "test"
 _DUMMY_SUBJECTS = ["subject"]
 
@@ -111,6 +113,32 @@ def _benchmark_with_subjects(subjects: list[Any], dataset_policy: DatasetPolicy)
         fewshot_split=_DUMMY_SPLIT,
         subjects=subjects,
         dataset_policy=dataset_policy,
+        language=None,
+    )
+
+
+def _make_eval(
+    task_cls: type[ComposedEval],
+    *,
+    num_fewshot: int = 0,
+    reader: ChoiceReader = _DUMMY_READER,
+    loader: DatasetLoader = _DUMMY_LOADER,
+    sample_split: str = _DUMMY_SPLIT,
+    fewshot_split: str = _DUMMY_SPLIT,
+    subjects: list[Any] = _DUMMY_SUBJECTS,
+    language: LanguageSpec = None,
+    rnd: random.Random = _DUMMY_RNG,
+) -> ComposedEval:
+    """Build a ``ComposedEval`` for tests, defaulting to dummies for every argument the test does not provide."""
+    return task_cls(
+        num_fewshot,
+        reader=reader,
+        loader=loader,
+        sample_split=sample_split,
+        fewshot_split=fewshot_split,
+        subjects=subjects,
+        language=language,
+        rnd=rnd,
     )
 
 
@@ -267,41 +295,15 @@ def test_base_task() -> None:
         def _get_ground_truth(self, item: dict[str, Any]) -> list[str]:
             return []
 
-    task1 = MyTask1(
-        reader=_DUMMY_READER,
-        loader=_DUMMY_LOADER,
-        sample_split=_DUMMY_SPLIT,
-        fewshot_split=_DUMMY_SPLIT,
-        subjects=_DUMMY_SUBJECTS,
-    )
-    assert task1.NAME == "MyTask1"
-
-    task2 = MyTask2(
-        0,
-        reader=_DUMMY_READER,
-        loader=_DUMMY_LOADER,
-        sample_split=_DUMMY_SPLIT,
-        fewshot_split=_DUMMY_SPLIT,
-        subjects=_DUMMY_SUBJECTS,
-    )
-    assert task2.NAME == "MyTask2"
+    assert _make_eval(MyTask1).NAME == "MyTask1"
+    assert _make_eval(MyTask2).NAME == "MyTask2"
 
 
 def test_user_prompt_suffix_rejected() -> None:
-    # Given a composed eval (composed evals have no completion path, so a suffix is never valid)
-    class MyTask(ComposedEval):
-        TASK_STYLER = _DummyStyler()
-
-    # When constructing it with a user prompt suffix, then it is rejected
+    # Composed evals have no completion path, so create rejects a user prompt suffix
     with pytest.raises(ValueError, match="only supported for completion tasks"):
-        MyTask(
-            0,
-            reader=_DUMMY_READER,
-            loader=_DUMMY_LOADER,
-            sample_split=_DUMMY_SPLIT,
-            fewshot_split=_DUMMY_SPLIT,
-            subjects=_DUMMY_SUBJECTS,
-            user_prompt_suffix="/think_short",
+        _benchmark_with_subjects(_DUMMY_SUBJECTS, _DUMMY_POLICY).create(
+            0, None, None, user_prompt_suffix="/think_short"
         )
 
 
@@ -319,13 +321,7 @@ def test_get_metrics_combines_styler_and_response_type_metrics() -> None:
         TASK_STYLER = _StubTaskStyler()
 
     # Then its metrics are the styler's metrics plus the loglikelihood response-type metrics
-    task = MyTask(
-        reader=_DUMMY_READER,
-        loader=_DUMMY_LOADER,
-        sample_split=_DUMMY_SPLIT,
-        fewshot_split=_DUMMY_SPLIT,
-        subjects=_DUMMY_SUBJECTS,
-    )
+    task = _make_eval(MyTask)
     assert set(task.get_metrics()) == {_FakeMetric, BytesLoglikelihood, SequencePositionsLoglikelihood}
 
 
@@ -342,13 +338,7 @@ def test_get_metadata_reports_dataset_path_from_loader() -> None:
         NAME = "MyTask"
         TASK_STYLER = _DummyStyler()
 
-    task = MyTask(
-        reader=_DUMMY_READER,
-        loader=_LoaderStub(),
-        sample_split=_DUMMY_SPLIT,
-        fewshot_split=_DUMMY_SPLIT,
-        subjects=_DUMMY_SUBJECTS,
-    )
+    task = _make_eval(MyTask, loader=_LoaderStub())
 
     # Then get_metadata reports that dataset path
     assert task.get_metadata()["dataset_path"] == "some/dataset"
@@ -371,13 +361,7 @@ def test_get_messages_assembles_instruction_and_cue() -> None:
         NAME = "MyTask"
         TASK_STYLER = _Styler()
 
-    task = MyTask(
-        reader=_Reader(),
-        loader=_DUMMY_LOADER,
-        sample_split=_DUMMY_SPLIT,
-        fewshot_split=_DUMMY_SPLIT,
-        subjects=_DUMMY_SUBJECTS,
-    )
+    task = _make_eval(MyTask, reader=_Reader())
 
     # Then the instruction becomes the evaluated USER turn and the cue an ASSISTANT turn
     assert task._get_messages({"question": "the goal"}) == [

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -101,13 +101,19 @@ class _StubTaskStyler(TaskStyler):
         return ""
 
 
-def _benchmark_with_subjects(subjects: list[Any], dataset_policy: DatasetPolicy) -> ComposedBenchmark:
+def _benchmark_with_subjects(
+    subjects: list[Any],
+    dataset_policy: DatasetPolicy,
+    id: str = "dummy-benchmark",
+    display_name: str | None = None,
+) -> ComposedBenchmark:
     class MyTask(ComposedEval):
-        NAME = "MyTask"
         TASK_STYLER = _DummyStyler()
 
     return ComposedBenchmark.from_base(
         MyTask,
+        id=id,
+        display_name=display_name,
         reader=_DUMMY_READER,
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
@@ -120,6 +126,8 @@ def _benchmark_with_subjects(subjects: list[Any], dataset_policy: DatasetPolicy)
 def _make_eval(
     task_cls: type[ComposedEval],
     *,
+    id: str = "dummy-eval",
+    display_name: str = "dummy-eval",
     num_fewshot: int = 0,
     reader: ChoiceReader = _DUMMY_READER,
     loader: DatasetLoader = _DUMMY_LOADER,
@@ -132,6 +140,8 @@ def _make_eval(
     """Build a ``ComposedEval`` for tests, defaulting to dummies for every argument the test does not provide."""
     return task_cls(
         num_fewshot,
+        id=id,
+        display_name=display_name,
         reader=reader,
         loader=loader,
         sample_split=sample_split,
@@ -276,27 +286,17 @@ def test_markdown_doc_renders_policy_dataset_section_and_example() -> None:
     assert "## Example prompt" in doc
 
 
-def test_base_task() -> None:
-    class MyTask1(ComposedEval):
-        NAME = "MyTask1"
+def test_display_name_defaults_to_id() -> None:
+    benchmark = _benchmark_with_subjects(_DUMMY_SUBJECTS, _DUMMY_POLICY, id="the-id")
+    assert benchmark.display_name() == "the-id"
 
-        def _get_instruction_text(self, item: dict[str, Any]) -> str:
-            return ""
 
-        def _get_ground_truth(self, item: dict[str, Any]) -> list[str]:
-            return []
+def test_id_and_display_name_reach_the_eval() -> None:
+    benchmark = _benchmark_with_subjects(_DUMMY_SUBJECTS, _DUMMY_POLICY, id="the-id", display_name="Nice Name")
+    assert (benchmark.id(), benchmark.display_name()) == ("the-id", "Nice Name")
 
-    class MyTask2(ComposedEval):
-        NAME = "MyTask2"
-
-        def _get_instruction_text(self, item: dict[str, Any]) -> str:
-            return ""
-
-        def _get_ground_truth(self, item: dict[str, Any]) -> list[str]:
-            return []
-
-    assert _make_eval(MyTask1).NAME == "MyTask1"
-    assert _make_eval(MyTask2).NAME == "MyTask2"
+    task = benchmark.create(0, None, None)
+    assert (task.id(), task.display_name()) == ("the-id", "Nice Name")
 
 
 def test_user_prompt_suffix_rejected() -> None:
@@ -317,7 +317,6 @@ def test_cli_user_prompt_suffix_parsing() -> None:
 def test_get_metrics_combines_styler_and_response_type_metrics() -> None:
     # Given a composed eval whose styler declares its own metrics
     class MyTask(ComposedEval):
-        NAME = "MyTask"
         TASK_STYLER = _StubTaskStyler()
 
     # Then its metrics are the styler's metrics plus the loglikelihood response-type metrics
@@ -335,7 +334,6 @@ def test_get_metadata_reports_dataset_path_from_loader() -> None:
             return {"dataset_path": "some/dataset"}
 
     class MyTask(ComposedEval):
-        NAME = "MyTask"
         TASK_STYLER = _DummyStyler()
 
     task = _make_eval(MyTask, loader=_LoaderStub())
@@ -358,7 +356,6 @@ def test_get_messages_assembles_instruction_and_cue() -> None:
             return "the cue"
 
     class MyTask(ComposedEval):
-        NAME = "MyTask"
         TASK_STYLER = _Styler()
 
     task = _make_eval(MyTask, reader=_Reader())

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
@@ -13,8 +12,7 @@ from eval_framework.metrics.efficiency.bytes_per_sequence_position import (
     SequencePositionsLoglikelihood,
 )
 from eval_framework.run import parse_args
-from eval_framework.tasks import dataset_revisions as dr
-from eval_framework.tasks.dataset_loading import DatasetLoader
+from eval_framework.tasks.dataset_loading import DatasetLoader, DatasetPolicy
 from eval_framework.tasks.task_style import TaskStyle, TaskStyler
 from template_formatting.formatter import Message, Role
 
@@ -34,8 +32,16 @@ class _DummyDatasetLoader(DatasetLoader):
         return DatasetDict()
 
 
+class _DummyDatasetPolicy(DatasetPolicy):
+    """A no-op policy for benchmark doubles that never load a dataset."""
+
+    def loader(self, custom_hf_revision: str | None) -> DatasetLoader:
+        return _DUMMY_LOADER
+
+
 _DUMMY_READER = _DummyReader()
 _DUMMY_LOADER = _DummyDatasetLoader()
+_DUMMY_POLICY = _DummyDatasetPolicy()
 _DUMMY_DATASET_PATH = "dummy/dataset"
 _DUMMY_SPLIT = "test"
 _DUMMY_SUBJECTS = ["subject"]
@@ -88,7 +94,7 @@ class _StubTaskStyler(TaskStyler):
         return ""
 
 
-def _benchmark_with_subjects(subjects: list[Any], revision_lockfile: Path) -> ComposedBenchmark:
+def _benchmark_with_subjects(subjects: list[Any], dataset_policy: DatasetPolicy) -> ComposedBenchmark:
     class MyTask(ComposedEval):
         NAME = "MyTask"
         TASK_STYLER = _DummyStyler()
@@ -100,16 +106,8 @@ def _benchmark_with_subjects(subjects: list[Any], revision_lockfile: Path) -> Co
         sample_split=_DUMMY_SPLIT,
         fewshot_split=_DUMMY_SPLIT,
         subjects=subjects,
-        revision_lockfile=revision_lockfile,
+        dataset_policy=dataset_policy,
     )
-
-
-@pytest.fixture
-def dummy_lockfile(tmp_path: Path) -> Path:
-    """Pins the dummy dataset so a composed benchmark (always pinned) can be built."""
-    lockfile = tmp_path / "hf-dataset-revisions.json"
-    dr.HfDatasetRevisions({_DUMMY_DATASET_PATH: "dummy-sha"}).to_file(lockfile)
-    return lockfile
 
 
 @pytest.mark.parametrize(
@@ -175,13 +173,12 @@ def dummy_lockfile(tmp_path: Path) -> Path:
     ],
 )
 def test_task_custom_subjects(
-    dummy_lockfile: Path,
     subjects: list[str] | list[tuple],
     custom_subjects: list[str] | None,
     expected: list[str] | list[tuple],
 ) -> None:
     # Filtering by custom subjects happens in create().
-    task = _benchmark_with_subjects(subjects, dummy_lockfile).create(0, custom_subjects, None)
+    task = _benchmark_with_subjects(subjects, _DUMMY_POLICY).create(0, custom_subjects, None)
     assert task.subjects == expected
 
 
@@ -196,11 +193,28 @@ def test_task_custom_subjects(
         ([("ctx1", 4096, "single"), ("ctx1", 8192, "multi")], ["ctx1,abc,single"]),
     ],
 )
-def test_task_custom_subjects_rejects_unknown(
-    dummy_lockfile: Path, subjects: list[str] | list[tuple], custom_subjects: list[str]
-) -> None:
+def test_task_custom_subjects_rejects_unknown(subjects: list[str] | list[tuple], custom_subjects: list[str]) -> None:
     with pytest.raises(ValueError):
-        _benchmark_with_subjects(subjects, dummy_lockfile).create(0, custom_subjects, None)
+        _benchmark_with_subjects(subjects, _DUMMY_POLICY).create(0, custom_subjects, None)
+
+
+def test_create_resolves_loader_through_policy_with_revision_override() -> None:
+    # Given a policy that spies on how create invokes it
+    class _SpyPolicy(DatasetPolicy):
+        def __init__(self) -> None:
+            self.calls: list[str | None] = []
+
+        def loader(self, custom_hf_revision: str | None) -> DatasetLoader:
+            self.calls.append(custom_hf_revision)
+            return _DUMMY_LOADER
+
+    policy = _SpyPolicy()
+
+    # When creating an eval with a revision override
+    _benchmark_with_subjects(_DUMMY_SUBJECTS, policy).create(0, None, "custom-sha")
+
+    # Then create forwards the override to the policy
+    assert policy.calls == ["custom-sha"]
 
 
 def test_base_task() -> None:
@@ -268,40 +282,6 @@ def test_cli_user_prompt_suffix_parsing() -> None:
         args = parse_args()
 
     assert args.user_prompt_suffix == "/think_short"
-
-
-def test_pinned_hf_revision_applied_when_unset(tmp_path: Path) -> None:
-    # Given a benchmark whose lock file pins its dataset
-    lockfile = tmp_path / "hf-dataset-revisions.json"
-    dr.HfDatasetRevisions({_DUMMY_DATASET_PATH: "pinned-sha"}).to_file(lockfile)
-
-    # When creating an eval without a revision override
-    task = _benchmark_with_subjects(_DUMMY_SUBJECTS, lockfile).create(0, None, None)
-
-    # Then the pinned revision is applied
-    assert task.loader.revision == "pinned-sha"
-
-
-def test_missing_pin_in_declared_lockfile_raises(tmp_path: Path) -> None:
-    # Given a benchmark whose lock file has no pin for its dataset
-    lockfile = tmp_path / "hf-dataset-revisions.json"
-    dr.HfDatasetRevisions({}).to_file(lockfile)
-
-    # Then creating an eval fails
-    with pytest.raises(KeyError, match="not pinned"):
-        _benchmark_with_subjects(_DUMMY_SUBJECTS, lockfile).create(0, None, None)
-
-
-def test_custom_hf_revision_overrides_pinned(tmp_path: Path) -> None:
-    # Given a benchmark whose lock file pins its dataset
-    lockfile = tmp_path / "hf-dataset-revisions.json"
-    dr.HfDatasetRevisions({_DUMMY_DATASET_PATH: "pinned-sha"}).to_file(lockfile)
-
-    # When creating an eval with a revision override
-    task = _benchmark_with_subjects(_DUMMY_SUBJECTS, lockfile).create(0, None, "custom-sha")
-
-    # Then the override beats the pin
-    assert task.loader.revision == "custom-sha"
 
 
 def test_get_metrics_combines_styler_and_response_type_metrics() -> None:

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -78,8 +78,24 @@ class _StubTaskStyler(TaskStyler):
         return ""
 
 
+def _benchmark_with_subjects(subjects: list[Any]) -> ComposedBenchmark:
+    class MyTask(ComposedEval):
+        REVISION_LOCKFILE = None
+        NAME = "MyTask"
+        TASK_STYLER = _DummyStyler()
+
+    return ComposedBenchmark.from_base(
+        MyTask,
+        reader=_DUMMY_READER,
+        dataset_path=_DUMMY_DATASET_PATH,
+        sample_split=_DUMMY_SPLIT,
+        fewshot_split=_DUMMY_SPLIT,
+        subjects=subjects,
+    )
+
+
 @pytest.mark.parametrize(
-    "subjects,custom_subjects,expected_value",
+    "subjects,custom_subjects,expected",
     [
         (["subject1", "subject2"], [], ["subject1", "subject2"]),
         (["subject1", "subject2"], None, ["subject1", "subject2"]),
@@ -138,37 +154,30 @@ class _StubTaskStyler(TaskStyler):
             ["ctx1,*,*"],
             [("ctx1", 4096, "single"), ("ctx1", 8192, "multi")],
         ),
-        (["subject1", "subject2"], ["invalid_subject"], "ValueError"),
-        ([("EN_US", "topic1"), ("EN_US", "topic2")], ["EN_US,invalid_topic"], "ValueError"),
-        ([("ctx1", 4096, "single"), ("ctx1", 8192, "multi")], ["ctx1,9999,single"], "ValueError"),
-        # matching compares stringified subject fields, not a parsed native value, so a non-numeric
-        # part at an int position is just another "not a legal value" case, not a separate parse error.
-        ([("ctx1", 4096, "single"), ("ctx1", 8192, "multi")], ["ctx1,abc,single"], "ValueError"),
     ],
 )
 def test_task_custom_subjects(
-    subjects: list[str] | list[tuple], custom_subjects: list[str] | None, expected_value: list[str] | list[tuple] | str
+    subjects: list[str] | list[tuple], custom_subjects: list[str] | None, expected: list[str] | list[tuple]
 ) -> None:
-    class MyTask(ComposedEval):
-        REVISION_LOCKFILE = None
-        NAME = "MyTask"
-        TASK_STYLER = _DummyStyler()
+    # Filtering by custom subjects happens in create().
+    task = _benchmark_with_subjects(subjects).create(0, custom_subjects, None)
+    assert task.subjects == expected
 
-    benchmark = ComposedBenchmark.from_base(
-        MyTask,
-        reader=_DUMMY_READER,
-        dataset_path=_DUMMY_DATASET_PATH,
-        sample_split=_DUMMY_SPLIT,
-        fewshot_split=_DUMMY_SPLIT,
-        subjects=subjects,
-    )
-    # Filtering by custom subjects happens in create(), so exercise it there.
-    if expected_value == "ValueError":
-        with pytest.raises(ValueError):
-            benchmark.create(0, custom_subjects, None)
-    else:
-        task = benchmark.create(0, custom_subjects, None)
-        assert task.subjects == expected_value
+
+@pytest.mark.parametrize(
+    "subjects,custom_subjects",
+    [
+        (["subject1", "subject2"], ["invalid_subject"]),
+        ([("EN_US", "topic1"), ("EN_US", "topic2")], ["EN_US,invalid_topic"]),
+        ([("ctx1", 4096, "single"), ("ctx1", 8192, "multi")], ["ctx1,9999,single"]),
+        # matching compares stringified subject fields, not a parsed native value, so a non-numeric
+        # part at an int position is just another "not a legal value" case, not a separate parse error.
+        ([("ctx1", 4096, "single"), ("ctx1", 8192, "multi")], ["ctx1,abc,single"]),
+    ],
+)
+def test_task_custom_subjects_rejects_unknown(subjects: list[str] | list[tuple], custom_subjects: list[str]) -> None:
+    with pytest.raises(ValueError):
+        _benchmark_with_subjects(subjects).create(0, custom_subjects, None)
 
 
 def test_base_task() -> None:


### PR DESCRIPTION
- **refactor: BaseTask implementation copied as ComposedEval**
- **refactor: piqa_ellamind trivially migrated to ComposedEval**
- **refactor: ComposedBenchmark simplified to always assume TaskStyler is present**
- **refactor: ComposedBenchmark now takes ChoiceReader**
- **chore: dead code handling user suffix for ComposedBenchmark removed**
- **chore: Remove dead code in ComposedBenchmark::generate_markdown_doc**
- **chore: legacy code paths removed from ComposedBenchmark**
- **refactor: DATASET_PATH is now a member instead of classvariable**
- **refactor: SAMPLE_SPLIT and FEWSHOT_SPLIT are now members of ComposedEval**
- **refactor: ComposedEval.with_overwrite collapsed into __init__**
- **chore: Fix piqa_ellamind tests**
- **refactor: test piqa_ellamind without patching _load_hf_dataset**
- **refactor: ComposedBenchmark now holds potential subjects as members**
