### PR TITLE
fix: multiple new lines at the end of markdown file removed

### DIFF
--- a/src/eval_framework/tasks/markdown_doc.py
+++ b/src/eval_framework/tasks/markdown_doc.py
@@ -71,4 +71,4 @@ def markdown_doc(
             buf.write("None\n")
         buf.write("````\n")
 
-    return buf.getvalue()
+    return buf.getvalue().rstrip("\n") + "\n"

--- a/tests/tests_eval_framework/tasks/test_markdown_doc.py
+++ b/tests/tests_eval_framework/tasks/test_markdown_doc.py
@@ -107,6 +107,5 @@ RESPONSE_TYPE = COMPLETION
 METRICS = [Accuracy, F1]
 SUBJECTS = ['no_subject']
 ````
-
 """
     )


### PR DESCRIPTION
## Description

Ruff fails due to multiple newlines in the docs file.
