### PR TITLE
feat: additionally compute micro averages

### DIFF
--- a/docs/understanding_results_guide.md
+++ b/docs/understanding_results_guide.md
@@ -89,6 +89,7 @@ This file provides high-level performance summaries across all evaluation sample
 {
   "ErrorFreeRatio Accuracy Loglikelihood": 1.0,
   "Average Accuracy Loglikelihood": 0.215,
+  "Average Accuracy Loglikelihood (micro)": 0.22,
   "Average Accuracy Loglikelihood - ARC-Challenge": 0.14,
   "Average Accuracy Loglikelihood - ARC-Easy": 0.29,
   "ErrorFreeRatio Bytes": 1.0,
@@ -98,7 +99,8 @@ This file provides high-level performance summaries across all evaluation sample
 
 **Metric Types:**
 - **`ErrorFreeRatio`**: Percentage of samples that completed without errors (1.0 = 100%)
-- **`Average`**: Mean score across all samples
+- **`Average`**: Mean of the per-subject means (macro average), so every subject counts equally
+- **`Average (micro)`**: Mean over all samples, so larger subjects count more (micro average). Identical to `Average` for tasks without subjects.
 - **Subject-specific**: Metrics broken down by task subset (e.g., "ARC-Challenge" vs "ARC-Easy")
 
 ## Metadata

--- a/src/eval_framework/evaluation_generator.py
+++ b/src/eval_framework/evaluation_generator.py
@@ -136,9 +136,12 @@ class EvaluationGenerator:
             error_free_ratio = float(len(data_subset_error_free) / total_count)
             aggregated_results[f"ErrorFreeRatio {metric}"] = error_free_ratio
 
+            # Default average is weighted by key and subject (macro average).
             # aggregate by key and subject first to have equal weights for all key / subject combinations
             key_subject_mean = data_subset_error_free.groupby(["key", "subject"]).mean()
             aggregated_results[f"Average {metric}"] = float(key_subject_mean[["value"]].mean()["value"])
+            # Additionally, report the plain mean over all samples (micro average or per-sample average).
+            aggregated_results[f"Average {metric} (micro)"] = float(data_subset_error_free["value"].mean())
 
             if error_free_ratio < 1.0:
                 # Treat error samples (with value=None) as 0 for the "including errors" average
@@ -274,12 +277,15 @@ class EvaluationGenerator:
                 raise ValueError(f"Metric {metric_name} not found in metrics list")
 
             for aggregator in current_metric.AGGREGATORS:
+                # Compute the aggregator per problem (collapsing the repeats of each problem into one score).
+                per_problem = aggregator(metric_group, ["subject", "problem"])
+                # Macro average: mean per key/subject group, then mean over groups, giving equal weight to every group.
                 aggregated_results[f"{aggregator.name} {current_metric_class}.{metric_name}"] = (
-                    aggregator(metric_group, ["subject", "problem"])  # Compute the aggregator per problem...
-                    .groupby(["key", "subject"])  # ... then group by key, subject...
-                    .agg({"value": "mean"})["value"]  # ...and average scores over each key, subject group...
-                    .mean()  # ...and lastly average the scores across all groups giving equal weight to every
-                    .item()  # key, subject group.
+                    per_problem.groupby(["key", "subject"]).agg({"value": "mean"})["value"].mean().item()
+                )
+                # Micro average: plain mean over all problems.
+                aggregated_results[f"{aggregator.name} {current_metric_class}.{metric_name} (micro)"] = (
+                    per_problem["value"].mean().item()
                 )
 
         # Loop to additionally compute per-subject/per-key breakdown metric scores, e.g. for only subject="algebra"

--- a/tests/tests_eval_framework/test_evaluation_generator.py
+++ b/tests/tests_eval_framework/test_evaluation_generator.py
@@ -204,6 +204,7 @@ def test_aggregate_results(tmp_path: Path) -> None:
     assert aggregated_results == pytest.approx(
         {
             "Average metric1": 2.0,  # mean of all key-subject pairs (3.0, 4.0, 1.0, 0.0)
+            "Average metric1 (micro)": 15 / 7,  # plain mean of the 7 error-free values
             "Average metric1 (including Errors)": 1.8125,  # errors treated as 0: (2.25, 1.0, 4.0, 0.0)
             "Average metric1 - key1": 3.5,  # mean of means of subjects (3.0 and 4.0)
             "Average metric1 (including Errors) - key1": 3.125,  # errors as 0: (2.25, 4.0)
@@ -214,10 +215,12 @@ def test_aggregate_results(tmp_path: Path) -> None:
             "Average metric1 - subject2": 2.0,
             "Average metric1 (including Errors) - subject2": 2.0,  # errors as 0: (4.0, 0.0)
             "Average metric2": 3.0,  # NaNs are skipped in the mean calculation
+            "Average metric2 (micro)": 3.0,
             "Average metric2 - subject1": 3.0,
             "Average metric2 - subject2": float("nan"),  # NaN appears
             # key in metric2 is not output because it's just a single submetric
             "Average metric3": 19.0,  # key=None case works
+            "Average metric3 (micro)": 19.0,
             "Average metric3 - subject1": 20.0,
             "Average metric3 - subject2": 18.0,
             "ErrorFreeRatio metric1": 0.8,
@@ -324,11 +327,13 @@ def test_aggregate_results_with_aggregators(tmp_path: Path) -> None:
     # p5 s2 k2 0
     assert aggregated == {
         "Pass@1 MockPassAtKMetric.ExactMatch": pytest.approx(((2 / 3 + 0) / 2 + 1 + 1 + 0) / 4),
+        "Pass@1 MockPassAtKMetric.ExactMatch (micro)": pytest.approx((2 / 3 + 0 + 1 + 1 + 0) / 5),
         "Pass@1 ExactMatch - key1 - subject1": pytest.approx((2 / 3 + 0) / 2),
         "Pass@1 ExactMatch - key1 - subject2": 1,
         "Pass@1 ExactMatch - key2 - subject1": 1,
         "Pass@1 ExactMatch - key2 - subject2": 0.0,
         "Pass@2 MockPassAtKMetric.ExactMatch": pytest.approx((1 / 2 + 1 + 1 + 0) / 4),
+        "Pass@2 MockPassAtKMetric.ExactMatch (micro)": pytest.approx((1 + 0 + 1 + 1 + 0) / 5),
         "Pass@2 ExactMatch - key1 - subject1": pytest.approx((1 + 0) / 2),
         "Pass@2 ExactMatch - key1 - subject2": 1,
         "Pass@2 ExactMatch - key2 - subject1": 1,
@@ -396,6 +401,7 @@ def test_aggregate_results_with_identifier_mean(tmp_path: Path) -> None:
     # First loop: groupby (key, subject) means → (1/3, 1.0, 1.0, 0) → overall mean = 0.5833
     assert aggregated == {
         "IdentifierMean MockIdentifierMeanMetric.ExactMatch": pytest.approx(((2 / 3 + 0) / 2 + 1 + 1 + 0) / 4),
+        "IdentifierMean MockIdentifierMeanMetric.ExactMatch (micro)": pytest.approx((2 / 3 + 0 + 1 + 1 + 0) / 5),
         "IdentifierMean ExactMatch - key1 - subject1": pytest.approx((2 / 3 + 0) / 2),
         "IdentifierMean ExactMatch - key2 - subject1": 1,
         "IdentifierMean ExactMatch - key1 - subject2": 1,


### PR DESCRIPTION
## Description

Additionally compute micro-averages (per-sample average), denoted `Average {metric} (micro)`. Extends to aggregators as well.
