### PR TITLE
feat: optional initial prompt for composed benchmarks

### DIFF
--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -2,7 +2,7 @@ import logging
 import random
 import traceback
 import typing
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Self, final, override
 
 from datasets import DatasetDict
@@ -33,6 +33,10 @@ logger = logging.getLogger(__name__)
 # The language(s) a benchmark tests: a single language, a per-subtopic mapping, or None (not language-specific).
 LanguageSpec = Language | dict[str, Language] | dict[str, tuple[Language, Language]] | None
 
+# An initial prompt ("preamble") for a benchmark: maps the subject label to the text prepended once
+# at the top of each assembled prompt (e.g. "The following are multiple choice questions about {subject}.").
+InitialPrompt = Callable[[str], str]
+
 
 @final
 class ComposedEval(Eval):
@@ -48,6 +52,7 @@ class ComposedEval(Eval):
         subjects: Subjects,
         language: LanguageSpec,
         rnd: random.Random,
+        initial_prompt: InitialPrompt | None = None,
     ) -> None:
         self._display_name = display_name
         self.num_fewshot = num_fewshot
@@ -58,6 +63,7 @@ class ComposedEval(Eval):
         self._subjects = subjects
         self.language = language
         self.rnd = rnd
+        self._initial_prompt = initial_prompt
 
     def _shuffle_splits(self, hf_dataset: DatasetDict) -> dict[str, Any]:
         dataset = {}
@@ -91,6 +97,12 @@ class ComposedEval(Eval):
                 prefix = self._fewshot_prefix(item, fewshot_pool)
                 for body in self._kind.samples(item):
                     messages = [*prefix, Message(role=Role.USER, content=body.prompt)]
+                    if self._initial_prompt is not None:
+                        # Prepended once, to the very first message (same placement as BaseTask's
+                        # ``_get_initial_prompt_text``): before the first fewshot example if present.
+                        first = messages[0]
+                        content = f"{self._initial_prompt(subject.label)}\n\n{first.content}"
+                        messages[0] = Message(role=first.role, content=content)
                     if body.cue:
                         messages.append(Message(role=Role.ASSISTANT, content=body.cue))
                     yield Sample(
@@ -260,6 +272,7 @@ class ComposedBenchmark(Benchmark):
         fewshot_split: str,
         dataset_policy: DatasetPolicy,
         language: LanguageSpec,
+        initial_prompt: InitialPrompt | None = None,
     ) -> None:
         self._id = id
         self._display_name = display_name
@@ -269,6 +282,7 @@ class ComposedBenchmark(Benchmark):
         self.fewshot_split = fewshot_split
         self.language = language
         self.dataset_policy = dataset_policy
+        self._initial_prompt = initial_prompt
 
     @classmethod
     def compose(
@@ -282,9 +296,13 @@ class ComposedBenchmark(Benchmark):
         dataset_policy: DatasetPolicy,
         language: LanguageSpec,
         display_name: str | None = None,
+        initial_prompt: InitialPrompt | None = None,
     ) -> Self:
         """Build a ``ComposedBenchmark`` from its inputs; ``subjects`` defaults to ``NoSubject``
-        (a single unnamed slice) and ``display_name`` to ``id``."""
+        (a single unnamed slice) and ``display_name`` to ``id``.
+
+        ``initial_prompt`` maps the subject label to a preamble prepended once to each prompt's
+        first message (separated by a blank line), before the first fewshot example if present."""
         return cls(
             id=id,
             display_name=display_name if display_name is not None else id,
@@ -294,6 +312,7 @@ class ComposedBenchmark(Benchmark):
             fewshot_split=fewshot_split,
             language=language,
             dataset_policy=dataset_policy,
+            initial_prompt=initial_prompt,
         )
 
     @override
@@ -326,6 +345,7 @@ class ComposedBenchmark(Benchmark):
             language=self.language,
             loader=self.dataset_policy.loader(custom_hf_revision),
             rnd=random.Random(seed),
+            initial_prompt=self._initial_prompt,
         )
 
     @override
@@ -362,6 +382,7 @@ class ComposedBenchmark(Benchmark):
             language=self.language,
             loader=self.dataset_policy.loader(None),
             rnd=random.Random(RANDOM_SEED),
+            initial_prompt=self._initial_prompt,
         )
         sample = next(iter(instance.iterate_samples(1)))
         dataset = instance._load_dataset(subjects[0].load_key)

--- a/tests/tests_eval_framework/test_composed_benchmark.py
+++ b/tests/tests_eval_framework/test_composed_benchmark.py
@@ -6,7 +6,7 @@ import pytest
 from datasets import Dataset, DatasetDict
 
 from eval_framework.choices import ChoiceFields, ChoiceReader
-from eval_framework.composed import ComposedBenchmark, ComposedEval, LanguageSpec
+from eval_framework.composed import ComposedBenchmark, ComposedEval, InitialPrompt, LanguageSpec
 from eval_framework.contract import ResponseType
 from eval_framework.eval_kind import Choice
 from eval_framework.metrics.base import BaseMetric
@@ -19,6 +19,7 @@ from eval_framework.subjects import ListOfSubjects, Subject, Subjects, SubjectsS
 from eval_framework.tasks.dataset_loading import DatasetLoader, DatasetPolicy
 from eval_framework.tasks.task_style import TaskStyle, TaskStyler
 from template_formatting.formatter import ConcatFormatter, Message, Role
+from tests.tests_eval_framework.benchmarks.utils import DatasetStub, first_sample
 
 
 class _DummyReader(ChoiceReader):
@@ -128,6 +129,7 @@ def _make_benchmark(
     subjects: SubjectsSelector = _DUMMY_SELECTOR,
     dataset_policy: DatasetPolicy | None = None,
     language: LanguageSpec = None,
+    initial_prompt: InitialPrompt | None = None,
 ) -> ComposedBenchmark:
     """Build a ``ComposedBenchmark`` for tests, defaulting to dummies for every argument the test does not provide."""
     return ComposedBenchmark.compose(
@@ -139,6 +141,7 @@ def _make_benchmark(
         subjects=subjects,
         dataset_policy=dataset_policy or _DummyDatasetPolicy(),
         language=language,
+        initial_prompt=initial_prompt,
     )
 
 
@@ -325,5 +328,41 @@ def test_message_sampling() -> None:
     [sample] = list(task.iterate_samples())
     assert sample.messages == [
         Message(role=Role.USER, content="instruction: the goal"),
+        Message(role=Role.ASSISTANT, content="the cue"),
+    ]
+
+
+def test_initial_prompt_is_prepended_once_before_the_first_fewshot_example() -> None:
+    # Given a reader/styler pair that echoes each item's question,
+    class _Reader(ChoiceReader):
+        @override
+        def read(self, item: dict[str, Any]) -> ChoiceFields:
+            return ChoiceFields(raw_question=item["question"], choices=[], correct_index=0)
+
+    class _Styler(_DummyStyler):
+        @override
+        def get_instruction_text(self, raw_question: str, choices: list[str]) -> str:
+            return f"instruction: {raw_question}"
+
+        @override
+        def get_cue_text(self) -> str:
+            return "the cue"
+
+    # and a benchmark over one eval row and one fewshot row, with a subject-dependent initial prompt
+    benchmark = _make_benchmark(
+        reader=_Reader(),
+        styler=_Styler(),
+        fewshot_split="train",
+        dataset_policy=DatasetStub({"test": [{"question": "eval q"}], "train": [{"question": "shot q"}]}),
+        initial_prompt=lambda subject: f"About {subject}.",
+    )
+
+    # When assembling a 1-shot sample, then the initial prompt appears exactly once,
+    # at the top of the first (fewshot) USER message
+    sample = first_sample(benchmark, num_fewshot=1)
+    assert sample.messages == [
+        Message(role=Role.USER, content="About subject.\n\ninstruction: shot q"),
+        Message(role=Role.ASSISTANT, content="the cue"),
+        Message(role=Role.USER, content="instruction: eval q"),
         Message(role=Role.ASSISTANT, content="the cue"),
     ]


### PR DESCRIPTION
## Description

Adds support for an (optional) "initial prompt" (preamble) to composed benchmarks (already exists for `BaseTasks`, with similar behavior).
Additionally, a test is included to ensure the preamble is inserted in the correct position.

Current "initial prompt" optionally takes a subject label, for phrasings such as "The following are MC questions about {subject}".
