### PR TITLE
refactor!: drop prompt and response from results.jsonl

### DIFF
--- a/docs/understanding_results_guide.md
+++ b/docs/understanding_results_guide.md
@@ -43,8 +43,6 @@ This file contains one JSON object per line, each representing a metric calculat
   "key": null,
   "value": 0.0,
   "higher_is_better": true,
-  "prompt": "Question: Which is the function of the gallbladder?\nAnswer:",
-  "response": " store bile",
   "llm_judge_prompt": null,
   "llm_judge_response": null,
   "code_execution_trace": null,
@@ -58,9 +56,9 @@ This file contains one JSON object per line, each representing a metric calculat
 - **`metric_name`**: The specific metric being measured
 - **`value`**: The metric score (0.0 = incorrect, 1.0 = correct for binary metrics)
 - **`higher_is_better`**: Whether higher values indicate better performance
-- **`prompt`**: The input given to the model
-- **`response`**: The model's output
 - **`error`**: Any errors encountered during evaluation
+
+The prompt and the model's response are not repeated here; look them up in `output.jsonl` by `id` and `subject`.
 
 ### 2. `output.jsonl` - Raw Model Responses
 

--- a/src/eval_framework/evaluation_generator.py
+++ b/src/eval_framework/evaluation_generator.py
@@ -74,7 +74,6 @@ class EvaluationGenerator:
                     else:
                         metric_name = metric_result.metric_name
                         key = None
-                    completion = response.completion if isinstance(response, Completion) else str(response.ground_truth)
 
                     result = Result(
                         id=response.id,
@@ -87,8 +86,6 @@ class EvaluationGenerator:
                         task_name=self.task_name,
                         value=metric_result.value,
                         higher_is_better=metric_result.higher_is_better,
-                        prompt=response.prompt,
-                        response=completion,
                         llm_judge_prompt=metric_result.llm_judge_prompt,
                         llm_judge_response=metric_result.llm_judge_response,
                         code_execution_trace=metric_result.code_execution_trace,
@@ -247,7 +244,8 @@ class EvaluationGenerator:
                     "key": r.key,
                     "value": r.value,
                     "error": r.error,
-                    "prompt": r.prompt,
+                    # Repeats of one problem carry consecutive ids (see `repeat_samples`).
+                    "problem": r.id // self.config.repeats,
                 }
                 for r in results
             ]
@@ -274,7 +272,7 @@ class EvaluationGenerator:
 
             for aggregator in current_metric.AGGREGATORS:
                 aggregated_results[f"{aggregator.name} {current_metric_class}.{metric_name}"] = (
-                    aggregator(metric_group, ["prompt"])  # Compute the aggregator, grouped by the prompt...
+                    aggregator(metric_group, ["subject", "problem"])  # Compute the aggregator per problem...
                     .groupby(["key", "subject"])  # ... then group by key, subject...
                     .agg({"value": "mean"})["value"]  # ...and average scores over each key, subject group...
                     .mean()  # ...and lastly average the scores across all groups giving equal weight to every
@@ -301,7 +299,9 @@ class EvaluationGenerator:
                     if not key
                     else f"{aggregator.name} {metric_name} - {key} - {subject}"
                 )
-                aggregated_results[save_string] = aggregator(ksm_group, ["prompt"])["value"].mean().mean().item()
+                aggregated_results[save_string] = (
+                    aggregator(ksm_group, ["subject", "problem"])["value"].mean().mean().item()
+                )
 
         return aggregated_results
 

--- a/src/eval_framework/metrics/aggregators/aggregators.py
+++ b/src/eval_framework/metrics/aggregators/aggregators.py
@@ -8,14 +8,14 @@ from scipy.special import comb
 class Aggregator(Protocol):
     """Base class for metric aggregators.
 
-    An aggregator collapses multiple evaluation rows for the same problem (i.e. prompt) into a
-    single score per problem. The input DataFrame has one row per (problem, attempt)
+    An aggregator collapses multiple evaluation rows for the same problem (the repeats of one
+    sample) into a single score per problem. The input DataFrame has one row per (problem, attempt)
     pair; the output has one row per problem with a new ``value``.
 
     Args:
         response_df: DataFrame where each row is one evaluation attempt. Must contain
             a ``value`` column (the per-attempt score) and all ``identifier_columns``.
-        identifier_columns: Columns that uniquely identify a problem (e.g. ``["prompt"]``).
+        identifier_columns: Columns that uniquely identify a problem (e.g. ``["subject", "problem"]``).
             Rows sharing the same identifier are different attempts at the same problem.
 
     Returns:

--- a/src/eval_framework/result_processors/base.py
+++ b/src/eval_framework/result_processors/base.py
@@ -13,6 +13,14 @@ load_dotenv()
 
 
 class Result(BaseModel):
+    """One metric value for one sample.
+
+    Prompt and response are deliberately not part of a result: they are in
+    output.jsonl under the same id and subject, and repeating them in every
+    metric row multiplied results.jsonl by the number of metrics, which for
+    long-context tasks meant gigabytes.
+    """
+
     model_config = ConfigDict(extra="forbid")
     id: int
     subject: str
@@ -24,8 +32,6 @@ class Result(BaseModel):
     key: str | None
     value: float | None
     higher_is_better: bool
-    prompt: str
-    response: str
     llm_judge_prompt: str | None = None
     llm_judge_response: str | None = None
     code_execution_trace: str | None = None

--- a/tests/tests_eval_framework/test_evaluation_generator.py
+++ b/tests/tests_eval_framework/test_evaluation_generator.py
@@ -195,8 +195,6 @@ def test_aggregate_results(tmp_path: Path) -> None:
                 metric_class_name=metric_name,
                 value=value,
                 higher_is_better=True,
-                prompt="prompt",
-                response="completion",
                 error=error,
             )
         )
@@ -275,28 +273,28 @@ def test_aggregate_results_with_aggregators(tmp_path: Path) -> None:
     evaluator.metrics = [MockPassAtKMetric]
 
     responses = [
-        ("subject1", "ExactMatch", "key1", "p1", 1.0, None),
-        ("subject1", "ExactMatch", "key1", "p1", 1.0, None),
-        ("subject1", "ExactMatch", "key1", "p1", 0.0, None),
-        ("subject1", "ExactMatch", "key1", "p2", 0.0, None),
-        ("subject1", "ExactMatch", "key2", "p3", 1.0, None),
-        ("subject2", "ExactMatch", "key1", "p4", 1.0, None),
-        ("subject2", "ExactMatch", "key2", "p5", 0.0, None),
+        ("subject1", "ExactMatch", "key1", 0, 1.0, None),
+        ("subject1", "ExactMatch", "key1", 0, 1.0, None),
+        ("subject1", "ExactMatch", "key1", 0, 0.0, None),
+        ("subject1", "ExactMatch", "key1", 1, 0.0, None),
+        ("subject1", "ExactMatch", "key2", 2, 1.0, None),
+        ("subject2", "ExactMatch", "key1", 3, 1.0, None),
+        ("subject2", "ExactMatch", "key2", 4, 0.0, None),
         (
             "subject2",
             "ExactMatch",
             "key1",
-            "p6",
+            5,
             None,
             Error(error_class="AssertionError", message="asserted False!", traceback="just check the test data"),
         ),
     ]
 
     results = []
-    for subject, metric_name, key, prompt, value, error in responses:
+    for subject, metric_name, key, sample_id, value, error in responses:
         results.append(
             Result(
-                id=0,
+                id=sample_id,
                 metric_name=metric_name,
                 num_fewshot=0,
                 key=key,
@@ -306,8 +304,6 @@ def test_aggregate_results_with_aggregators(tmp_path: Path) -> None:
                 metric_class_name="MockPassAtKMetric",
                 value=value,
                 higher_is_better=True,
-                prompt=prompt,
-                response="completion",
                 error=error,
             )
         )
@@ -353,28 +349,28 @@ def test_aggregate_results_with_identifier_mean(tmp_path: Path) -> None:
     evaluator.metrics = [MockIdentifierMeanMetric]
 
     responses = [
-        ("subject1", "ExactMatch", "key1", "p1", 1.0, None),
-        ("subject1", "ExactMatch", "key1", "p1", 1.0, None),
-        ("subject1", "ExactMatch", "key1", "p1", 0.0, None),
-        ("subject1", "ExactMatch", "key1", "p2", 0.0, None),
-        ("subject1", "ExactMatch", "key2", "p3", 1.0, None),
-        ("subject2", "ExactMatch", "key1", "p4", 1.0, None),
-        ("subject2", "ExactMatch", "key2", "p5", 0.0, None),
+        ("subject1", "ExactMatch", "key1", 0, 1.0, None),
+        ("subject1", "ExactMatch", "key1", 0, 1.0, None),
+        ("subject1", "ExactMatch", "key1", 0, 0.0, None),
+        ("subject1", "ExactMatch", "key1", 1, 0.0, None),
+        ("subject1", "ExactMatch", "key2", 2, 1.0, None),
+        ("subject2", "ExactMatch", "key1", 3, 1.0, None),
+        ("subject2", "ExactMatch", "key2", 4, 0.0, None),
         (
             "subject2",
             "ExactMatch",
             "key1",
-            "p5",
+            4,
             None,
             Error(error_class="AssertionError", message="asserted False!", traceback="just check the test data"),
         ),
     ]
 
     results = []
-    for subject, metric_name, key, prompt, value, error in responses:
+    for subject, metric_name, key, sample_id, value, error in responses:
         results.append(
             Result(
-                id=0,
+                id=sample_id,
                 metric_name=metric_name,
                 num_fewshot=0,
                 key=key,
@@ -384,8 +380,6 @@ def test_aggregate_results_with_identifier_mean(tmp_path: Path) -> None:
                 metric_class_name="MockIdentifierMeanMetric",
                 value=value,
                 higher_is_better=True,
-                prompt=prompt,
-                response="completion",
                 error=error,
             )
         )

--- a/tests/tests_eval_framework/test_results_processor.py
+++ b/tests/tests_eval_framework/test_results_processor.py
@@ -193,8 +193,6 @@ def test_file_result_processor_save_and_load_metrics(tmp_path: Path) -> None:
                 key=None,
                 value=0.5,
                 higher_is_better=True,
-                prompt="What is 2+2?",
-                response="4",
             )
         )
 


### PR DESCRIPTION
## Description

results.jsonl has one row per sample per metric, and each row repeated the sample's full prompt and response, so a task with 7 metrics wrote every prompt 8 times across output.jsonl and results.jsonl. For long-context tasks that is gigabytes (HelmetRagQa_32768: 2.6 GB results.jsonl next to a 1.0 GB output.jsonl; 128k contexts land around 10 GB), which currently gets our eval pods evicted for exceeding their disk limit.

Prompt and response stay in output.jsonl once per sample, joinable by id and subject. The pass@k / IdentifierMean aggregators grouped attempts by prompt text; they now group by (subject, id // repeats), which is how repeat_samples encodes the original sample.