### PR TITLE
feat: report finish reasons as per-benchmark FinishReason metric

### DIFF
--- a/src/eval_framework/composed.py
+++ b/src/eval_framework/composed.py
@@ -15,6 +15,7 @@ from eval_framework.metrics.efficiency.bytes_per_sequence_position import (
     SequencePositionsCompletion,
     SequencePositionsLoglikelihood,
 )
+from eval_framework.metrics.efficiency.finish_reason import FinishReason
 from eval_framework.metrics.efficiency.token_counters import TokenCounts
 from eval_framework.shared.errors import raise_errors
 from eval_framework.shared.types import Completion, Error, RawCompletion
@@ -250,7 +251,7 @@ def _metrics_for(kind: EvalKind) -> list[type["BaseMetric"]]:
     response_type_metrics: list[type[BaseMetric]]
     match kind.response_type:
         case ResponseType.COMPLETION:
-            response_type_metrics = [BytesCompletion, SequencePositionsCompletion, TokenCounts]
+            response_type_metrics = [BytesCompletion, SequencePositionsCompletion, TokenCounts, FinishReason]
         case ResponseType.LOGLIKELIHOODS:
             response_type_metrics = [BytesLoglikelihood, SequencePositionsLoglikelihood]
         case _:

--- a/src/eval_framework/metrics/efficiency/finish_reason.py
+++ b/src/eval_framework/metrics/efficiency/finish_reason.py
@@ -1,0 +1,39 @@
+from eval_framework.metrics.base import BaseMetric, MetricResult
+from eval_framework.shared.types import Completion
+
+
+class FinishReason(BaseMetric[Completion]):
+    """Why the backend ended the generation, as one 0/1 indicator per reason.
+
+    Averaged over a benchmark, each key becomes a rate: `FinishReason/Repetition`
+    is the share of completions vLLM aborted through its `repetition_detection`
+    sampling parameter (looping output), `FinishReason/Length` the share that hit
+    `max_tokens`, and `FinishReason/Stop` the share that ended on their own (EOS
+    or a stop sequence). Reasons outside these keys (e.g. `tool_calls`) count as
+    0 for all of them.
+
+    Reads the `finish_reason` backends already attach to the response. All values
+    are None when the backend did not report one (e.g. HuggingFace) or when the
+    sample errored, so such samples do not dilute the rates.
+    """
+
+    NAME = "FinishReason"
+    KEYS = ["Stop", "Length", "Repetition"]
+    _REASONS = {"Stop": "stop", "Length": "length", "Repetition": "repetition"}
+
+    def calculate(self, response: Completion) -> list[MetricResult]:
+        finish_reason = response.raw_completion_finish_reason
+        if response.error or finish_reason is None:
+            values: dict[str, float | None] = {key: None for key in self.KEYS}
+        else:
+            values = {key: float(finish_reason.lower() == reason) for key, reason in self._REASONS.items()}
+
+        return [
+            MetricResult(
+                metric_name=f"{self.NAME}/{key}",
+                value=value,
+                higher_is_better=key == "Stop",
+                error=response.error,
+            )
+            for key, value in values.items()
+        ]

--- a/src/eval_framework/tasks/base.py
+++ b/src/eval_framework/tasks/base.py
@@ -18,6 +18,7 @@ from eval_framework.metrics.efficiency.bytes_per_sequence_position import (
     SequencePositionsCompletion,
     SequencePositionsLoglikelihood,
 )
+from eval_framework.metrics.efficiency.finish_reason import FinishReason
 from eval_framework.metrics.efficiency.token_counters import TokenCounts
 from eval_framework.shared.errors import raise_errors
 from eval_framework.shared.types import BaseMetricContext, Completion, Error, RawCompletion
@@ -468,6 +469,7 @@ class BaseTask[SubjectType](Eval):
                     BytesCompletion,
                     SequencePositionsCompletion,
                     TokenCounts,
+                    FinishReason,
                 ]
             case ResponseType.LOGLIKELIHOODS:
                 metrics = [BytesLoglikelihood, SequencePositionsLoglikelihood]

--- a/tests/tests_eval_framework/metrics/efficiency_metrics/test_finish_reason.py
+++ b/tests/tests_eval_framework/metrics/efficiency_metrics/test_finish_reason.py
@@ -1,0 +1,57 @@
+import pytest
+
+from eval_framework.metrics.efficiency.finish_reason import FinishReason
+from eval_framework.shared.types import Completion, Error
+
+
+def _completion(**overrides: object) -> Completion:
+    defaults: dict = {
+        "id": 1,
+        "subject": "x",
+        "ground_truth": "gt",
+        "prompt": "test",
+        "prompt_num_tokens": 1,
+        "messages": None,
+        "completion": "42",
+        "raw_completion": "the answer is 42",
+        "raw_completion_num_tokens": 10,
+        "raw_completion_finish_reason": "stop",
+    }
+    defaults.update(overrides)
+    return Completion(**defaults)
+
+
+@pytest.mark.parametrize(
+    "finish_reason,expected",
+    [
+        ("stop", {"Stop": 1.0, "Length": 0.0, "Repetition": 0.0}),
+        ("length", {"Stop": 0.0, "Length": 1.0, "Repetition": 0.0}),
+        ("repetition", {"Stop": 0.0, "Length": 0.0, "Repetition": 1.0}),
+        ("REPETITION", {"Stop": 0.0, "Length": 0.0, "Repetition": 1.0}),
+        ("tool_calls", {"Stop": 0.0, "Length": 0.0, "Repetition": 0.0}),
+    ],
+)
+def test_finish_reason_one_hot_encodes_reported_reason(finish_reason: str, expected: dict[str, float]) -> None:
+    results = FinishReason().calculate(_completion(raw_completion_finish_reason=finish_reason))
+    assert len(results) == 3
+
+    by_name = {result.metric_name: result for result in results}
+    assert {name.removeprefix("FinishReason/"): result.value for name, result in by_name.items()} == expected
+    assert by_name["FinishReason/Stop"].higher_is_better is True
+    assert by_name["FinishReason/Length"].higher_is_better is False
+    assert by_name["FinishReason/Repetition"].higher_is_better is False
+
+
+def test_finish_reason_is_none_when_backend_did_not_report() -> None:
+    results = FinishReason().calculate(_completion(raw_completion_finish_reason=None))
+    assert len(results) == 3
+    assert all(result.value is None for result in results)
+    assert all(result.error is None for result in results)
+
+
+def test_finish_reason_is_none_when_sample_errored() -> None:
+    error = Error(error_class="", message="", traceback="")
+    results = FinishReason().calculate(_completion(raw_completion_finish_reason="repetition", error=error))
+    assert len(results) == 3
+    assert all(result.value is None for result in results)
+    assert all(result.error is error for result in results)

--- a/tests/tests_eval_framework/test_base_task.py
+++ b/tests/tests_eval_framework/test_base_task.py
@@ -6,6 +6,7 @@ import pytest
 
 from eval_framework.metrics.completion.accuracy_completion import AccuracyCompletion
 from eval_framework.metrics.efficiency.bytes_per_sequence_position import BytesCompletion, SequencePositionsCompletion
+from eval_framework.metrics.efficiency.finish_reason import FinishReason
 from eval_framework.metrics.efficiency.token_counters import TokenCounts
 from eval_framework.run import parse_args
 from eval_framework.tasks import dataset_revisions as dr
@@ -263,6 +264,7 @@ def test_completion_metrics_returns_all_completion_metrics() -> None:
         BytesCompletion,
         SequencePositionsCompletion,
         TokenCounts,
+        FinishReason,
     }
 
 


### PR DESCRIPTION
## Description

Expose the backend's finish_reason (already stored on every Completion) as 0/1 indicators under FinishReason/Stop, /Length and /Repetition on all completion tasks. Averaged per benchmark this gives the rate of completions vLLM aborted via repetition detection and the rate truncated at max_tokens.

