### PR TITLE
fix: keep None values in `judge_model_args`

### DIFF
--- a/src/eval_framework/tasks/eval_config.py
+++ b/src/eval_framework/tasks/eval_config.py
@@ -106,7 +106,7 @@ class EvalConfig(BaseConfig):
                     v = float(v)
                 else:
                     v = int(v)
-            except ValueError:
+            except (ValueError, TypeError):  # not a number, or None
                 pass
             typed_value[k] = v
         return typed_value

--- a/tests/tests_eval_framework/test_eval_config_validation.py
+++ b/tests/tests_eval_framework/test_eval_config_validation.py
@@ -293,6 +293,17 @@ class TestEvalConfigJudgeModelArgsValidation:
         assert config.judge_model_args["use_cache"] == "True"
         assert isinstance(config.judge_model_args["use_cache"], str)
 
+    def test_judge_model_args_keep_none(self) -> None:
+        """A None value (e.g. an unset api_key) must pass through instead of crashing the number coercion."""
+        config = EvalConfig(
+            llm_class=OpenAIModel,
+            llm_judge_class=OpenAIModel,
+            judge_model_args={"model_name": "gpt-4", "api_key": None},
+            task_name="MMLU",
+        )
+
+        assert config.judge_model_args["api_key"] is None
+
     def test_judge_model_args_serialization(self) -> None:
         config_data = {
             "llm_class": OpenAIModel,


### PR DESCRIPTION
## Description

The current except only caught ValueError, so a None argument (e.g. an unset judge api_key) crashed with a TypeError. In case a judge API key is actually needed, a missing judge API key now fails with a clear "missing credentials" error instead of an obscure int() TypeError.