### PR TITLE
fix(ifeval): make the integral-float kwargs check meaningful

### DIFF
--- a/src/eval_framework/tasks/benchmarks/ifeval.py
+++ b/src/eval_framework/tasks/benchmarks/ifeval.py
@@ -35,8 +35,8 @@ class IFEval(BaseTask[str]):
 
         new_kwargs = []
         for d in item["kwargs"]:
-            # fixing undesired float fields in the dataset
-            assert all([abs(v - float(v)) < 1e-5 for v in d.values() if isinstance(v, float)])
+            # some dataset variants type integer kwargs as float; int() below must not truncate anything
+            assert all(v.is_integer() for v in d.values() if isinstance(v, float)), f"Non-integer float in {d}"
             # None marks an absent kwarg; dropping it gives dense and sparse dataset shapes the same context
             new_kwargs.append({k: int(v) if isinstance(v, float) else v for k, v in d.items() if v is not None})
 

--- a/tests/tests_eval_framework/tasks/benchmarks/test_ifeval.py
+++ b/tests/tests_eval_framework/tasks/benchmarks/test_ifeval.py
@@ -35,3 +35,14 @@ def test_get_context_gives_same_kwargs_whether_absent_keys_are_omitted_or_none()
     for kwargs in (absent_keys_omitted, absent_keys_as_none):
         item = {"key": 142, "prompt": "", "instruction_id_list": [], "kwargs": kwargs}
         assert task._get_context(item).additional_kwargs == absent_keys_omitted
+
+
+def test_get_context_casts_integral_floats_to_int_and_rejects_others() -> None:
+    """Some dataset variants type integer kwargs as float; a non-integer value would be silently truncated."""
+    task = IFEval()
+    item = {"key": 0, "prompt": "", "instruction_id_list": [], "kwargs": [{"frequency": 2.0}]}
+    assert task._get_context(item).additional_kwargs == [{"frequency": 2}]
+
+    item["kwargs"] = [{"frequency": 2.5}]
+    with pytest.raises(AssertionError):
+        task._get_context(item)


### PR DESCRIPTION
IFEval casts float instruction counts to int. The guard against silently rounding down a fractional count could never fail; now it does. Eval results are unaffected.