### PR TITLE
feat: record reasoning text and finish_reason per sample

### DIFF
--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -245,6 +245,8 @@ class ComposedEval(Eval):
                     raw_completion=raw_completion.completion,
                     raw_completion_num_tokens=raw_completion.completion_num_tokens,
                     raw_completion_reasoning_num_tokens=raw_completion.reasoning_num_tokens,
+                    raw_completion_reasoning=raw_completion.reasoning,
+                    raw_completion_finish_reason=raw_completion.finish_reason,
                     context=sample.context,
                     error=raw_completion.raw_completion_error or error,
                 )

--- a/src/eval_framework/llm/openai.py
+++ b/src/eval_framework/llm/openai.py
@@ -206,6 +206,7 @@ class OpenAIModel(BaseLLM):
                         if completion_tokens is not None
                         else (self._count_tokens(completion) if self._encoder is not None else None)
                     ),
+                    finish_reason=response.choices[0].finish_reason,
                 )
 
             else:
@@ -225,7 +226,13 @@ class OpenAIModel(BaseLLM):
                 completion_tokens = getattr(chat_response.usage, "completion_tokens", None)
                 completion_details = getattr(chat_response.usage, "completion_tokens_details", None)
                 reasoning_tokens = getattr(completion_details, "reasoning_tokens", None)
-                completion = chat_response.choices[0].message.content or ""
+                choice = chat_response.choices[0]
+                completion = choice.message.content or ""
+                # vLLM's reasoning parser returns the think block as `reasoning`; older
+                # versions named the field `reasoning_content`.
+                reasoning = getattr(choice.message, "reasoning", None) or getattr(
+                    choice.message, "reasoning_content", None
+                )
                 return RawCompletion(
                     prompt=prompt,
                     prompt_num_tokens=prompt_tokens,
@@ -245,6 +252,8 @@ class OpenAIModel(BaseLLM):
                         else (self._count_tokens(completion) if self._encoder is not None else None)
                     ),
                     reasoning_num_tokens=reasoning_tokens,
+                    reasoning=reasoning,
+                    finish_reason=choice.finish_reason,
                 )
 
         with concurrent.futures.ThreadPoolExecutor() as executor:

--- a/src/eval_framework/shared/types.py
+++ b/src/eval_framework/shared/types.py
@@ -97,6 +97,16 @@ class RawCompletion(BaseCompletion):
         "or None if the backend did not report it. Non-reasoning models and backends that "
         "do not surface a reasoning-token count leave this None.",
     ] = None
+    reasoning: Annotated[
+        str | None,
+        "reasoning (thinking) text the model generated before the completion, or None if the "
+        "backend did not return it separately",
+    ] = None
+    finish_reason: Annotated[
+        str | None,
+        "why generation ended as reported by the backend, e.g. `stop`, `length` or `repetition`; "
+        "None if the backend did not report it",
+    ] = None
     raw_completion_error: Error | None = None
 
 
@@ -114,6 +124,16 @@ class Completion(BaseCompletion):
         int | None,
         "portion of raw_completion_num_tokens that the model spent on reasoning, or None if the "
         "backend did not report it",
+    ] = None
+    raw_completion_reasoning: Annotated[
+        str | None,
+        "reasoning (thinking) text the model generated before the raw completion, or None if the "
+        "backend did not return it separately",
+    ] = None
+    raw_completion_finish_reason: Annotated[
+        str | None,
+        "why generation ended as reported by the backend, e.g. `stop`, `length` or `repetition`; "
+        "None if the backend did not report it",
     ] = None
     context: list[BaseMetricContext] | BaseMetricContext | None = None
     error: Error | None = None

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -436,6 +436,8 @@ class BaseTask[SubjectType](Eval):
                     raw_completion=raw_completion.completion,
                     raw_completion_num_tokens=raw_completion.completion_num_tokens,
                     raw_completion_reasoning_num_tokens=raw_completion.reasoning_num_tokens,
+                    raw_completion_reasoning=raw_completion.reasoning,
+                    raw_completion_finish_reason=raw_completion.finish_reason,
                     context=sample.context,
                     error=raw_completion.raw_completion_error or error,
                 )

--- a/tests/tests_eval_framework/llm/test_openai.py
+++ b/tests/tests_eval_framework/llm/test_openai.py
@@ -118,11 +118,37 @@ def test_openai_loglikelihoods(model_cls: type[BaseLLM]) -> None:
     assert set(results[1].loglikelihoods_num_tokens.keys()) == {" foo", " bar"}
 
 
-def _make_chat_response(mocker: MockerFixture, content: str = "test") -> object:
+def _make_chat_response(
+    mocker: MockerFixture,
+    content: str = "test",
+    reasoning: str | None = None,
+    finish_reason: str = "stop",
+) -> object:
     response = mocker.MagicMock()
     response.choices[0].message.content = content
+    response.choices[0].message.reasoning = reasoning
+    response.choices[0].message.reasoning_content = None
+    response.choices[0].finish_reason = finish_reason
     response.usage.prompt_tokens = 5
     return response
+
+
+def test_generate_from_messages_keeps_reasoning_and_finish_reason(mocker: MockerFixture) -> None:
+    # Given a chat response whose think block was split off by the server
+    mock_client = mocker.MagicMock()
+    mocker.patch("eval_framework.llm.openai.OpenAI", return_value=mock_client)
+    mock_client.chat.completions.create.return_value = _make_chat_response(
+        mocker, content="42", reasoning="let me think", finish_reason="length"
+    )
+    model = OpenAIModel(model_name="gpt-4o-mini-2024-07-18")
+
+    # When
+    [result] = model.generate_from_messages([[Message(role=Role.USER, content="Hello")]])
+
+    # Then the completion stays answer-only and the rest is kept alongside it
+    assert result.completion == "42"
+    assert result.reasoning == "let me think"
+    assert result.finish_reason == "length"
 
 
 def test_openai_chat_api_top_p_generate_from_messages(mocker: MockerFixture) -> None:


### PR DESCRIPTION
When a reasoning model runs out of tokens while still thinking, output.jsonl shows 65k tokens and an empty answer: the thinking text is dropped and nothing says the generation was cut off. Store the thinking text and the finish reason per sample. Scores are unaffected. Context: Aleph-Alpha-Research/savanna#4006.