### PR TITLE
feat: support structured output in OpenAIModel

### DIFF
--- a/src/eval_framework/llm/openai.py
+++ b/src/eval_framework/llm/openai.py
@@ -7,13 +7,14 @@ from collections.abc import Callable, Sequence
 from functools import partial
 
 import tiktoken
-from openai import OpenAI
+from openai import OpenAI, omit
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
     ChatCompletionMessageParam,
     ChatCompletionSystemMessageParam,
     ChatCompletionUserMessageParam,
 )
+from openai.types.chat.completion_create_params import ResponseFormat
 from tokenizers import Tokenizer
 from transformers import AutoTokenizer
 
@@ -59,6 +60,7 @@ class OpenAIModel(BaseLLM):
         organization: str | None = None,
         base_url: str | None = None,
         bytes_per_token: float | None = None,
+        response_format: ResponseFormat | None = None,
     ) -> None:
         """
         Initialize the OpenAIModel.
@@ -72,6 +74,8 @@ class OpenAIModel(BaseLLM):
             organization: Optional OpenAI organization ID.
             base_url: Optional API base URL for Azure or alternate endpoints.
             bytes_per_token: Optional custom bytes per token scalar for non-standard models.
+            response_format: Optional OpenAI ``response_format`` payload for structured output, e.g.
+                ``{"type": "json_schema", "json_schema": {...}}``. Only used by the chat completion API.
         """
         assert model_name is not None or self.LLM_NAME is not None, "A model name must be specified."
         self._model_name = model_name if model_name else self.LLM_NAME
@@ -84,6 +88,7 @@ class OpenAIModel(BaseLLM):
         if top_p is not None:
             assert 0.0 <= top_p <= 1.0, "top_p must be between 0.0 and 1.0"
         self._top_p = top_p
+        self._response_format = response_format
 
         self._client = OpenAI(
             api_key=api_key if api_key is not None else os.getenv("OPENAI_API_KEY", ""),
@@ -220,6 +225,7 @@ class OpenAIModel(BaseLLM):
                     top_p=effective_top_p,
                     max_tokens=scaled_max_tokens,
                     stop=stop_sequences,
+                    response_format=self._response_format if self._response_format is not None else omit,
                 )
                 prompt = "\n".join([f"{m.get('role', '')}: {m.get('content', '')}" for m in chat_messages])
                 prompt_tokens = getattr(chat_response.usage, "prompt_tokens", None)

--- a/tests/tests_eval_framework/llm/test_openai.py
+++ b/tests/tests_eval_framework/llm/test_openai.py
@@ -1,4 +1,6 @@
 import pytest
+from openai import omit
+from openai.types.chat.completion_create_params import ResponseFormat
 from pytest_mock import MockerFixture
 
 from eval_framework.llm.base import BaseLLM
@@ -166,6 +168,23 @@ def test_openai_chat_api_top_p_generate_from_messages(mocker: MockerFixture) -> 
     model.generate_from_messages(_MESSAGES, top_p=0.75)
     call_kwargs = mock_client.chat.completions.create.call_args.kwargs
     assert call_kwargs["top_p"] == 0.75
+
+
+def test_openai_chat_api_forwards_response_format(mocker: MockerFixture) -> None:
+    mock_client = mocker.MagicMock()
+    mocker.patch("eval_framework.llm.openai.OpenAI", return_value=mock_client)
+    mock_client.chat.completions.create.return_value = _make_chat_response(mocker)
+    _MESSAGES = [[Message(role=Role.USER, content="Hello")]]
+
+    OpenAIModel(model_name="gpt-4o-mini-2024-07-18").generate_from_messages(_MESSAGES)
+    assert mock_client.chat.completions.create.call_args.kwargs["response_format"] is omit
+
+    response_format: ResponseFormat = {
+        "type": "json_schema",
+        "json_schema": {"name": "verdict", "schema": {"type": "object"}},
+    }
+    OpenAIModel(model_name="gpt-4o-mini-2024-07-18", response_format=response_format).generate_from_messages(_MESSAGES)
+    assert mock_client.chat.completions.create.call_args.kwargs["response_format"] == response_format
 
 
 def test_generate_from_messages_validates_temperature_and_top_p(mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Description

Adds an optional response_format argument forwarded to the chat completions call, so callers can request JSON schema constrained output from OpenAI, OpenRouter or vLLM endpoints. If none is given, use `omit` to have the same behavior as before.
