### PR TITLE
fix(ifeval): drop key-specific kwargs hotfixes that crash on datasets 5

### DIFF
--- a/src/eval_framework/tasks/benchmarks/ifeval.py
+++ b/src/eval_framework/tasks/benchmarks/ifeval.py
@@ -37,16 +37,8 @@ class IFEval(BaseTask[str]):
         for d in item["kwargs"]:
             # fixing undesired float fields in the dataset
             assert all([abs(v - float(v)) < 1e-5 for v in d.values() if isinstance(v, float)])
-            new_kwargs.append({k: v if not isinstance(v, float) else int(v) for k, v in d.items()})
-
-        # fixing changes to the HF dataset done on Apr 10 2025
-        if item["key"] == 142:
-            new_kwargs[2]["relation"] = None
-            new_kwargs[2]["frequency"] = None
-            new_kwargs[2]["keywords"] = new_kwargs[2]["keyword"]
-            del new_kwargs[2]["keyword"]
-        if item["key"] == 1512:
-            new_kwargs[0]["relation"] = None
+            # None marks an absent kwarg; dropping it gives dense and sparse dataset shapes the same context
+            new_kwargs.append({k: int(v) if isinstance(v, float) else v for k, v in d.items() if v is not None})
 
         item["kwargs"] = new_kwargs
 

--- a/tests/tests_eval_framework/tasks/benchmarks/test_ifeval.py
+++ b/tests/tests_eval_framework/tasks/benchmarks/test_ifeval.py
@@ -1,5 +1,6 @@
 import pytest
 
+from eval_framework.tasks.benchmarks.ifeval import IFEval
 from eval_framework.tasks.registry import Registry
 from eval_framework.tasks.task_names import register_ifeval_tasks
 from template_formatting.formatter import BaseFormatter, ConcatFormatter, Llama3Formatter
@@ -15,3 +16,22 @@ register_ifeval_tasks(registry=_ifeval_registry)
 @pytest.mark.parametrize("task_name", _ifeval_registry.task_names())
 def test_formatter_hash(task_name: str, formatter_cls: type[BaseFormatter]) -> None:
     run_formatter_hash_test(task_name, formatter_cls, registry=_ifeval_registry)
+
+
+def test_get_context_gives_same_kwargs_whether_absent_keys_are_omitted_or_none() -> None:
+    """
+    Each IFEval sample has a list of kwargs dicts, one per instruction. The HF `datasets` library decides how a
+    dict with absent keys is loaded: version 5 omits them, older versions (and caches written by them) include every
+    key with None. The task must produce the same context from both, otherwise a run's result depends on which
+    `datasets` version wrote the cache.
+    """
+    absent_keys_omitted = [{"keyword": "knock", "frequency": 2}, {"keywords": ["cat"]}]
+    absent_keys_as_none = [
+        {"keyword": "knock", "frequency": 2, "keywords": None},
+        {"keyword": None, "frequency": None, "keywords": ["cat"]},
+    ]
+    task = IFEval()
+
+    for kwargs in (absent_keys_omitted, absent_keys_as_none):
+        item = {"key": 142, "prompt": "", "instruction_id_list": [], "kwargs": kwargs}
+        assert task._get_context(item).additional_kwargs == absent_keys_omitted


### PR DESCRIPTION
IFEval and IFEvalDe failed on a fresh HF dataset cache. The upstream datasets have since been fixed, so the hotfix causing the failure is no longer needed and is removed. Added a test to check the task works with both old and new caches.